### PR TITLE
Add Towncrier

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../'))
+sys.path.insert(0, os.path.abspath("../"))  # NOQA
+
+import securitas
 
 
 # -- Project information -----------------------------------------------------
@@ -23,10 +25,10 @@ copyright = '2020, Red Hat, Inc'
 author = 'Fedora Infrastructure'
 
 # The short X.Y version
-version = '0.0'
+version = ".".join(securitas.__version__.split(".")[:2])
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = securitas.__version__
 
 
 # -- General configuration ---------------------------------------------------
@@ -37,6 +39,7 @@ release = '0.0.1'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
 ]
@@ -83,4 +86,10 @@ html_static_path = ['_static']
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+}
+
+extlinks = {
+    "commit": ("https://github.com/fedora-infra/securitas/commit/%s", ""),
+    "issue": ("https://github.com/fedora-infra/securitas/issues/%s", "#"),
+    "pr": ("https://github.com/fedora-infra/securitas/pull/%s", "PR#"),
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -70,6 +70,40 @@ Your pull request should contain tests for your new feature or bug fix. If
 you're not certain how to write tests, we will be happy to help you.
 
 
+Release Notes
+-------------
+
+To add entries to the release notes, create a file in the ``news`` directory in the
+``source.type`` name format, where the ``source`` part of the filename is:
+
+* ``42`` when the change is described in issue ``42``
+* ``PR42`` when the change has been implemented in pull request ``42``, and
+  there is no associated issue
+* ``Cabcdef`` when the change has been implemented in changeset ``abcdef``, and
+  there is no associated issue or pull request.
+
+And where the extension ``type`` is one of:
+
+* ``bic``: for backwards incompatible changes
+* ``dependency``: for dependency changes
+* ``feature``: for new features
+* ``bug``: for bug fixes
+* ``dev``: for development improvements
+* ``docs``: for documentation improvements
+* ``other``: for other changes
+
+The content of the file will end up in the release notes. It should not end with a ``.``
+(full stop).
+
+If it is not present already, add a file in the ``news`` directory named ``username.author``
+where ``username`` is the first part of your commit's email address, and containing the name
+you want to be credited as. There is a script to generate a list of authors that we run
+before releasing, but creating the file manually allows you to set a custom name.
+
+A preview of the release notes can be generated with
+``SECURITAS_CONFIG_PATH=`pwd`/securitas.cfg.default towncrier --draft``.
+
+
 Licensing
 ---------
 
@@ -116,3 +150,19 @@ address, indicating that you agree to the `Developer Certificate of Origin
 	    this project or the open source license(s) involved.
 
 Use ``git commit -s`` to add the Signed-off-by tag.
+
+
+Releasing
+---------
+
+When cutting a new release, follow these steps:
+
+#. Update the version in ``pyproject.toml``
+#. Add missing authors to the release notes fragments by changing to the ``news`` directory and
+   running the ``get-authors.py`` script, but check for duplicates and errors
+#. Generate the release notes by running
+   ``SECURITAS_CONFIG_PATH=`pwd`/securitas.cfg.default towncrier``
+#. Commit the changes
+#. Tag the commit with ``-s`` to generate a signed tag
+#. Push those changes to the upstream Github repository (via a PR or not)
+#. Generate a tarball and push to PyPI with the command ``poetry --build publish``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Here is what works so far:
    :caption: User Guide
 
    installation
+   release_notes
 
 .. API
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,0 +1,7 @@
+=============
+Release notes
+=============
+
+.. towncrier release notes start
+
+

--- a/news/_template.rst
+++ b/news/_template.rst
@@ -1,0 +1,59 @@
+{% macro reference(value) -%}
+   {%- if value.startswith("PR") -%}
+     :pr:`{{ value[2:] }}`
+   {%- elif value.startswith("C") -%}
+     :commit:`{{ value[1:] }}`
+   {%- else -%}
+     :issue:`{{ value }}`
+   {%- endif -%}
+{%- endmacro -%}
+
+This is a {major|feature|bugfix} release that adds [short summary].
+
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] and category != "author" %}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+* {{ text }} ({% for value in values -%}
+                 {{ reference(value) }}
+                 {%- if not loop.last %}, {% endif -%}
+              {%- endfor %}).
+{% endfor %}
+{% else %}
+* {{ sections[section][category]['']|sort|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% if sections[section]["author"] %}
+{{definitions['author']["name"]}}
+{{ underline * definitions['author']['name']|length }}
+
+Many thanks to the contributors of bug reports, pull requests, and pull request
+reviews for this release:
+
+{% for text, values in sections[section]["author"].items() %}
+* {{ text }}
+{% endfor %}
+{% endif %}
+
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/news/get-authors.py
+++ b/news/get-authors.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+"""
+
+This script browses through git commit history (starting at latest tag), collects all authors of
+commits and creates fragment for `towncrier`_ tool.
+
+It's meant to be run during the release process, before generating the release notes.
+
+Example::
+
+    $ python get_authors.py
+
+.. _towncrier: https://github.com/hawkowl/towncrier/
+
+Authors:
+    Aurelien Bompard
+    Michal Konecny
+"""
+
+import os
+from subprocess import check_output
+
+last_tag = check_output(
+    "git tag | sort -n | tail -n 1", shell=True, universal_newlines=True
+)
+authors = {}
+log_range = last_tag.strip() + "..HEAD"
+output = check_output(
+    ["git", "log", log_range, "--format=%ae\t%an"], universal_newlines=True
+)
+for line in output.splitlines():
+    email, fullname = line.split("\t")
+    email = email.split("@")[0].replace(".", "")
+    if email in authors:
+        continue
+    authors[email] = fullname
+
+for nick, fullname in authors.items():
+    filename = "{}.author".format(nick)
+    if os.path.exists(filename):
+        continue
+    print(f"Adding author {fullname} ({nick})")
+    with open(filename, "w") as f:
+        f.write(fullname)
+        f.write("\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,54 @@ build-backend = "poetry.masonry.api"
 
 [tool.black]
 skip-string-normalization = true
+
+[tool.towncrier]
+package = "securitas"
+filename = "docs/release_notes.rst"
+directory = "news/"
+title_format = "v{version}"
+issue_format = "{issue}"
+template = "news/_template.rst"
+underlines = "=^-"
+wrap = true
+all_bullets = true
+
+  [[tool.towncrier.type]]
+  directory = "bic"
+  name = "Backwards Incompatible Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "dependency"
+  name = "Dependency Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "feature"
+  name = "Features"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "bug"
+  name = "Bug Fixes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "dev"
+  name = "Development Improvements"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "docs"
+  name = "Documentation Improvements"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "other"
+  name = "Other Changes"
+  showcontent = true
+
+  [[tool.towncrier.type]]
+  directory = "author"
+  name = "Contributors"
+  showcontent = true

--- a/securitas/__init__.py
+++ b/securitas/__init__.py
@@ -10,3 +10,16 @@ if app.config.get('TEMPLATES_AUTO_RELOAD'):
     app.jinja_env.auto_reload = True
 
 ipa_admin = IPAAdmin(app)
+
+
+try:
+    import importlib.metadata
+
+    __version__ = importlib.metadata.version("securitas")
+except ImportError:
+    try:
+        import pkg_resources
+
+        __version__ = pkg_resources.get_distribution("securitas").version
+    except ImportError:
+        __version__ = None

--- a/securitas/security/ipa.py
+++ b/securitas/security/ipa.py
@@ -3,6 +3,7 @@ import python_freeipa
 from python_freeipa import Client
 import random
 
+
 # Construct an IPA client from app config, but don't attempt to log in with it
 # or to form a session of any kind with it. This is useful for one-off cases
 # like password resets where a session isn't actually required.


### PR DESCRIPTION
This PR introduces usage of Towncrier to manage the release notes. It builds upon #62, so please just look at the last commit, the others come from #62 and I'll rebase when it's merged.

This PR fixes #66.