### PR TITLE
add the ability in the UI to add new GPG Key Ids

### DIFF
--- a/securitas/controller/user.py
+++ b/securitas/controller/user.py
@@ -56,4 +56,8 @@ def user_edit(ipa, username):
             flash('Profile has been succesfully updated.', 'success')
             return redirect(url_for('user', username=username))
 
+    # Append 2 empty entries at the bottom of the fieldlist
+    for i in range(2):
+        form.gpgkeys.append_entry()
+
     return render_template('user-edit.html', user=user, form=form)

--- a/securitas/form/edit_user.py
+++ b/securitas/form/edit_user.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import FieldList, StringField, SelectField
 from wtforms.fields.html5 import EmailField
-from wtforms.validators import AnyOf, DataRequired, Email, Optional
+from wtforms.validators import AnyOf, DataRequired, Email, Optional, Length
 
 from securitas.utility.locales import LOCALES
 from securitas.utility.timezones import TIMEZONES
@@ -35,7 +35,9 @@ class EditUserForm(FlaskForm):
 
     ircnick = StringField('IRC Nickname', validators=[Optional()])
 
-    gpgkeys = FieldList(StringField('GPG Keys', validators=[Optional()]))
+    gpgkeys = FieldList(
+        StringField('GPG Keys', validators=[Optional(), Length(max=16)])
+    )
 
     timezone = SelectField(
         'Timezone',

--- a/securitas/templates/_form_macros.html
+++ b/securitas/templates/_form_macros.html
@@ -1,24 +1,29 @@
-{% macro with_errors(field) %}
-  {% if kwargs.pop('nolabel', '') %}
-    {% set label = False %}
-  {% else %}
-    {% set label = True %}
-  {% endif %}
+{% macro form_field(field) %}
+  {% set css_class = 'form-control ' + kwargs.pop('class', '') %}
   {% if field.errors %}
-    {% set css_class = 'form-control is-invalid ' + kwargs.pop('class', '') %}
-  {% else %}
-    {% set css_class = 'form-control ' + kwargs.pop('class', '') %}
+    {% set css_class = css_class + ' is-invalid ' %}
   {% endif %}
-
-  {% if label %}
+  {% if kwargs.pop('label', True) %}
     <label for="{{ field.name }}" class="mb-0 font-weight-bold">{{ field.label }}</label>
   {% endif %}
   {{ field(class=css_class, **kwargs) }}
-  
   {% if field.errors %}
-  <div class="invalid-feedback">
+    <div class="invalid-feedback">
       {{ field.errors|map('escape')|join(' ') }}
-  </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+
+{% macro with_errors(field) %}
+  {% if field.type == 'FieldList' %}
+    {% if kwargs.pop('label', True) %}
+      <label for="{{ field.name }}" class="mb-0 font-weight-bold">{{ field[0].label }}</label>
+    {% endif %}
+    {% for subfield in field %}
+      {{ form_field(subfield, label=False, **kwargs) }}
+    {% endfor %}
+  {% else %}
+    {{ form_field(field, **kwargs) }}
   {% endif %}
 {% endmacro %}
 

--- a/securitas/templates/_login_form.html
+++ b/securitas/templates/_login_form.html
@@ -6,10 +6,10 @@
   </div>
   <div class="row">
     <div class="input-field col-12">
-      {{ macros.with_errors(login_form.username, class="validate", placeholder="username", tabindex="1", nolabel=True) }}
+      {{ macros.with_errors(login_form.username, class="validate", placeholder="username", tabindex="1", label=False) }}
     </div>
     <div class="input-field col-12">
-      {{ macros.with_errors(login_form.password, class="validate", placeholder="password", tabindex="2", nolabel=True) }}
+      {{ macros.with_errors(login_form.password, class="validate", placeholder="password", tabindex="2", label=False) }}
     </div>
     <div class="col-12 mt-2">
       {{ macros.non_field_errors(login_form) }}

--- a/securitas/templates/user-edit.html
+++ b/securitas/templates/user-edit.html
@@ -35,8 +35,7 @@
             <div class="form-group col">{{ macros.with_errors(form.rhbz_mail) }}</div>
           </div>
           <div class="form-row">
-            {# TODO: We need to have a way to add more keys and fix this styling #}
-            <div class="form-group col">{{ macros.with_errors(form.gpgkeys) }}</div>
+            <div class="form-group col">{{ macros.with_errors(form.gpgkeys, maxlength="16", class="text-monospace mb-1", placeholder="add a GPG Key ID") }}</div>
           </div>
           
           <div class="form-row">


### PR DESCRIPTION
Adds the ability to add 4 additional GPG Key IDs on every
save of the edit user dialog. This basic solution was chosen
so we can use append_field() from WTForms fieldlists, rather
than some hand-crafted hacky javascript to add new fields on
the fly.

The drawback with this approach is that a user can only add 4
new GPG Keys at a time. More than 4 keys can be added, the user
just has to submit the form, and then add more.

Resolves: #96

Signed-off-by: Ryan Lerch <rlerch@redhat.com>