### PR TITLE
Don't delete the user when registration fails

### DIFF
--- a/securitas/controller/registration.py
+++ b/securitas/controller/registration.py
@@ -18,6 +18,7 @@ def register():
         username = form.username.data
         password = form.password.data
         now = datetime.datetime.utcnow().replace(microsecond=0)
+        # First, create the user.
         try:
             ipa_admin.user_add(
                 username,
@@ -30,15 +31,6 @@ def register():
                 faslocale=guess_locale(),
                 fastimezone=DEFAULTS["user_timezone"],
             )
-
-            # Now we fake a password change, so that it's not immediately expired.
-            # This also logs the user in right away.
-            ipa = untouched_ipa_client(app)
-            ipa.change_password(username, password, password)
-        except python_freeipa.exceptions.PWChangePolicyError as e:
-            # situations like "password is too short"
-            form.password.errors.append(e.policy_error)
-            ipa_admin.user_del(username)
         except python_freeipa.exceptions.DuplicateEntry as e:
             # the username already exists
             form.username.errors.append(e.message)
@@ -60,12 +52,43 @@ def register():
             form.errors['non_field_errors'] = [
                 'An error occurred while creating the account, please try again.'
             ]
-            ipa_admin.user_del(username)
+
         else:
-            flash(
-                'Congratulations, you now have an account! Go ahead and sign in to proceed.',
-                'success',
-            )
-            return redirect(url_for('root'))
+            # User creation succeeded. Now we fake a password change, so that it's not immediately
+            # expired. This also logs the user in right away.
+            try:
+                ipa = untouched_ipa_client(app)
+                ipa.change_password(username, password, password)
+            except python_freeipa.exceptions.PWChangePolicyError as e:
+                # The user is created but the password does not match the policy. Alert the user
+                # and ask them to change their password.
+                flash(
+                    f'Your account has been created, but the password you chose does not comply '
+                    f'with the policy ({e.policy_error}) and has thus been set as expired. '
+                    f'You will be asked to change it after logging in.',
+                    'warning',
+                )
+                # Send them to the login page, they will have to change their password
+                # after login.
+                return redirect(url_for('login'))
+            except python_freeipa.exceptions.FreeIPAError as e:
+                app.logger.error(
+                    f'An unhandled error {e.__class__.__name__} happened while changing initial '
+                    f'password for user {username}: {e.message}'
+                )
+                # At this point the user has been created, they can't register again. Send them to
+                # the login page with an appropriate warning.
+                flash(
+                    f'Your account has been created, but an error occurred while setting your '
+                    f'password ({e.message}). You may need to change it after logging in.',
+                    'warning',
+                )
+                return redirect(url_for('login'))
+            else:
+                flash(
+                    'Congratulations, you now have an account! Go ahead and sign in to proceed.',
+                    'success',
+                )
+                return redirect(url_for('root'))
 
     return render_template('register.html', register_form=form)

--- a/securitas/tests/unit/controller/cassettes/test_registration/test_register_generic_pwchange_error.yaml
+++ b/securitas/tests/unit/controller/cassettes/test_registration/test_register_generic_pwchange_error.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 29 Jan 2020 17:26:54 GMT
+      - Wed, 29 Jan 2020 17:35:06 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=%2bGtBE4ygUTmG7zK%2beKMeljg%2bchydeLsnSqIxEUAgT8Cudc2KKCgDiq7lLrsJz%2fuiNItfMDPZ7pormwBo8VwSx%2b0yJ0u5OFtX0rtemjSliiBVKPbzDKabF0rQriUicsC%2fScn8d6fFwOxBV5TN3lrmz55aBKhAvO9hLLV9Sb2QtlqQqIaLm902HgIDMo%2f0kvrq;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=kjc672X8gUlSnLIZw9xH3zMzbfrY5SvVqnuYakDOpcaU9lp6141BU8RymjZAA76HlvV3oX%2b5ee2gkprWMummHb5%2f0D7Fb6Sblmp2wjB2xLfFPbeeGuvF0%2f3EXUkiTVUuUPF7%2fAVQidMM48lugqZ6cLYBCLdJpxzTCPH9x8ATur41fQEHkNqVruo0LoXrCE2X;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=%2bGtBE4ygUTmG7zK%2beKMeljg%2bchydeLsnSqIxEUAgT8Cudc2KKCgDiq7lLrsJz%2fuiNItfMDPZ7pormwBo8VwSx%2b0yJ0u5OFtX0rtemjSliiBVKPbzDKabF0rQriUicsC%2fScn8d6fFwOxBV5TN3lrmz55aBKhAvO9hLLV9Sb2QtlqQqIaLm902HgIDMo%2f0kvrq
+      - ipa_session=MagBearerToken=kjc672X8gUlSnLIZw9xH3zMzbfrY5SvVqnuYakDOpcaU9lp6141BU8RymjZAA76HlvV3oX%2b5ee2gkprWMummHb5%2f0D7Fb6Sblmp2wjB2xLfFPbeeGuvF0%2f3EXUkiTVUuUPF7%2fAVQidMM48lugqZ6cLYBCLdJpxzTCPH9x8ATur41fQEHkNqVruo0LoXrCE2X
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:06 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,8 +108,8 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "First", "sn": "Last", "cn": "First Last", "loginshell": "/bin/bash", "userpassword":
-      "42", "fascreationtime": "2020-01-29T17:26:54Z", "faslocale": "en-US", "fastimezone":
-      "UTC"}]}'
+      "password", "fascreationtime": "2020-01-29T17:35:06Z", "faslocale": "en-US",
+      "fastimezone": "UTC"}]}'
     headers:
       Accept:
       - application/json
