### PR TITLE
Fix the docs so readthedocs can build them

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,10 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# Explcitely set the master doc
+# https://github.com/readthedocs/readthedocs.org/issues/2569
+master_doc = 'index'
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Readthedocs requires a default value to be explicitely set in `docs/conf.py`.
Then we'll be able to advertise our docs at https://securitas.readthedocs.io/