### PR TITLE
Fix tox.ini to declare poetry as a dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = lint,format,licenses,bandit,covclean,{py36,py37}-{unittest,integration
 isolated_build = true
 
 [testenv]
+deps = poetry
 whitelist_externals = poetry
 setenv =
     SECURITAS_CONFIG_PATH={toxinidir}/securitas/tests/unit/securitas.cfg
@@ -53,6 +54,7 @@ commands =
 
 [testenv:licenses]
 deps =
+    poetry
     liccheck
 # Poetry 1.0+ has an export command that can replace "poetry run pip freeze"
 commands =


### PR DESCRIPTION
The tox runs failed in Centos CI because they didn't install poetry.