### PR TITLE
fix incorrect FREEIPA_SERVER config key

### DIFF
--- a/securitas/security/ipa_admin.py
+++ b/securitas/security/ipa_admin.py
@@ -1,4 +1,5 @@
 from python_freeipa import Client
+import random
 
 
 class IPAAdmin(object):
@@ -12,7 +13,7 @@ class IPAAdmin(object):
     # Attempt to obtain an administrative IPA session
     def __maybe_ipa_admin_session(self):
         self.__client = Client(
-            self.__app.config['FREEIPA_SERVER'],
+            random.choice(self.__app.config['FREEIPA_SERVERS']),
             verify_ssl=self.__app.config['FREEIPA_CACERT'],
         )
         self.__client.login(self.__username, self.__password)


### PR DESCRIPTION
previously, ipa_admin was trying to reference a
non-existant configuration key "FREEIPA_SERVER".
This commit changes the key to the correct "FREEIPA_SERVERS",
and uses the same random technique used in security/ipa.py
to choose a single server from the list in FREEIPA_SERVERS

Signed-off-by: Ryan Lerch <rlerch@redhat.com>