### PR TITLE
a simple vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/_build/
 
 # VS Code
 .vscode
+
+# Vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f31-cloud-libvirt"
+  #config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.hostname = "ipa.example.com"
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.cpus = 2
+    libvirt.memory = 2048 
+  end
+
+  # Vagrant adds '127.0.0.1 ipa.example.com ipa' as the first line in /etc/hosts
+  # and freeipa doesnt like that, so we remove it
+  config.vm.provision "shell", inline: "sudo sed -i '1d' /etc/hosts"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "devel/ansible/playbook.yml"
+  end
+
+end

--- a/devel/ansible/playbook.yml
+++ b/devel/ansible/playbook.yml
@@ -1,0 +1,6 @@
+---
+- hosts: all
+  become: true
+  become_method: sudo
+  roles:
+    - dev

--- a/devel/ansible/roles/dev/files/.bashrc
+++ b/devel/ansible/roles/dev/files/.bashrc
@@ -1,0 +1,6 @@
+# .bashrc
+
+export FLASK_APP=/vagrant/securitas/app.py
+export SECURITAS_CONFIG_PATH=/home/vagrant/securitas.cfg
+
+alias securitas-devel="poetry run flask run --host=0.0.0.0"

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Install RPM packages
+  dnf:
+      name: ['git', 'vim', 'poetry', 'python3-flask', 'python3-pip', 'python3-cryptography', 'freeipa-server']
+      state: present
+
+- name: install python deps with poetry
+  shell: poetry install
+  become: yes
+  become_user: vagrant
+  args:
+    chdir: /vagrant/
+
+- name: install freeipa server
+  shell: ipa-server-install -a adminPassw0rd! --hostname=ipa.example.com -r EXAMPLE.COM -p adminPassw0rd! -n example.com -U
+
+- name: get freeipa-fas
+  git:
+    repo: https://github.com/fedora-infra/freeipa-fas.git
+    dest: /tmp/freeipa-fas
+
+- name: install freeipa-fas
+  shell: ./install.sh
+  args:
+    chdir: /tmp/freeipa-fas/
+
+- name: Install the .bashrc
+  copy:
+      src: .bashrc
+      dest: /home/vagrant/.bashrc
+      mode: 0644
+      owner: vagrant
+      group: vagrant
+
+- name: Install securitas.cfg
+  copy:
+      src: /vagrant/securitas.cfg.default
+      dest: /home/vagrant/securitas.cfg
+      remote_src: yes
+      owner: vagrant
+      group: vagrant
+
+
+

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -25,6 +25,35 @@ below.
 .. note:: If you do not wish to use GitHub, please send patches to
           infrastructure@lists.fedoraproject.org.
 
+Development Environment
+=======================
+Vagrant allows contributors to get quickly up and running with a Securitas development environment by
+automatically configuring a virtual machine. To get started, first install the Vagrant and Virtualization 
+packages needed, and start the libvirt service::
+
+    $ sudo dnf install ansible libvirt vagrant-libvirt vagrant-sshfs vagrant-hostmanager
+    $ sudo systemctl enable libvirtd
+    $ sudo systemctl start libvirtd
+
+Check out the code and run ``vagrant up``::
+
+    $ git clone https://github.com/fedora-infra/securitas
+    $ cd securitas
+    $ vagrant up
+
+Next, SSH into your newly provisioned development environment, and start the securitas web application:
+
+    $ vagrant ssh
+    $ cd /vagrant/
+    $ poetry run flask run --host=0.0.0.0
+
+With the securitas web application running, go to http://ipa.example.com:5000/ in the browser on your
+host machine to see the web application. http://ipa.example.com will give you access to the regular freeIPA
+webUI.
+
+Note that the ``/vagrant/`` file contains the source of the git checkout on your host. Any changes
+to the files in that directory on the host will be automatically synced to the VM.
+
 
 Guidelines
 ==========

--- a/securitas.cfg.default
+++ b/securitas.cfg.default
@@ -1,8 +1,8 @@
 TEMPLATES_AUTO_RELOAD = True
 
 # IPA settings
-FREEIPA_SERVERS = ['ipa01.idm.your.beloved.example']
-FREEIPA_CACERT = '/etc/ipa01.crt'
+FREEIPA_SERVERS = ['ipa.example.com']
+FREEIPA_CACERT = '/etc/ipa/ca.crt'
 
 # Any user with admin privileges
 FREEIPA_ADMIN_USER = 'admin'


### PR DESCRIPTION
A dev environment for securitas using vagrant and vagrant libvirt.

Quick Instructions:

**Install Deps & start libvirt**

    sudo dnf install ansible libvirt vagrant-libvirt vagrant-sshfs vagrant-hostmanager
    sudo systemctl enable libvirtd
    sudo systemctl start libvirtd

**Create the environment**

    cd <your-securitas-checkout>
    vagrant up

**Start the server**

    cd <your-securitas-checkout>
    vagrant ssh
    cd /vagrant/
    poetry run flask run --host=0.0.0.0

now in the browser on your host, go to http://ipa.example.com:5000

note too you can go to ipa.example.com as well for the normal IPA webui 