@@ -118,11 +118,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '252'
+      - '258'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=%2bGtBE4ygUTmG7zK%2beKMeljg%2bchydeLsnSqIxEUAgT8Cudc2KKCgDiq7lLrsJz%2fuiNItfMDPZ7pormwBo8VwSx%2b0yJ0u5OFtX0rtemjSliiBVKPbzDKabF0rQriUicsC%2fScn8d6fFwOxBV5TN3lrmz55aBKhAvO9hLLV9Sb2QtlqQqIaLm902HgIDMo%2f0kvrq
+      - ipa_session=MagBearerToken=kjc672X8gUlSnLIZw9xH3zMzbfrY5SvVqnuYakDOpcaU9lp6141BU8RymjZAA76HlvV3oX%2b5ee2gkprWMummHb5%2f0D7Fb6Sblmp2wjB2xLfFPbeeGuvF0%2f3EXUkiTVUuUPF7%2fAVQidMM48lugqZ6cLYBCLdJpxzTCPH9x8ATur41fQEHkNqVruo0LoXrCE2X
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -132,20 +132,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU224TMRD9ldW+8JKk3W0CCVIlQkkQ0NIiKCAuimbtSWLitRdfcqHqvzO2N00r
-        cXnK7Jn7mePc5Aatly5/mt3cN5min6/5VBjrsnOwLv/eyXIubCNhp6DGP7mFEk6AtMl3HrEFMm3/
-        FKyrH8gck2CT2+kmJ7hBY7UKljYLUOIXOKEVyAMuFDryPQS8RRPTtRVbYEx75cL3ylSNEYqJBiT4
-        bQs5wVboGi0F27UoBaSJ2g9rl/uac7B7kxzv7fKl0b65nF/56g3ubMBrbC6NWAg1Uc7sEhkNeCV+
-        ehQ87jeshmwOx6zbLyvWLQqELoyGrDsoB/3j42JUFXASE8PI1H6jDcdtI0wkIJYoj0uKLEfFk/Lx
-        oP9lH00UumbD2RLUAv8ViFtngIODEHSTz2YVWHzcn83oOx+PX+PmxRRZPVrzs9Hyy8uiqVbPp58m
-        07fXk+30fPX26sO78Wl++z0tXIOCBXKMG4euTJ1yX9e7DhmLQJENVnsM2+HsFLdQNxKDyXQdx5Ka
-        WLNLlDLWOKqEOqKxltHpW+5i2YjQLZyo8ZdWadPrD2dJZoIrX1d0pYAWgyERUPaL6LOJvTvl3dfE
-        nZRji2eTz+OLq/NJ7+zyYt+OGYwXCG3/Su5S18iFIfnoloyjAB0dBvf/GJC6SM1Apvqoutfv26XW
-        qB4+tojXIOS9oVtWe3tKaT8GSivB/rtfQ08ezRoDzXN6uRh2ATvbC5BgZ/weXeHOQXXAagwL6fks
-        Xju2Caqnijb9XQTiw+YHXUTnf2RxS6lrkD4M3p4+NrOW9GaTdt2uie4NGCXUIgS0q+YfqQPd60JY
-        23ra1Kjyq1dZG5Cle2QbsJnSLrOk5E4214Zq8owGaejulZDC7aJ/4cGAcoi8l42t9TVVzyJ75pHN
-        QuF1KtzJyl55MgidmeahbXFCigmEpLd3k6e0WZsQBkspt/FxUe0aoo7yMefIs8Ba9i1x8S2PBKEx
-        OmhJeSnDvw0/2HfiDgWA05wP7h7YPfTt94a9fn77GwAA//8DACq7rXAIBgAA
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUJ2VwoVEJqihLUlksqoK0oKJq1J4mJ197a3lxA/HvH9oYU
+        iZanzJ65nznOY2rQVtKlH5LHv02m6OdXOhLGuuQUrEvvGknKhS0lbBQU+JpbKOEESBt9pwGbIdP2
+        tWCd3yNzTIKNbqfLlOASjdXKW9rMQIkHcEIrkDtcKHTkewlUFk1I11asgTFdKee/FyYvjVBMlCCh
+        WteQE2yBrtRSsE2NUkCcqP6wdr6tOQW7NclxaecnRlflxXRc5V9xYz1eYHlhxEyooXJmE8kooVLi
+        d4WCh/3yNvD9/n6v2evkvJllCM2DaTZt9jv9XrudHeYZdEOiH5nar7ThuC6FCQSEEp12hyI7h9n7
+        br/dv9lGE4WuXHE2BzXD/wXi2hng4MAHPaaTSQ4W93uTCX2ng8GXL6v7EbLicMmPD+c3J1mZLz6N
+        fgxH59fD9eh0cT6++jY4Sp/u4sIFKJghx7Cx78rUEa+KYtMgY+Ypst6qj2EbnB3hGopSojeZLqI+
+        xBLVS0EFnEhnBsPuThSvrLUf16pqekPngEhNd7BzlDI49nKh9mjReXDOdYFcGLqzrqfe89DeLp0K
+        qqrI6d7em/UPqGen162H/bevACF3k3ysV21t96R9/B4PWsVdrq+On6+9FegzDbHE8OfgbHw6bB1f
+        nG1DGSitBHszlLpJTWExBlXz+jLgNgrp+RGW9OTRLNFzOKWXi54isJOtAAl2ptqiC9w4yHdYgZ4L
+        PZ2Ea4fKXvVU0ca/C9/NE7rTRXC+IYsnSl2CrPzw9V1DM2tJbzZq123K4F6BUULNfEBNSfqdOpBq
+        zoS1tadODSoff07qgCSeMlmBTZR2iSUlN5KpNlSTJzRISerLhRRuE/yzCgwoh8hbycDaqqDqSWDP
+        vLOJL7yMhRtJp9Xp9n1nprlvm3VJt56Q+PYe05g2qRP8YDHlKTwuql1AkGc64Bx54llLbiMXt2kg
+        CI3RXoaqktL/2/Cd/awnXwA4zflCH57dXd9e66DVS5/+AAAA//8DAJhFLaUIBgAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:06 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -186,7 +186,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=%2bGtBE4ygUTmG7zK%2beKMeljg%2bchydeLsnSqIxEUAgT8Cudc2KKCgDiq7lLrsJz%2fuiNItfMDPZ7pormwBo8VwSx%2b0yJ0u5OFtX0rtemjSliiBVKPbzDKabF0rQriUicsC%2fScn8d6fFwOxBV5TN3lrmz55aBKhAvO9hLLV9Sb2QtlqQqIaLm902HgIDMo%2f0kvrq
+      - ipa_session=MagBearerToken=kjc672X8gUlSnLIZw9xH3zMzbfrY5SvVqnuYakDOpcaU9lp6141BU8RymjZAA76HlvV3oX%2b5ee2gkprWMummHb5%2f0D7Fb6Sblmp2wjB2xLfFPbeeGuvF0%2f3EXUkiTVUuUPF7%2fAVQidMM48lugqZ6cLYBCLdJpxzTCPH9x8ATur41fQEHkNqVruo0LoXrCE2X
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -213,7 +213,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:06 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -226,59 +226,6 @@ interactions:
       - Accept-Encoding
       X-Frame-Options:
       - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=dummy&new_password=42&old_password=42
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/change_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA2SPQQrDMAwE73mFfuCkx2B86QcKfYFqi9jFtYqlNuT3dVqTSw+LYJldVjbqI7vB
-        RsLQjibN5E7jCNeX9yRizc8arOnIjcO2ByZ3QZGVawAfsSwEle7klUJDp0Y8m0Qrl+WPXFEOeoYz
-        l8ZhKgrvxBk1cZnhyCQBZQaJXNWa3tj27P2mrzHfNz4AAAD//wMAZB8Hus0AAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/html; charset=utf-8
-      Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-      X-IPA-Pwchange-Policy-Error:
-      - 'Constraint violation: Password is too short'
-      X-IPA-Pwchange-Result:
-      - policy-error
     status:
       code: 200
       message: Success
