### PR TITLE
Restore the Flask dev server's ability to run non-installed apps

### DIFF
--- a/securitas/__init__.py
+++ b/securitas/__init__.py
@@ -20,6 +20,10 @@ except ImportError:
     try:
         import pkg_resources
 
-        __version__ = pkg_resources.get_distribution("securitas").version
+        try:
+            __version__ = pkg_resources.get_distribution("securitas").version
+        except pkg_resources.DistributionNotFound:
+            # The app is not installed, but the flask dev server can run it nonetheless.
+            __version__ = None
     except ImportError:
         __version__ = None


### PR DESCRIPTION
The flask dev server doesn't need the app to be installed to run it. Changeset 321d0f9 broke that feature, this commit should restore it.