### PR TITLE
Boost coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,8 +9,10 @@ source =
    .tox/*/site-packages/securitas
 
 [report]
+fail_under = 100
 exclude_lines =
     pragma: no cover
     if __name__ == .__main__.:
 omit =
     securitas/tests/*
+    securitas/__init__.py

--- a/securitas/__init__.py
+++ b/securitas/__init__.py
@@ -24,17 +24,15 @@ app.register_blueprint(blueprint)
 try:
     import importlib.metadata
 
-    __version__ = importlib.metadata.version("securitas")  # pragma: no cover
+    __version__ = importlib.metadata.version("securitas")
 except ImportError:
     try:
         import pkg_resources
 
         try:
-            __version__ = pkg_resources.get_distribution(
-                "securitas"
-            ).version  # pragma: no cover
+            __version__ = pkg_resources.get_distribution("securitas").version
         except pkg_resources.DistributionNotFound:
             # The app is not installed, but the flask dev server can run it nonetheless.
-            __version__ = None  # pragma: no cover
+            __version__ = None
     except ImportError:
-        __version__ = None  # pragma: no cover
+        __version__ = None

--- a/securitas/controller/root.py
+++ b/securitas/controller/root.py
@@ -35,19 +35,11 @@ def search_json(ipa):
         users_ = [User(u) for u in ipa.user_find(username)['result']]
 
         for user_ in users_:
-            uid = user_.username
-            cn = user_.name
-            if uid is not None:
-                # If the cn is None, who cares?
-                res.append({'uid': uid, 'cn': cn})
+            res.append({'uid': user_.username, 'cn': user_.name})
 
     if groupname:
         groups_ = [Group(g) for g in ipa.group_find(groupname)['result']]
         for group_ in groups_:
-            cn = group_.name
-            description = group_.description
-            if cn is not None:
-                # If the description is None, who cares?
-                res.append({'cn': cn, 'description': description})
+            res.append({'cn': group_.name, 'description': group_.description})
 
     return jsonify(res)


### PR DESCRIPTION
This changeset brings coverage up to 100% by removing branches that were always true, and ignoring the main `__init__.py` file that does not contain much logic and is better covered by integration tests anyway.

It also sets coverage to fail under 100%, to make sure we stay there.