@@ -304,7 +251,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -312,20 +259,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:07 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=DbK%2bjWsaaioq97gSCYj%2bgO%2f%2bwnEk4Chg7TRlZb4EvBqz378Nz7TYaIP%2fLUHbbyXXaVyRgi%2bZVf0DW11flSucAYbNXn1H47Eq8nd5cIrirxRP2NSAlMLQRMOxgz3Y9LZf24b6XiWRfG%2fAabWxE7jCQpAfMV8HHB8ALz0NVBTWOQUkvYlplaoyosnD92J0QllI;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=vUuLdMLADPf3DFwNn3adecljFQaBAO37plqInG6k45Pgeypd2Redt9cFcECV0h3qBLwlCajmziG7IgQzQkkHwiCYfJF%2bO23CPUYfaoG7w2bkeSB3brJ2TdJ%2fDW5DYycpFJbPedTom7%2fILYWC0%2b0fGPwuJwvAyYXLC0PTs9%2bJM8G%2fYslH3J1N6eTTVVuhHt75;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -347,7 +294,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=DbK%2bjWsaaioq97gSCYj%2bgO%2f%2bwnEk4Chg7TRlZb4EvBqz378Nz7TYaIP%2fLUHbbyXXaVyRgi%2bZVf0DW11flSucAYbNXn1H47Eq8nd5cIrirxRP2NSAlMLQRMOxgz3Y9LZf24b6XiWRfG%2fAabWxE7jCQpAfMV8HHB8ALz0NVBTWOQUkvYlplaoyosnD92J0QllI
+      - ipa_session=MagBearerToken=vUuLdMLADPf3DFwNn3adecljFQaBAO37plqInG6k45Pgeypd2Redt9cFcECV0h3qBLwlCajmziG7IgQzQkkHwiCYfJF%2bO23CPUYfaoG7w2bkeSB3brJ2TdJ%2fDW5DYycpFJbPedTom7%2fILYWC0%2b0fGPwuJwvAyYXLC0PTs9%2bJM8G%2fYslH3J1N6eTTVVuhHt75
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -374,7 +321,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:07 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -403,7 +350,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=DbK%2bjWsaaioq97gSCYj%2bgO%2f%2bwnEk4Chg7TRlZb4EvBqz378Nz7TYaIP%2fLUHbbyXXaVyRgi%2bZVf0DW11flSucAYbNXn1H47Eq8nd5cIrirxRP2NSAlMLQRMOxgz3Y9LZf24b6XiWRfG%2fAabWxE7jCQpAfMV8HHB8ALz0NVBTWOQUkvYlplaoyosnD92J0QllI
+      - ipa_session=MagBearerToken=vUuLdMLADPf3DFwNn3adecljFQaBAO37plqInG6k45Pgeypd2Redt9cFcECV0h3qBLwlCajmziG7IgQzQkkHwiCYfJF%2bO23CPUYfaoG7w2bkeSB3brJ2TdJ%2fDW5DYycpFJbPedTom7%2fILYWC0%2b0fGPwuJwvAyYXLC0PTs9%2bJM8G%2fYslH3J1N6eTTVVuhHt75
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -431,7 +378,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:07 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -459,7 +406,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=DbK%2bjWsaaioq97gSCYj%2bgO%2f%2bwnEk4Chg7TRlZb4EvBqz378Nz7TYaIP%2fLUHbbyXXaVyRgi%2bZVf0DW11flSucAYbNXn1H47Eq8nd5cIrirxRP2NSAlMLQRMOxgz3Y9LZf24b6XiWRfG%2fAabWxE7jCQpAfMV8HHB8ALz0NVBTWOQUkvYlplaoyosnD92J0QllI
+      - ipa_session=MagBearerToken=vUuLdMLADPf3DFwNn3adecljFQaBAO37plqInG6k45Pgeypd2Redt9cFcECV0h3qBLwlCajmziG7IgQzQkkHwiCYfJF%2bO23CPUYfaoG7w2bkeSB3brJ2TdJ%2fDW5DYycpFJbPedTom7%2fILYWC0%2b0fGPwuJwvAyYXLC0PTs9%2bJM8G%2fYslH3J1N6eTTVVuhHt75
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -486,7 +433,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2020 17:26:55 GMT
+      - Wed, 29 Jan 2020 17:35:07 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:


### PR DESCRIPTION
This will avoid potential attack vectors, as well as actually work in production where we won't be allowed to delete users anyway.

When a password does not comply with policy, it will stay expired and the newly registered user will be sent to the login page where they will have to change it.

I see one downside: during the time between registration and the password change, the user will have an expired password that does not comply with the policy (and might very well be very insecure). Right now I don't know how to mitigate that.

I'd love to have the opinion from an UX person (wink wink @ryanlerch) on the workflow I've implemented here. To test it, try to register with too short a password.

Also pinging @relrod who raised the initial issue.