### PR TITLE
show membermanagers that arent members in group page

### DIFF
--- a/securitas/controller/group.py
+++ b/securitas/controller/group.py
@@ -16,13 +16,15 @@ def group(ipa, groupname):
     sponsor_form = AddGroupMemberForm(groupname=groupname)
     remove_form = RemoveGroupMemberForm(groupname=groupname)
 
-    # This only finds sponsors that are also members of the group. Can we have sponsors which are
-    # not members?
-    sponsors = []
     members = [User(u) for u in ipa.user_find(in_group=groupname)['result']]
-    for member in members:
-        if member.username in group.sponsors:
-            sponsors.append(member)
+
+    batch_methods = [
+        {"method": "user_find", "params": [[], {"uid": sponsorname, 'all': True}]}
+        for sponsorname in group.sponsors
+    ]
+    sponsors = [
+        User(u['result'][0]) for u in ipa.batch(methods=batch_methods)['results']
+    ]
 
     # We can safely assume g.current_user exists after @with_ipa
     current_user_is_sponsor = g.current_user.username in group.sponsors

--- a/securitas/tests/unit/controller/cassettes/test_group/test_group.yaml
+++ b/securitas/tests/unit/controller/cassettes/test_group/test_group.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:06 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=U0D1MVGb2I1EIZXLfC0RtojwGIsvQKjbX6m7x6IGzZVF8AbGCv%2fNGmG0I2jsjNczdbyS4qfncD9mf5S%2fSGOuoj%2fpOTztVj76OGsLs8J6lfwxO%2flrTR16tb09DV9gdW3ZJUejMgsircyO2XEbJ8l52tmcphCP%2fwZLzswrzZO23pMA8v4yZ%2furQ9%2bUIslWCnhJ;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=thTMbXs0UJq9HQlam3RgOPatLm5KRRLoxIA%2fiOwfbO%2fuuqxY%2b35%2bnQcjx7p77FfFXXtxnujqhzJxJmvHEiFLl%2fuVRCyn4%2bmmeCzgnuRstn57GsP9KmcBQvol3c0XRWi4OQqdejtWHGG%2b%2fYKugDN1feh%2fJymIEHaoGsitxojotEoXHxDIz7h1xaXprHn70JJv;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U0D1MVGb2I1EIZXLfC0RtojwGIsvQKjbX6m7x6IGzZVF8AbGCv%2fNGmG0I2jsjNczdbyS4qfncD9mf5S%2fSGOuoj%2fpOTztVj76OGsLs8J6lfwxO%2flrTR16tb09DV9gdW3ZJUejMgsircyO2XEbJ8l52tmcphCP%2fwZLzswrzZO23pMA8v4yZ%2furQ9%2bUIslWCnhJ
+      - ipa_session=MagBearerToken=thTMbXs0UJq9HQlam3RgOPatLm5KRRLoxIA%2fiOwfbO%2fuuqxY%2b35%2bnQcjx7p77FfFXXtxnujqhzJxJmvHEiFLl%2fuVRCyn4%2bmmeCzgnuRstn57GsP9KmcBQvol3c0XRWi4OQqdejtWHGG%2b%2fYKugDN1feh%2fJymIEHaoGsitxojotEoXHxDIz7h1xaXprHn70JJv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:06 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
-      "dummy_password", "fascreationtime": "2020-01-22T10:14:08Z"}]}'
+      "dummy_password", "fascreationtime": "2020-02-13T08:29:06Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U0D1MVGb2I1EIZXLfC0RtojwGIsvQKjbX6m7x6IGzZVF8AbGCv%2fNGmG0I2jsjNczdbyS4qfncD9mf5S%2fSGOuoj%2fpOTztVj76OGsLs8J6lfwxO%2flrTR16tb09DV9gdW3ZJUejMgsircyO2XEbJ8l52tmcphCP%2fwZLzswrzZO23pMA8v4yZ%2furQ9%2bUIslWCnhJ
+      - ipa_session=MagBearerToken=thTMbXs0UJq9HQlam3RgOPatLm5KRRLoxIA%2fiOwfbO%2fuuqxY%2b35%2bnQcjx7p77FfFXXtxnujqhzJxJmvHEiFLl%2fuVRCyn4%2bmmeCzgnuRstn57GsP9KmcBQvol3c0XRWi4OQqdejtWHGG%2b%2fYKugDN1feh%2fJymIEHaoGsitxojotEoXHxDIz7h1xaXprHn70JJv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUbU8aQRD+K5f70i+IHIJiE5NSi8bWF5rWtrEaMrc7wJa93eu+IFfDf+/O3iGa
-        GP3E3Lw8M/vMMzykBq2XLn2fPDw1mQo/v9NPviiq5NqiSe9aScqFLSVUCgp8KSyUcAKkrWPX0TdD
-        pu1LyTr/g8wxCbYOO12mwV2isVqRpc0MlPgHTmgFcusXCl2IPXd4gqVybcUKGNNeOfpemLw0QjFR
-        ggS/alxOsAW6UkvBqsYbEuqJmg9r5xvMKdiNGQLf7PzUaF9eTcc+/4KVJX+B5ZURM6FGypmqJqME
-        r8Rfj4LH9yHfH3Szzv7OHptOd7IMYWdwkPd3+t1+r9PJDvMM9mIhjRza32vDcVUKEwmIEN1ON2R2
-        A0rW6xzcbLIDha6852wOaoavJeLKGeDggJIe0skkB4v7vckkfKfD4efl2fEcWXG45MeH85vTrMwX
-        H09+jk4ur0erk/PF5fj71+FRur6rH1yAghlyjC+mrkwdcdpxKxgzosiS1SzDtjg7whUUpUQymS7i
-        WFIH1uwcpYwYu7lQu2Gs+WZmBkorwUA+ii72+DD6NbwYn4/ax1cXMbUAIZ+Em07tTZunOngDaa4L
-        5MIEKejmYbvk2o3ZtaYFV77IgyQomvUHxHa/28SWqJ4fSPQHETGDcZdOFC+saVCvydarfjwT/0ov
-        30hrO1kZThjNEsk/DZeI9B6wk42ggtsZv/EusHKQb30FUiM9ncTtRWhScUC09fnTbNR1u+cYfGPN
-        61C6BOnp0c2ssZm1QT+21qKryhi+B6OEmlFCQ2L6I3QIrF0Ia5tIUxpVOz5LmoSk5im5B5so7RIb
-        lNlKptoETJ6EQcrAfi6kcFWMzzwYUA6Rt5Ohtb4I6Elkz7yzCQEva+BW0m139/rUmWlObbO9sAQi
-        pL6lh7QumzQFNFhdso7HErALiFpKh5wjT4i15Lbm4jaNBKExmnasvJT078G39qNwCQB4mPOZZond
-        bd9ee9Dupev/AAAA//8DAO5tXw7YBQAA
+        H4sIAAAAAAAAA4RU224aMRD9FWtf+sJlIUBIpUilKYmq5kIvSas0EZq1h8Vl13ZtL5ci/r22dxcS
+        KUqemJ3LmfGZM2wjjabIbPSebJ+aVLif39GnIs835Nagjh4bJGLcqAw2AnJ8KcwFtxwyU8Zugy9F
+        Ks1LyTL5g9TSDEwZtlJFzq1QGym8JXUKgv8Dy6WA7ODnAq2LPXcUHtaXS8PXQKkshPXfC50ozQXl
+        CjIo1pXLcrpAq2TG6abyuoRyourDmHmNOQNTmy7w3cwvtCzUzWxSJF9wY7w/R3WjecrFWFi9KclQ
+        UAj+t0DOwvtwMDhGZNDs4RE0Ox2EJnRw2Ox3+7047sdDSjuh0I/s2q+kZrhWXAcCAkQ37sZxt3MU
+        D7sncf++znYUWrVidA4ixdcScW01MLDgk7bRdJqAwUFvOnXf0Wh0+e1sfIc0P1mys5P5/UVHJYuP
+        5z/H59e34/X55eJ68uPr6DTaPZYPzkFAigzDi31XKk6Z33HDGamnyHirWoZpMHqKa8hVht6kMg9j
+        zWWOjGtHvKxg2t7VDkj14BSEFJxCtldeCH8Y/xpdTS7HrbObq5BqSp72Gis4E0WeuC/vHgz7gziO
+        j+M6dkAKHrdnqjHQbXn+ApODPZN7Tb0xUPrKAClfonh+SsGfA8+eQFactWrCMulkZuaYlUnthIu2
+        2+M8BJU7YdRL9E+buUtEzzCYaS0o57a6qL0L3FhIDr4c/ahyNg3bC/BexQ7RlOfv6fXEHfYcgm+s
+        eedKl5AV/qEV3aGZMU4/ptSi3agQXoEWXKQ+oaImunMd3EquuDFVpCoNqp18JlUCKZkmKzBESEuM
+        U2aDzKR2mIy4QZRbbcIzbjchnhagQVh3ky0yMqbIHToJ7Ol3hnjgZQncIN1W96jvO1PJfFunh7jj
+        CSlvaRuVZdOqwA9WluzCsTjsHIK6oxFjyIhnjTyUXDxEgSDUWnqViCLL/L8HO9h7sXkAYG7OZzrz
+        7B769lrDVi/a/QcAAP//AwCAjArO2AUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:06 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U0D1MVGb2I1EIZXLfC0RtojwGIsvQKjbX6m7x6IGzZVF8AbGCv%2fNGmG0I2jsjNczdbyS4qfncD9mf5S%2fSGOuoj%2fpOTztVj76OGsLs8J6lfwxO%2flrTR16tb09DV9gdW3ZJUejMgsircyO2XEbJ8l52tmcphCP%2fwZLzswrzZO23pMA8v4yZ%2furQ9%2bUIslWCnhJ
+      - ipa_session=MagBearerToken=thTMbXs0UJq9HQlam3RgOPatLm5KRRLoxIA%2fiOwfbO%2fuuqxY%2b35%2bnQcjx7p77FfFXXtxnujqhzJxJmvHEiFLl%2fuVRCyn4%2bmmeCzgnuRstn57GsP9KmcBQvol3c0XRWi4OQqdejtWHGG%2b%2fYKugDN1feh%2fJymIEHaoGsitxojotEoXHxDIz7h1xaXprHn70JJv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:06 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -314,13 +314,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:08 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -365,13 +365,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:09 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=oFULMjDQ9o%2fi7UQFpi2W19rgF09YEKqCpBxYVbcn1p8ilzxadnqJnERQm%2fT4%2fdnIlpABogurkQgnxNpTJhyz9mPpLpyO5%2fUn1X1fLooavjG%2fNYQU7AxULQcbg0%2fTU5Omb2zq1uAAVruPwyMGupmrKGS4wvLWP4oY1GgYIwBr5zk5V5H2h%2buSrTneKbbzGQAh;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=11RBLq%2f1UFQBrwIg%2f98SKXEkBEsCf25KfKQ2kZfKJKtod2PrguGg9xTWceUx9qWo5ly7VA16SCJi%2b%2bh9qrluZWbCVCxvzQpS4%2bT4AAk3otUheLm7WznwceLZ4Lfcg%2frpQJF46StXxKm5Zy2G7afakXuVk2J1gMAOaSOTaqZ8NTTKnZknW9UmozDyzKXoAeaB;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -395,7 +395,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=oFULMjDQ9o%2fi7UQFpi2W19rgF09YEKqCpBxYVbcn1p8ilzxadnqJnERQm%2fT4%2fdnIlpABogurkQgnxNpTJhyz9mPpLpyO5%2fUn1X1fLooavjG%2fNYQU7AxULQcbg0%2fTU5Omb2zq1uAAVruPwyMGupmrKGS4wvLWP4oY1GgYIwBr5zk5V5H2h%2buSrTneKbbzGQAh
+      - ipa_session=MagBearerToken=11RBLq%2f1UFQBrwIg%2f98SKXEkBEsCf25KfKQ2kZfKJKtod2PrguGg9xTWceUx9qWo5ly7VA16SCJi%2b%2bh9qrluZWbCVCxvzQpS4%2bT4AAk3otUheLm7WznwceLZ4Lfcg%2frpQJF46StXxKm5Zy2G7afakXuVk2J1gMAOaSOTaqZ8NTTKnZknW9UmozDyzKXoAeaB
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:09 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -451,7 +451,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=oFULMjDQ9o%2fi7UQFpi2W19rgF09YEKqCpBxYVbcn1p8ilzxadnqJnERQm%2fT4%2fdnIlpABogurkQgnxNpTJhyz9mPpLpyO5%2fUn1X1fLooavjG%2fNYQU7AxULQcbg0%2fTU5Omb2zq1uAAVruPwyMGupmrKGS4wvLWP4oY1GgYIwBr5zk5V5H2h%2buSrTneKbbzGQAh
+      - ipa_session=MagBearerToken=11RBLq%2f1UFQBrwIg%2f98SKXEkBEsCf25KfKQ2kZfKJKtod2PrguGg9xTWceUx9qWo5ly7VA16SCJi%2b%2bh9qrluZWbCVCxvzQpS4%2bT4AAk3otUheLm7WznwceLZ4Lfcg%2frpQJF46StXxKm5Zy2G7afakXuVk2J1gMAOaSOTaqZ8NTTKnZknW9UmozDyzKXoAeaB
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -461,14 +461,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0ySTYvcMAyG/4rJpZck5GMC08JCh7KHQofuqRS6pWhsTXBJbNeyZ3cY5r/XcgKT
-        m2RJj9680a3wSHEKxSdx24b29BdlkBMQpfxXEawrSlGM3kZnzwZmJM4NUkCVXznVDiKh3+YLiBNn
-        Sb8vpd9rr9H/ImqVNyA2fb/HXdXL87lqW4QKmqarhm7YNU378dRCnwelyf0qzvO1evAUkvTaBW2X
-        +kHkDvHoGLUycT6hz/V22HeJOyxQxUMJ/bTBlinNAXEEUtpoApVKPuE7zG5CDqWdi3sCXGCKyIyt
-        rvSejCIYMbt4K8LV5aY38EabMVuYvOSnH+gpaT9qorWyjnLx8PJVrA1i+QbxBiSMDYLQhFKcrU9M
-        JZIcB0Gf9KTDNdfHCB5MQFS1OBDFOdHTkL+g/0CCwZcFXIqu7vqBN0ureG3bJ4PYHAiQr2IZ+7MO
-        sLBl5H5nDxN7Bn/NepVCtVgvXreWvBbZLfTe8m8wcZr4FtQjdl4bmY5jYg6oJPfz88/D8eXbc/3l
-        +5HVbdbv6n29K+7/AQAA//8DAPbE0WDGAgAA
+        H4sIAAAAAAAAA0xSwYrbMBD9FeFLL7ZREnsTCgsNyx4KDd1TKXTLMpEmRostuRopuyHk36uRDfFt
+        Zt68N6OnuRYeKfah+Cquy9Ad31EF1QNRyv8UwY1FKYrOuzi6k4UBiXOLFFDnKqdmhEjol/kkxMno
+        yHxO0N+515p/EY3OE3ArGy23WDW4gWq1QqhgfZJVu24bKVu5U2qViRpJeTMG42wm7oWOw3ARd2k1
+        Ablc3cud0TYOR/QZfdi1D1LK7SzKlER8XJDKlOaAOAKlXLSBSq0e8ROGsUcOlRuKWxI4Qx+RNZZT
+        Uz0ZRdBhdvFahMuYmz7AW2O7bGHykku/0FN60sEQzchMZXD/8l3MDWJ6g/gAEtYFQWhDKU7OJ00t
+        0jojBHM0vQmXjHcRPNiAqGuxJ4pDUk8kf0b/hQQLnyfhUqzr9ablycppHrvaSLlicyBAvoqJ9jYT
+        eLGJcruxh0l7AH/J+2qNevoR8bq05LXIbqH3jr/Bxr7nW9D3ePTGqnQcPeuATut+e/69P7z8eK6f
+        fh54u8X4pt7VTXH7DwAA//8DAIAjxwnGAgAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -481,7 +481,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:09 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -509,7 +509,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=oFULMjDQ9o%2fi7UQFpi2W19rgF09YEKqCpBxYVbcn1p8ilzxadnqJnERQm%2fT4%2fdnIlpABogurkQgnxNpTJhyz9mPpLpyO5%2fUn1X1fLooavjG%2fNYQU7AxULQcbg0%2fTU5Omb2zq1uAAVruPwyMGupmrKGS4wvLWP4oY1GgYIwBr5zk5V5H2h%2buSrTneKbbzGQAh
+      - ipa_session=MagBearerToken=11RBLq%2f1UFQBrwIg%2f98SKXEkBEsCf25KfKQ2kZfKJKtod2PrguGg9xTWceUx9qWo5ly7VA16SCJi%2b%2bh9qrluZWbCVCxvzQpS4%2bT4AAk3otUheLm7WznwceLZ4Lfcg%2frpQJF46StXxKm5Zy2G7afakXuVk2J1gMAOaSOTaqZ8NTTKnZknW9UmozDyzKXoAeaB
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -536,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:09 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -587,13 +587,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:09 GMT
+      - Thu, 13 Feb 2020 08:29:07 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=JBjPX06Vtmyrs8jpGzdxpXrXmVqVZqwxff0%2fBw55drBRvLwNGnhZ2GVIoX1BPqziF%2b6YXYQovJXX4nOjDBuvQmUAXf7OtgQp93AgzAHVXBI%2b7OOCuYAU8oseT1svkD4DWMVi8DGe35aLuM%2bfucypDdFzboGVZQUPl3NvGhYC6NFctmVNAnyr2zTrESrMw6MH;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=gxRiFGs7OpF7MvdWjV8Bea9ru2R1VVDB5EgCLHMmp69eV5CY2kICkrUXr1czt4ew8hWEGpU2MSWoltyJ5KyBULMjZPASOO13jbtOTPAWGf50oGj9N20kp1QgZHM0JKAtcSqsJb66iulzrLn99mTMUOlqKLnkiGFjgjEer3jczc9%2bFNamrbbRbU5kQ9fz6eWs;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -617,7 +617,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JBjPX06Vtmyrs8jpGzdxpXrXmVqVZqwxff0%2fBw55drBRvLwNGnhZ2GVIoX1BPqziF%2b6YXYQovJXX4nOjDBuvQmUAXf7OtgQp93AgzAHVXBI%2b7OOCuYAU8oseT1svkD4DWMVi8DGe35aLuM%2bfucypDdFzboGVZQUPl3NvGhYC6NFctmVNAnyr2zTrESrMw6MH
+      - ipa_session=MagBearerToken=gxRiFGs7OpF7MvdWjV8Bea9ru2R1VVDB5EgCLHMmp69eV5CY2kICkrUXr1czt4ew8hWEGpU2MSWoltyJ5KyBULMjZPASOO13jbtOTPAWGf50oGj9N20kp1QgZHM0JKAtcSqsJb66iulzrLn99mTMUOlqKLnkiGFjgjEer3jczc9%2bFNamrbbRbU5kQ9fz6eWs
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -644,7 +644,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -673,7 +673,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JBjPX06Vtmyrs8jpGzdxpXrXmVqVZqwxff0%2fBw55drBRvLwNGnhZ2GVIoX1BPqziF%2b6YXYQovJXX4nOjDBuvQmUAXf7OtgQp93AgzAHVXBI%2b7OOCuYAU8oseT1svkD4DWMVi8DGe35aLuM%2bfucypDdFzboGVZQUPl3NvGhYC6NFctmVNAnyr2zTrESrMw6MH
+      - ipa_session=MagBearerToken=gxRiFGs7OpF7MvdWjV8Bea9ru2R1VVDB5EgCLHMmp69eV5CY2kICkrUXr1czt4ew8hWEGpU2MSWoltyJ5KyBULMjZPASOO13jbtOTPAWGf50oGj9N20kp1QgZHM0JKAtcSqsJb66iulzrLn99mTMUOlqKLnkiGFjgjEer3jczc9%2bFNamrbbRbU5kQ9fz6eWs
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -683,15 +683,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RS32vbMBD+V4Re9mKb2I4hGwQW2j4UFtaXjUEJRZHORsWWPJ3UNgT/79PJSeO3
-        vd3p9P3QpztzBxh6z7+xM5d2GHvwoGJXZoy3QvepOfMBhiO4VAZMxfMh3uicDeO1iedvWkJqpyke
-        LKjt8RWkv+sFIs25tyO/4m1rxABIvQGM8jNrbPUoSG3Zz0TUjBb1xzw6zLNfRv8N8HifFABWdb2B
-        dV7Lts3LEkQuVqsqb6pmvVqVX4+lqBNQmnRfhWE45Te+zxc/86DVNo0zabZkCKkQUtpgPGZKbuFD
-        UHRUxhATXgFKp0ev7cy/Y4mC3RQ6rUz4FCmbTRV9NfVC3bbXbBWRRKvbhU0ykYr/2ZkSIaLoIKV/
-        5v400j/xd+GMNl2KPv4BHf2Oz4ue9xrxMrlAabh7emSXC2z2zt4FMmM9QzA+Y611kVMxWiXh9VH3
-        2p/SvAvCCeMBVMF2iGGI7IxWBtwXZET8NhNnrCqquiFlaRXJlnUMhkIQXqRtmmEvFwAZmyHTdKC3
-        gnOWQjWh72kz1K0enTYyrkpPIKGiie8Pf3b7px8Pxd3PPWkuSNfFpljz6R8AAAD//wMAbK1rHSQD
-        AAA=
+        H4sIAAAAAAAAA4RSTYvbMBD9K0KXXmwjJ/YmFAIN2z0sNHQvLYUQFkUaGxVbcvWxuyH4v1cjO41v
+        vc2b0Xsz8zRXasGFztPP5EqF6YcOPMiIyozQhqsugSvtoT+DTWFwKTie4ovWmjDcQMy/KQEJjmNM
+        LKTN+TcI/9hx57BOvRnojW8azXtwiDW42H5SjVANHLst8SSEYDBOfUyl01T7odWfAM9fUwfYsEqy
+        DeQVrHlelsBzvmpYXq/qirGabYUoE1GCE1YNXhmdiHsiQ99fyF1aTIWUzu/pVkkdZluO9GFbPzDG
+        NpPoP7+ONCi5S9RM6B2u4zDgQpigvcuk2MEHR+MxjF+w4Jvm5q3EEeIgu8UQKJOC/wmOSdA53kJy
+        /0r9ZcB/ou/caqXbZH38A0z9jANGKw7KubkyU7G4f3km8wMy7U7euSPaeOJA+4w0xkZNSfCUuFdn
+        1Sl/SfU2cMu1B5AF2TsX+qhO8GTAfnIEhd8m4YysitW6xs7CSGxbrhnDe5Tc83RNE+11JuBgE2Uc
+        T7grWGvQex26Di9D3uPBKi3iqXRI4jIO8eXp1/7w8u2pePx+wJ4L0arYFhUd/wIAAP//AwCDyoOS
+        JAMAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -704,7 +704,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -732,7 +732,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JBjPX06Vtmyrs8jpGzdxpXrXmVqVZqwxff0%2fBw55drBRvLwNGnhZ2GVIoX1BPqziF%2b6YXYQovJXX4nOjDBuvQmUAXf7OtgQp93AgzAHVXBI%2b7OOCuYAU8oseT1svkD4DWMVi8DGe35aLuM%2bfucypDdFzboGVZQUPl3NvGhYC6NFctmVNAnyr2zTrESrMw6MH
+      - ipa_session=MagBearerToken=gxRiFGs7OpF7MvdWjV8Bea9ru2R1VVDB5EgCLHMmp69eV5CY2kICkrUXr1czt4ew8hWEGpU2MSWoltyJ5KyBULMjZPASOO13jbtOTPAWGf50oGj9N20kp1QgZHM0JKAtcSqsJb66iulzrLn99mTMUOlqKLnkiGFjgjEer3jczc9%2bFNamrbbRbU5kQ9fz6eWs
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -759,230 +759,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.example.com/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '20'
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=MYu7c%2f4iB1ufLHbcjgWeEwbek8KLUMbIQgPL8xBZSlF%2f8gkrhiE66BovdUaEG5GnfBmeXve45gAJUSV5un07I%2bAAUbMMY9HXCkO1MRFDSXjWVZBmcWSdYCy9vM8bPoCbhT1tLxqAla5rz4i92wa4xrU%2f%2b%2fTCJR6g%2bpFGW3JNfAk8KyEGksoak3juGGH6%2fds9;path=/ipa;httponly;secure;
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=MYu7c%2f4iB1ufLHbcjgWeEwbek8KLUMbIQgPL8xBZSlF%2f8gkrhiE66BovdUaEG5GnfBmeXve45gAJUSV5un07I%2bAAUbMMY9HXCkO1MRFDSXjWVZBmcWSdYCy9vM8bPoCbhT1tLxqAla5rz4i92wa4xrU%2f%2b%2fTCJR6g%2bpFGW3JNfAk8KyEGksoak3juGGH6%2fds9
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "group_add_member_manager", "params": [["dummy-group"], {"all":
-      true, "raw": true, "user": "dummy", "group": null}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '127'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=MYu7c%2f4iB1ufLHbcjgWeEwbek8KLUMbIQgPL8xBZSlF%2f8gkrhiE66BovdUaEG5GnfBmeXve45gAJUSV5un07I%2bAAUbMMY9HXCkO1MRFDSXjWVZBmcWSdYCy9vM8bPoCbhT1tLxqAla5rz4i92wa4xrU%2f%2b%2fTCJR6g%2bpFGW3JNfAk8KyEGksoak3juGGH6%2fds9
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5xSTYvbMBD9K8KXXmzjjxjSQmDDdg8LDd1LS6GEokhjo8WWXI20uyH4v1cjZRvf
-        Cr3N6Om9efNxySygH132iV0yYaZ5BAcyZHXOsp6rMSaXbILpBHbimg9g44vHGPw8ho+DNX6OybKE
-        dCVpTs8g3P3IEQnPnJmzd4LpNZ8AKdeAoWySCamaOcmv8yREyWxQvSXomLBvWv328Pg5VgCo2nYL
-        m6IVfV/UNfCCV1VTdE23qar646nmbSQKHf9LP03n4qaXOo2QV3IX4VzoHRlCCrgQxmuHuRQ7eOM0
-        MgrD8Fb826T+U0YCCqtmp0yyuWdRgt2MDkpq/9dr3W2b0F7XrkyY/n1BkkRCx7tVt2QiBv+ys0RB
-        xNBQXOIlc+cZSPCVW630EDcYVklP30N7wfNBIV6RK5XA/dMju35gyTt75ci0cQxBu5z1xgZNyegS
-        uVMnNSp3jvjgueXaAciS7RH9FNQDyb6A/YCMhF+ScM6asmk7qiyMpLJ1GwZDQ+COx6NMtF9XAhlL
-        lGU5Uq9graGhaj+OdGDyFs9WaREubiQSl8HE3cOP/eHpy0N5//VANVeim3JbbrLlDwAAAP//AwCL
-        Au9KYwMAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=MYu7c%2f4iB1ufLHbcjgWeEwbek8KLUMbIQgPL8xBZSlF%2f8gkrhiE66BovdUaEG5GnfBmeXve45gAJUSV5un07I%2bAAUbMMY9HXCkO1MRFDSXjWVZBmcWSdYCy9vM8bPoCbhT1tLxqAla5rz4i92wa4xrU%2f%2b%2fTCJR6g%2bpFGW3JNfAk8KyEGksoak3juGGH6%2fds9
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -1033,13 +810,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=dZTJ3QU3bavTpUJCmMUzfxfEw0OC6%2b9oyCGi2O6uR9hIwFsycXV%2bQSJOyi4Kz5r%2f81r6nDsaZHD%2fdYZk8R0Wg64ulTLnf1ectTmSWV%2fvliDL1gAy67hIw0BkeG3rJ2zju1pjD2Y1xLaS5dyrc1DX3jTyrfVy98e5Z1KXbzkBoyJwAqlSTCQH1uvX9i34aYox;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=5bl%2bwbFQcmgLXYgisAKGRZ3KHklB4Xrc5T41%2f6CtfJOoMA9zAzEdibg9Ajdsc9kpqgRICzfvoJmtDG%2f%2f9ZlnI%2bMjbVzOGkAZ2GkeK0Fyqz4yIno1AWvzwtPfPlxIx99R60gfDD6RJ%2bYGJHSiFIMBLme6TimaHF4t9Etqm4kTisRTXyhTkITtK2LVkcaRS%2fyo;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1063,7 +840,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dZTJ3QU3bavTpUJCmMUzfxfEw0OC6%2b9oyCGi2O6uR9hIwFsycXV%2bQSJOyi4Kz5r%2f81r6nDsaZHD%2fdYZk8R0Wg64ulTLnf1ectTmSWV%2fvliDL1gAy67hIw0BkeG3rJ2zju1pjD2Y1xLaS5dyrc1DX3jTyrfVy98e5Z1KXbzkBoyJwAqlSTCQH1uvX9i34aYox
+      - ipa_session=MagBearerToken=5bl%2bwbFQcmgLXYgisAKGRZ3KHklB4Xrc5T41%2f6CtfJOoMA9zAzEdibg9Ajdsc9kpqgRICzfvoJmtDG%2f%2f9ZlnI%2bMjbVzOGkAZ2GkeK0Fyqz4yIno1AWvzwtPfPlxIx99R60gfDD6RJ%2bYGJHSiFIMBLme6TimaHF4t9Etqm4kTisRTXyhTkITtK2LVkcaRS%2fyo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1090,7 +867,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1105,9 +882,8 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "user_add", "params": [["testuser1"], {"all": true, "givenname":
-      "Testuser1", "sn": "User", "cn": "Testuser1 User", "loginshell": "/bin/bash",
-      "userpassword": "testuser1_password", "fascreationtime": "2020-01-22T10:14:10Z"}]}'
+    body: '{"method": "group_add_member_manager", "params": [["dummy-group"], {"all":
+      true, "raw": true, "user": "dummy", "group": null}]}'
     headers:
       Accept:
       - application/json
@@ -1116,11 +892,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '236'
+      - '127'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dZTJ3QU3bavTpUJCmMUzfxfEw0OC6%2b9oyCGi2O6uR9hIwFsycXV%2bQSJOyi4Kz5r%2f81r6nDsaZHD%2fdYZk8R0Wg64ulTLnf1ectTmSWV%2fvliDL1gAy67hIw0BkeG3rJ2zju1pjD2Y1xLaS5dyrc1DX3jTyrfVy98e5Z1KXbzkBoyJwAqlSTCQH1uvX9i34aYox
+      - ipa_session=MagBearerToken=5bl%2bwbFQcmgLXYgisAKGRZ3KHklB4Xrc5T41%2f6CtfJOoMA9zAzEdibg9Ajdsc9kpqgRICzfvoJmtDG%2f%2f9ZlnI%2bMjbVzOGkAZ2GkeK0Fyqz4yIno1AWvzwtPfPlxIx99R60gfDD6RJ%2bYGJHSiFIMBLme6TimaHF4t9Etqm4kTisRTXyhTkITtK2LVkcaRS%2fyo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1130,20 +906,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xUW2/aMBT+K1Fe9gKUcJlgUqWxilbdemFau01dK3RiHxKPxM5sh8sQ/33HToCi
-        qttewD7nO7fvfM4m1GjKzIbvgs3zI5P09yO8Q2NLgzoK7uk3fGoEIRemyGAtIcfXIEIKKyAzlf/e
-        2xJkyrwWoOKfyCzLwFQQq4qQzAVqo6Q7KZ2AFL/BCiUhO9iFREu+Y4NL7sOVEStgTJXSuvtcx4UW
-        kokCMihXtckKNkdbqEywdW0lQNVRfTEm3eWcgdkdyfHFpBdalcXtbFLGn3BtnD3H4laLRMixtHpd
-        EVJAKcWvEgX38yHywQDag2aXzWbNKEJoxnGfN/udfq/djoZxBF0f6Fqm8kulOa4KoT0BPkWn3SFk
-        pxO1o157+LBDE4W2WHKWgkzwb0BcWQ0cLDjQJpxOYzD4tjed0j0cjT6uLs9SZPlwwc+G6cNFVMTz
-        D+ffxuc39+PV+dX8ZnL3eXQabp+qgXOQkCBHP7GryuSp3e25QZfE0WTcqV6IaXB2iivIiwzdkanc
-        t2aq8fbSSMQC5UuxeV+qcuRC06JUXfbEmU7sESpTtAuTYpZVkFjIExo29c4cRGXex7yvm2rtOioF
-        l2UeUz8OF/UHjs9+r+7udV9ZL/u4m+ci3I91KD7+PrqeXI1bZ7fXHk56Yxr92q3IX240au83ykAq
-        Kdh/pS3oqaNeoOtwRi8VHZtgpjuxkdnqcmed49pCfLDl6EZWs6nfqi/lFE4ZTfWJcDt08x9rwAP+
-        IYEthS8gK90Az5jzRY0hjZlKr3ZdeMgStBQycYB67PArVSG6roUxtacO9cqeXAY1IKg2FyzBBFLZ
-        wJB6G8FMacrJA2qmINpjkQm79v6kBA3S0tttBSNjypyyB55F/cYELvGiStwIOq1Ot+8qM8Vd2ahL
-        C3PEVO9tE1Zh0zrANVaFbP2Dotw5eEWHI86RB46E4PHAx2PoiUKtlVOeLLPMfWX44bzXmEsCnHo9
-        0oBj+VC71xq0euH2DwAAAP//AwBpF/mCDAYAAA==
+        H4sIAAAAAAAAA6SSS4vbMBDHv4rQpRfbyIm9CYVAw3YPCw3dS0thCUWRxkbFllw9djcEf/dqpCwx
+        vfTQ2zz0/43mcaEWXBg8/UguVJhxGsCDjF5dENpxNSTnQkcYT2BHrnkPNkWCS8bzMT7srQlTcuY5
+        ugukOf0C4e8H7hzmqTcTfReYTvMRHPoaXCybMdFVE0f80s8gdCbj1FtOHXPum1a/Azx+ThVgwxrJ
+        NlA2sOZlXQMv+apjZbtqG8ZathWiTkIJTlg1eWV0Eu6JDON4Jje0yIkULm/hXkkdcBwpe7dt7xhj
+        mwz9e07PNCi5S4RC6B125dDgQpigvSuk2MEbx7mjGTewwPyv3nTvC5LYSexnt+gFMcn4F3BOQOdi
+        S2mJF+rPEyDwlVutdJ82GFeJoe/xg3GiB+XcNXOVYnL/9EiuD0geIXnljmjjiQPtC9IZG5mS4CVy
+        r05qUP6c8n3glmsPICuydy6MkR5F9gXsB0cQ/JLBBVlVq3WLlYWRWLZeM4bnLLnn6Siz7OdVgB/L
+        knk+Yq9grcHZ6zAMeGDyZk9WaREvbkARl/ETnx5+7A9PXx6q+68HrLmANtW2auj8BwAA//8DAJS/
+        IWZjAwAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -1156,7 +927,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:10 GMT
+      - Thu, 13 Feb 2020 08:29:08 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1184,7 +955,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dZTJ3QU3bavTpUJCmMUzfxfEw0OC6%2b9oyCGi2O6uR9hIwFsycXV%2bQSJOyi4Kz5r%2f81r6nDsaZHD%2fdYZk8R0Wg64ulTLnf1ectTmSWV%2fvliDL1gAy67hIw0BkeG3rJ2zju1pjD2Y1xLaS5dyrc1DX3jTyrfVy98e5Z1KXbzkBoyJwAqlSTCQH1uvX9i34aYox
+      - ipa_session=MagBearerToken=5bl%2bwbFQcmgLXYgisAKGRZ3KHklB4Xrc5T41%2f6CtfJOoMA9zAzEdibg9Ajdsc9kpqgRICzfvoJmtDG%2f%2f9ZlnI%2bMjbVzOGkAZ2GkeK0Fyqz4yIno1AWvzwtPfPlxIx99R60gfDD6RJ%2bYGJHSiFIMBLme6TimaHF4t9Etqm4kTisRTXyhTkITtK2LVkcaRS%2fyo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1211,7 +982,236 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:09 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:09 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=AVtPizrGQC2tZaYaBXR7DSckEZ8ERT9iT251hrT84A%2f1ynwd%2b21irBkVs9%2f5RJZAEq0OYURL%2bSF0AJZbsUWxDEH97bxm8IuD0fCvksNmu7nhza63j9Qqt4BPJqe4CzSqb6kdByffwKhG2UNZDB3HzRLIkkvDAo1pRbgIYdQt48s5o1vNKMTlQ6JvwrNZ8N4E;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AVtPizrGQC2tZaYaBXR7DSckEZ8ERT9iT251hrT84A%2f1ynwd%2b21irBkVs9%2f5RJZAEq0OYURL%2bSF0AJZbsUWxDEH97bxm8IuD0fCvksNmu7nhza63j9Qqt4BPJqe4CzSqb6kdByffwKhG2UNZDB3HzRLIkkvDAo1pRbgIYdQt48s5o1vNKMTlQ6JvwrNZ8N4E
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:09 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["testuser1"], {"all": true, "givenname":
+      "Testuser1", "sn": "User", "cn": "Testuser1 User", "loginshell": "/bin/bash",
+      "userpassword": "testuser1_password", "fascreationtime": "2020-02-13T08:29:09Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '236'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AVtPizrGQC2tZaYaBXR7DSckEZ8ERT9iT251hrT84A%2f1ynwd%2b21irBkVs9%2f5RJZAEq0OYURL%2bSF0AJZbsUWxDEH97bxm8IuD0fCvksNmu7nhza63j9Qqt4BPJqe4CzSqb6kdByffwKhG2UNZDB3HzRLIkkvDAo1pRbgIYdQt48s5o1vNKMTlQ6JvwrNZ8N4E
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xUW2/TMBT+K1FeeOklTS+0SJMoUzchdiliHWhsqk7s09TUsYPt9ELV/47tpO0K
+        DHhp7XO+c/vO52xDhbrgJnwTbJ8fibB/X8M71KbQqFrBxP6GT7UgpEznHDYCMnwJwgQzDLgu/RNv
+        S5FI/VKATL4hMYSDLiFG5qE156i0FO4kVQqC/QDDpAB+tDOBxvpODS65D5earYEQWQjj7guV5IoJ
+        wnLgUKwrk2FkgSaXnJFNZbWAsqPqovV8n3MGen+0jk96fqlkkd/OxkXyATfa2TPMbxVLmRgJozYl
+        ITkUgn0vkFE/H76e0d4swnoH21BvtRDqSb/XrnfjbieKulGfkJYPdC3b8iupKK5zpjwBPkUcxVEU
+        t9pRPx5E/Yc92lJo8hUlcxAp/g2Ia6OAggEH2obTaQIae53p1N7D4fBqcj66R5INlvR8MH+4bOXJ
+        4t3F59HFzWS0vrha3IzvPg7Pwt1TOXAGAlKk6Cd2VYk4M/s91+wldTRpd6oWomuUnOEaspyjOxKZ
+        +da4tMzpOXLu8zQTJpq2tbl36nL2g26eb/QgyEPdt6Mvw+vx1ahxfnvt4UVF/wHhrRkw/ktg1Vdj
+        35StQ0BIwch/1ZnLDClTVkCyoqPpTM3TulZKRKHfqGHZH5Y1KJeVMiqKLLEjO0Sv3+1FUfQ63k/0
+        oi9lSxS/P1Pvy+1TR7VEx8fMvlR0XYOe7sVmzUYVe+sCNwaSoy1DV1LOpn6rPr1TuM2oy0+EW5Pr
+        7VQDHvAPCexs+BJ44Zp+tidfVGurMV3q1WxyD1mBEkykDlCNGt7bKpbTa6Z15alCvbLH74MKEJTM
+        BSvQgZAm0Fa9tWAmlc1JA9tMbneTMM7MxvvTAhQIg0gbwVDrIrPZA8+ieqUDl3hZJq4FcSNud11l
+        IqkraxcatRwx5XvbhmXYtApwjZUhO/+gbO4MvHLCIaVIA0dC8Hjk4zH0RKFS0m1eFJy7rww9ng/P
+        wiUBans9Ualj+Vi70+g3OuHuJwAAAP//AwBgssZFDAYAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:09 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AVtPizrGQC2tZaYaBXR7DSckEZ8ERT9iT251hrT84A%2f1ynwd%2b21irBkVs9%2f5RJZAEq0OYURL%2bSF0AJZbsUWxDEH97bxm8IuD0fCvksNmu7nhza63j9Qqt4BPJqe4CzSqb6kdByffwKhG2UNZDB3HzRLIkkvDAo1pRbgIYdQt48s5o1vNKMTlQ6JvwrNZ8N4E
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:09 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -1262,7 +1262,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:09 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -1315,13 +1315,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:09 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=eGzjh4sr0g7RPuKJrZAaQXHFITO%2biEPlUtP60Kk2mX%2bswk6nmqUYZHN7vfX4zP9oncEXJ2%2br8YXnKfc3N1apT79HlkgaTEKlPbS%2fsK3g38W6LCNi70FLXmRaIVfb6SOHH46HVoSP15KuvspWgZb9VGm8HaR9oNjsoJfLdYoHu2Od05NL43zEeoJkHlW7e%2bts;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=ZGCvvmbwWc%2bwxsGgWOOhpsTAxfuG9dyPzJcFMWJgv678AoiYGyIfk38x3HDtckKD5cBNtz%2fzKNFHpeu1elOXN4MeB31Akwgndp6iq1Z4gixdWX1kl1IYFbs9zubXsByH6hoEcumbsLcFJTZxEsX6PS8lDoSFlUzbbtbVPYRgEL64FCgLqA0nU03MZ9UmTndb;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1343,7 +1343,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=eGzjh4sr0g7RPuKJrZAaQXHFITO%2biEPlUtP60Kk2mX%2bswk6nmqUYZHN7vfX4zP9oncEXJ2%2br8YXnKfc3N1apT79HlkgaTEKlPbS%2fsK3g38W6LCNi70FLXmRaIVfb6SOHH46HVoSP15KuvspWgZb9VGm8HaR9oNjsoJfLdYoHu2Od05NL43zEeoJkHlW7e%2bts
+      - ipa_session=MagBearerToken=ZGCvvmbwWc%2bwxsGgWOOhpsTAxfuG9dyPzJcFMWJgv678AoiYGyIfk38x3HDtckKD5cBNtz%2fzKNFHpeu1elOXN4MeB31Akwgndp6iq1Z4gixdWX1kl1IYFbs9zubXsByH6hoEcumbsLcFJTZxEsX6PS8lDoSFlUzbbtbVPYRgEL64FCgLqA0nU03MZ9UmTndb
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1370,7 +1370,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1387,7 +1387,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["testuser2"], {"all": true, "givenname":
       "Testuser2", "sn": "User", "cn": "Testuser2 User", "loginshell": "/bin/bash",
-      "userpassword": "testuser2_password", "fascreationtime": "2020-01-22T10:14:11Z"}]}'
+      "userpassword": "testuser2_password", "fascreationtime": "2020-02-13T08:29:09Z"}]}'
     headers:
       Accept:
       - application/json
@@ -1400,7 +1400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=eGzjh4sr0g7RPuKJrZAaQXHFITO%2biEPlUtP60Kk2mX%2bswk6nmqUYZHN7vfX4zP9oncEXJ2%2br8YXnKfc3N1apT79HlkgaTEKlPbS%2fsK3g38W6LCNi70FLXmRaIVfb6SOHH46HVoSP15KuvspWgZb9VGm8HaR9oNjsoJfLdYoHu2Od05NL43zEeoJkHlW7e%2bts
+      - ipa_session=MagBearerToken=ZGCvvmbwWc%2bwxsGgWOOhpsTAxfuG9dyPzJcFMWJgv678AoiYGyIfk38x3HDtckKD5cBNtz%2fzKNFHpeu1elOXN4MeB31Akwgndp6iq1Z4gixdWX1kl1IYFbs9zubXsByH6hoEcumbsLcFJTZxEsX6PS8lDoSFlUzbbtbVPYRgEL64FCgLqA0nU03MZ9UmTndb
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1410,20 +1410,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xUa2/TMBT9K1G+8KWvtA1sSJMoUzcN9ihiAzQ2VTf2bWua2MF2+qDqf+faSdoV
-        GPClta/Pffic42xCjaZIbfg62DxdMkl/X8NbNLYwqLvBHf2Gj40g5MLkKawlZPgcREhhBaSmPL/z
-        sSkyZZ5LUMk3ZJalYEqIVXlI4Ry1UdKtlJ6CFD/ACiUh3ceFREtnhwFX3KcrI1bAmCqkdfu5TnIt
-        JBM5pFCsqpAVbI42V6lg6ypKgHKiamPMrK45AVMv6eCjmZ1rVeQ3k1GRvMe1cfEM8xstpkIOpdXr
-        kpAcCim+Fyi4vx9O+nHcYZ1mj00mzShCaB69SuJm3I37nU50nETQ84luZGq/VJrjKhfaE+BLdDtd
-        Qna7USfqR537Gk0U2nzJ2QzkFP8GxJXVwMGCA23C8TgBgy/74zHtw8Hg3fridIYsO17w0+PZ/XmU
-        J/O3Z5+HZ9d3w9XZ5fx6dPthcBJuH8sLZyBhihz9jV1XJk9srXODNlNHk3GrShDT4OwEV5DlKbol
-        U1npE8FlkSVEsSsTxUdu+jjesVELuPPfrs2b4ZfB1ehy2Dq9ufLwomJ7h6gaLFD+7l5/NlMZcqFJ
-        eVXdo+1C7cMKNAYDqaRg/zUGWYZp9MpZkf1BlKgUxZTC7h5F8RcmMhDpL20rLls1kakiC5oZpiWw
-        nQjZJo1n/jCnp456gY6gCb1UdJcHM67NRmGrizo6x7WFZB/L0I2lJmOvqi/vHE4VTfmJcDdx8x96
-        wAP+YYEtpS8gLRxNT4TzTY0hj5nSr3ade8gStBRy6gCVFOEn6kJcXwljqpMq1Tt7dBFUgKBkN1iC
-        CaSygSH3NoKJ0lSTBzRMTpolIhV27c+nBWiQFpG3goExRUbVA8+ifmECV3hRFm4E3Va3F7vOTHHX
-        NuqRdI6Y8r1twjJtXCW4wcqUrX9QVDsDb8BwwDnywJEQPOz5eAg9Uai1cu6QRZq6rwzfr3fvxBUB
-        TrMe+NKxvO/dbx21+uH2JwAAAP//AwClYqoDDAYAAA==
+        H4sIAAAAAAAAA4xUW2/aMBT+K1Ze9gI0hMtgUqWxilbTemFa201dK3RiH4JHYme2w2WI/z7bSaBo
+        YtsL2Od85/adz9kGCnWRmuAd2b4+UmH/vgf3qE2hUUXkwf4GLw0SMK7zFDYCMjwF4YIbDqku/Q/e
+        liCV+lSAjH8gNTQFXUKMzANrzlFpKdxJqgQE/wWGSwHpwc4FGus7NrjkPlxqvgZKZSGMuy9UnCsu
+        KM8hhWJdmQynCzS5TDndVFYLKDuqLlrP65wz0PXROr7o+ZWSRX43mxTxJ9xoZ88wv1M84WIsjNqU
+        hORQCP6zQM78fDjoRwM66za72IFmu43QjHuDYbMX9bph2AsHlLZ9oGvZll9JxXCdc+UJ8CmiMArD
+        qN0JB9EwHD7VaEuhyVeMzkEk+Dcgro0CBgYcaBtMpzFo7HenU3sPRqPrx4vxI9JsuGQXw/nTVTuP
+        Fx8uv44vbx/G68vrxe3k/vPoPNi9lANnICBBhn5iV5WKc1PvuWEviaNJu1O1EN1g9BzXkOUpuiOV
+        mW8tA56WGqjD31eoVg2xO6AKPRWGZ6enTKVdgp5jWiY8i7k4s1PO98zWYthr+VBz/G10M7kety7u
+        bmo4BSEFp/8F1+WS9gIvqsXvI7x1LjNkXFmhyYq2M2c6O0YlfIniz+dW+ZgosthWcb7+oNcPw/Bt
+        p6550pfbp45qia6rmX2p6LoBPa3FZs1GFbV1gRsD8cGWoUsrZ1O/VZ/eKdxm1OUnwk3v6h9rwAP+
+        IYGdDV9CWrhhX7Hli2ptNaZLvZpN7iErUIKLxAEqioJHW8VK44ZrXXmqUK/syUdSAUjJDlmBJkIa
+        oq16G2Qmlc3JiG0mtxKLecrNxvuTAhQIg8haZKR1kdnsxLOo3mjiEi/LxA0StaJOz1WmkrmyVpdh
+        2xFTvrdtUIZNqwDXWBmy8w/K5s7AKyIYMYaMOBLI84GP58AThUpJt11RpKn7yrDDea9tlwSY7fVI
+        o47lQ+1ua9DqBrvfAAAA//8DAFev2iQMBgAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -1436,7 +1436,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1464,7 +1464,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=eGzjh4sr0g7RPuKJrZAaQXHFITO%2biEPlUtP60Kk2mX%2bswk6nmqUYZHN7vfX4zP9oncEXJ2%2br8YXnKfc3N1apT79HlkgaTEKlPbS%2fsK3g38W6LCNi70FLXmRaIVfb6SOHH46HVoSP15KuvspWgZb9VGm8HaR9oNjsoJfLdYoHu2Od05NL43zEeoJkHlW7e%2bts
+      - ipa_session=MagBearerToken=ZGCvvmbwWc%2bwxsGgWOOhpsTAxfuG9dyPzJcFMWJgv678AoiYGyIfk38x3HDtckKD5cBNtz%2fzKNFHpeu1elOXN4MeB31Akwgndp6iq1Z4gixdWX1kl1IYFbs9zubXsByH6hoEcumbsLcFJTZxEsX6PS8lDoSFlUzbbtbVPYRgEL64FCgLqA0nU03MZ9UmTndb
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1491,7 +1491,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -1542,7 +1542,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -1580,7 +1580,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -1588,20 +1588,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:11 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=so2tTub%2bUJQG52HCeGAakKNaFWMXUCxl%2fMrdie0iEizCJnCshrlzpikQU3lblGVDa7GEc5%2fwVRFE6UrLiR1dv55RM26U4DdW4%2baf5gqv2mmJMhck5sumQjPQb1rSEIHFAZJUQjGwLrhw5RhgokFQVb8Sr%2bzcDEhaKtWM2SKH70%2boh6f9dkJHcHzrWNgUx1cb;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=MjhJ6CLrVZqw7utqtUQV3KPkAam4MOvdqUxUXIn92LxZX%2bf2igiGSJudasNwTxcXgsClYGSI9dWcH%2flv85eRxswRwuBThg6DVRutvwGABbeZp2BOLaW8mrVwCFmaLIO4NsdMmlheZFx9YoqOlV0VQb0pMERcVsmJyM0xHLfxxUI5FuE4BC8JPEV%2fj02Vayhi;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1623,7 +1623,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=so2tTub%2bUJQG52HCeGAakKNaFWMXUCxl%2fMrdie0iEizCJnCshrlzpikQU3lblGVDa7GEc5%2fwVRFE6UrLiR1dv55RM26U4DdW4%2baf5gqv2mmJMhck5sumQjPQb1rSEIHFAZJUQjGwLrhw5RhgokFQVb8Sr%2bzcDEhaKtWM2SKH70%2boh6f9dkJHcHzrWNgUx1cb
+      - ipa_session=MagBearerToken=MjhJ6CLrVZqw7utqtUQV3KPkAam4MOvdqUxUXIn92LxZX%2bf2igiGSJudasNwTxcXgsClYGSI9dWcH%2flv85eRxswRwuBThg6DVRutvwGABbeZp2BOLaW8mrVwCFmaLIO4NsdMmlheZFx9YoqOlV0VQb0pMERcVsmJyM0xHLfxxUI5FuE4BC8JPEV%2fj02Vayhi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1650,7 +1650,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1667,7 +1667,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["testuser3"], {"all": true, "givenname":
       "Testuser3", "sn": "User", "cn": "Testuser3 User", "loginshell": "/bin/bash",
-      "userpassword": "testuser3_password", "fascreationtime": "2020-01-22T10:14:11Z"}]}'
+      "userpassword": "testuser3_password", "fascreationtime": "2020-02-13T08:29:10Z"}]}'
     headers:
       Accept:
       - application/json
@@ -1680,7 +1680,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=so2tTub%2bUJQG52HCeGAakKNaFWMXUCxl%2fMrdie0iEizCJnCshrlzpikQU3lblGVDa7GEc5%2fwVRFE6UrLiR1dv55RM26U4DdW4%2baf5gqv2mmJMhck5sumQjPQb1rSEIHFAZJUQjGwLrhw5RhgokFQVb8Sr%2bzcDEhaKtWM2SKH70%2boh6f9dkJHcHzrWNgUx1cb
+      - ipa_session=MagBearerToken=MjhJ6CLrVZqw7utqtUQV3KPkAam4MOvdqUxUXIn92LxZX%2bf2igiGSJudasNwTxcXgsClYGSI9dWcH%2flv85eRxswRwuBThg6DVRutvwGABbeZp2BOLaW8mrVwCFmaLIO4NsdMmlheZFx9YoqOlV0VQb0pMERcVsmJyM0xHLfxxUI5FuE4BC8JPEV%2fj02Vayhi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1690,20 +1690,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xUyW7bMBD9FUGXXrzJSxoXCFA3cIK0WVw0aYs0gTEixxJrilRJyksM/3tJSrLj
-        Fkl7scmZNwvfvNEmVKgLbsJ3web5kQj79yO8RW0KjaoX3Nnf8LERhJTpnMNaQIYvQZhghgHXpf/O
-        2xIkUr8UIOOfSAzhoEuIkXlozTkqLYU7SZWAYE9gmBTA93Ym0FjfocEl9+FSsxUQIgth3H2u4lwx
-        QVgOHIpVZTKMzNHkkjOyrqwWUHZUXbRO65wz0PXROr7o9FzJIr+ZTYr4E661s2eY3yiWMDEWRq1L
-        QnIoBPtVIKP+fTiDuDN8i80emc2aUYTQjI8wbg66g36nEw3jCHo+0LVsyy+lorjKmfIE+BTdTtci
-        u92oE/Wj6L5GWwpNvqQkBZHga0BcGQUUDDjQJpxOY9B41J9O7T0cjT4+XZymSLLhgp4O0/vzKI/n
-        H86+jc+u78ars8v59eT28+gk3D6WD85AQIIU/YtdVSJOTD3nhr0kjibtTtVAdIOSE1xBlnN0RyIz
-        3xqXljmdIuc+Tztmom1bS+u+CQgpGAG+E+Cuzvvx99HV5HLcOr258vAMGP8DUlVs1eWea+I/MqYy
-        Q8qUlYasHtp2pvYuotQ6o6LIYisTh4gGx24Cg6PKt0Dx9/J4nxUXUehnbFj28vh0KYHd+hSv1Csq
-        yR12mNtVR7VA55vZTUX3NtDTWmzWbFRRW+e4NhDvbRm6YnI29VP16Z3CbUZdfiJcf67yoQY84B8S
-        2NrwBfDCPf5Zz76o1lZjutSrWecesgQlmEgcoCI1/GqrWAavmNaVpwr1yp5cBBUgKDkLlqADIU2g
-        rXobwUwqm5MGtpncTiJmnJm19ycFKBAGkbaCkdZFZrMHnkX1Rgcu8aJM3Ai6rW5v4CoTSV3ZqGcH
-        4ogp920TlmHTKsA1VoZs/ULZ3Bl4fYUjSpEGjoTgYc/HQ+iJQqWkm7koOHdfGbo/70TtkgC1vR5o
-        2bG8r91vHbf64fY3AAAA//8DAE0xAs8MBgAA
+        H4sIAAAAAAAAA4xUW2/aMBT+K1Ze9gI04dLCpEpjFa2m9cK0tpu6VujEPgSPxM5sh8sQ/322k0BZ
+        1W4vYJ/Ld875zudsAoW6SE3wnmyeH6mwfz+CW9Sm0Kg65M7+Bk8NEjCu8xTWAjJ8LYQLbjikuvTf
+        eVuCVOrXEmT8E6mhKegyxMg8sOYclZbCnaRKQPDfYLgUkO7tXKCxvkODA/fpUvMVUCoLYdx9ruJc
+        cUF5DikUq8pkOJ2jyWXK6bqy2oCyo+qi9azGnIKuj9bxVc8ulCzym+m4iD/jWjt7hvmN4gkXI2HU
+        uiQkh0LwXwVy5ufDPgUWRWGzix1oRhFCs3/S7jR77V43DHthn9LIJ7qWbfmlVAxXOVeeAA/RDtth
+        2I46Yb89CAcPdbSl0ORLRmcgEnwrEFdGAQMDLmgTTCYxaDzuTib2HgyHl/dno3uk2WDBzgazh4so
+        j+cfz7+Nzq/vRqvzy/n1+PbL8DTYPpUDZyAgQYZ+YleVilNT77lhL4mjSbtTtRDdYPQUV5DlKboj
+        lZlvbSYzZFxZ8mUFdeRMRzu0egAKQgpOId0pcRfyYfR9eDW+HLXObq58uC452+mt4EwUWWxvznzc
+        7x2HYXjSrX2HaN5q904VevoNz14yG4U7Znca+4/GkjcaSfgCxctn5n0Z8PQv6IrLVk1kKq0E9QzT
+        MvAo5uLI7njmnbl96qgW6Ead2peKjnnQk1ps1mxUUVvnuDYQ720ZupbldOK36uGdwi2iLj8Rjm5H
+        5KEGfMA/JLC16QtICzf0sxX4olpbjelSr2ad+5AlKMFF4gIqqoJ7W8Wu6YprXXmqVK/s8SdSBZCS
+        ebIETYQ0RFv1NshUKovJiG0mt+uOecrN2vuTAhQIg8haZKh1kVl04llU7zRxwIsSuEHarXan5ypT
+        yVxZq5EwcsSU720TlGmTKsE1VqZs/YOy2Bl49QdDxpARRwJ53PPxGHiiUCnplCOKNHVfGbY/70To
+        QIDZXg+051je1+62+q1usP0DAAD//wMAZnhEigwGAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -1716,7 +1716,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1744,7 +1744,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=so2tTub%2bUJQG52HCeGAakKNaFWMXUCxl%2fMrdie0iEizCJnCshrlzpikQU3lblGVDa7GEc5%2fwVRFE6UrLiR1dv55RM26U4DdW4%2baf5gqv2mmJMhck5sumQjPQb1rSEIHFAZJUQjGwLrhw5RhgokFQVb8Sr%2bzcDEhaKtWM2SKH70%2boh6f9dkJHcHzrWNgUx1cb
+      - ipa_session=MagBearerToken=MjhJ6CLrVZqw7utqtUQV3KPkAam4MOvdqUxUXIn92LxZX%2bf2igiGSJudasNwTxcXgsClYGSI9dWcH%2flv85eRxswRwuBThg6DVRutvwGABbeZp2BOLaW8mrVwCFmaLIO4NsdMmlheZFx9YoqOlV0VQb0pMERcVsmJyM0xHLfxxUI5FuE4BC8JPEV%2fj02Vayhi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1771,7 +1771,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -1822,7 +1822,510 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:10 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Z%2bCvIU3uw3CWJCAZorYcbXFoF9%2bKPAHKyJ3o%2fhvmkv9mT8E8NpCh2wjyb%2fyIJ9Cn4mzgAQkk6DqLV9af12hL5dteX9ljBvnReoaehvtTetjhKFNCBvtK8x6RpLgprGCLDr8LqJ2rhFV89VHe5vro8opMVde7afaUoBAy%2bQ6TrkSdwP4vFVGro2INrqm4GPUG;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Z%2bCvIU3uw3CWJCAZorYcbXFoF9%2bKPAHKyJ3o%2fhvmkv9mT8E8NpCh2wjyb%2fyIJ9Cn4mzgAQkk6DqLV9af12hL5dteX9ljBvnReoaehvtTetjhKFNCBvtK8x6RpLgprGCLDr8LqJ2rhFV89VHe5vro8opMVde7afaUoBAy%2bQ6TrkSdwP4vFVGro2INrqm4GPUG
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_add_member", "params": [["dummy-group"], {"all": true,
+      "raw": true, "user": ["testuser1", "testuser2", "testuser3"], "group": null}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '151'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Z%2bCvIU3uw3CWJCAZorYcbXFoF9%2bKPAHKyJ3o%2fhvmkv9mT8E8NpCh2wjyb%2fyIJ9Cn4mzgAQkk6DqLV9af12hL5dteX9ljBvnReoaehvtTetjhKFNCBvtK8x6RpLgprGCLDr8LqJ2rhFV89VHe5vro8opMVde7afaUoBAy%2bQ6TrkSdwP4vFVGro2INrqm4GPUG
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5xTS2sbMRD+K0KXXrxG+3BsCoaaNIdATXNpKRQTZGm8KOxKWz2SGLP/vRrJjvdW
+        6ts89H0z32jmRC240Hn6mZyoMP3QgQcZvXpG6IGrLjkn2kO/B5vM4JLxexdftNaE4eLE+KsSkNxx
+        jIEJtdm/gPD3HXcO89SbgV7w5qB5Dw59DS6Wz6zRVQPHalM/E6EzGKfec2qXcz+0+hPg8WuqAEvW
+        SLaEooGaF2UJvODVgRWLatEwtmArIcoEzNJ6rnmbhdGg5FqGvj/OhF5jAw4NLoQJ2ruZFGt45zgq
+        NOPQJjS34SMcMT6qx+fljbjqRlz9PzolOGHV4JXRSeyGJKnk+hMiJ1K4uIZbJXX4mNHdanHHGFtO
+        /8AcLqskkSISrSck2Fsy/tXlmAidi/+Zlu1E/XHAtaRv3Gql27RpceUw9DOqjlK2yrlz5gzF5Obp
+        kZwfkNw7eeOOaOOJA+1n5GBs5JQEL4d7tVed8seUbwO3XHsAOScb50If2QleCNhPjiDxayaekWpe
+        1QusLIzEsmXNWIlD4J6n48mw5zMAG8uQcdyhVrDW4FB16Do8BHm1B6u0iJfRIYjL2MSXh1+b7dO3
+        h/n99y3WnJA289W8oeNfAAAA//8DANzALCcTBAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Z%2bCvIU3uw3CWJCAZorYcbXFoF9%2bKPAHKyJ3o%2fhvmkv9mT8E8NpCh2wjyb%2fyIJ9Cn4mzgAQkk6DqLV9af12hL5dteX9ljBvnReoaehvtTetjhKFNCBvtK8x6RpLgprGCLDr8LqJ2rhFV89VHe5vro8opMVde7afaUoBAy%2bQ6TrkSdwP4vFVGro2INrqm4GPUG
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=c2OUocHx8%2fX0mhIa%2fu1RHbUk1ERVRJI7q%2f2WYvZ9TFRALZvQWrZ3kfAkP9UaypNltMOUwe7FDt6SPr0sWyl%2ftEpI%2fNLGStLivbEs6Vm8xwDLz%2fRYrxLdIMfFNIPBkowL1QsSdcsDdDY4Xi2zvfdgfLSx3DT3TH33NwY1%2fc0hhIWB7kUnIB9m6a9yYKw7%2bazW;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=c2OUocHx8%2fX0mhIa%2fu1RHbUk1ERVRJI7q%2f2WYvZ9TFRALZvQWrZ3kfAkP9UaypNltMOUwe7FDt6SPr0sWyl%2ftEpI%2fNLGStLivbEs6Vm8xwDLz%2fRYrxLdIMfFNIPBkowL1QsSdcsDdDY4Xi2zvfdgfLSx3DT3TH33NwY1%2fc0hhIWB7kUnIB9m6a9yYKw7%2bazW
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:11 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["testuser4"], {"all": true, "givenname":
+      "Testuser4", "sn": "User", "cn": "Testuser4 User", "loginshell": "/bin/bash",
+      "userpassword": "testuser4_password", "fascreationtime": "2020-02-13T08:29:11Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '236'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=c2OUocHx8%2fX0mhIa%2fu1RHbUk1ERVRJI7q%2f2WYvZ9TFRALZvQWrZ3kfAkP9UaypNltMOUwe7FDt6SPr0sWyl%2ftEpI%2fNLGStLivbEs6Vm8xwDLz%2fRYrxLdIMfFNIPBkowL1QsSdcsDdDY4Xi2zvfdgfLSx3DT3TH33NwY1%2fc0hhIWB7kUnIB9m6a9yYKw7%2bazW
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xUbW/aMBD+K1G+7AvQJLwMJlUaq2g1rW/T2q7qWqGLfQSPxPZsh8IQ/322k0DR
+        1G5fwL6X5+6ee5xNqFCXuQk/BJuXR8Lt34/wBrUpNapecGt/w6dWEFKmZQ5rDgW+FsI4MwxyXflv
+        vS1DIvRrCSL9icSQHHQVYoQMrVmi0oK7k1AZcPYbDBMc8r2dcTTWd2hw4D5daLYCQkTJjbsvVCoV
+        44RJyKFc1SbDyAKNFDkj69pqA6qO6ovW8wZzBro5Wsc3PT9TopRXs+sy/YJr7ewFyivFMsYn3Kh1
+        RYiEkrNfJTLq58PRMImhm7R72IV2HCO00+Gg2+4n/V4U9aMhIbFPdC3b8s9CUVxJpjwBHiKJkihK
+        4m40TEZx/NBEWwqNfKZkDjzDtwJxZRRQMOCCNuF0moLGQW86tfdwPD6/P5ncISlGS3oymj+cxTJd
+        fDr9Pjm9vJ2sTs8Xl9c3X8fH4fapGrgADhlS9BO7qoQfm2bPLXvJHE3aneqF6BYlx7iCQubojkQU
+        vjVdjbeTRskoL4vU3px5MOwPoih63/e+Alhe6aUp9bFG7DRwZc34LqISI1si/1vB3jcXBVKm7PZF
+        PcuRMx0dIlgdEIV+HYYVrzOdvdF+LqxI9BzzaoijlPEju4X5bvONWHed7uec3I8vrs8nnZOriyac
+        ABeckf8Kl/apo1qiI2dmXyq6wUFPG7FZs1FlY13g2kC6txXoJhKzqd+qL+UUbhF19YlwO3TUH2rA
+        B/xDAlubvoS8dAO8WJovqrXVmK70atbShzyD4oxnLqAeO7yzVexaLpjWtadO9cq+/hzUAUG1mOAZ
+        dMCFCbRVbyuYCWUxaWCbkXa9KcuZWXt/VoICbhBpJxhrXRYWPfAsqnc6cMDLCrgVJJ2k23eViaCu
+        rNVEFDtiqve2Cau0aZ3gGqtStv5BWewCvPjCMaVIA0dC8Ljn4zH0RKFSwgmLl3nuvjJ0f95px4EA
+        tb0eaMCxvK/d6ww7vXD7BwAA//8DAAe+ZWAMBgAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:12 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=c2OUocHx8%2fX0mhIa%2fu1RHbUk1ERVRJI7q%2f2WYvZ9TFRALZvQWrZ3kfAkP9UaypNltMOUwe7FDt6SPr0sWyl%2ftEpI%2fNLGStLivbEs6Vm8xwDLz%2fRYrxLdIMfFNIPBkowL1QsSdcsDdDY4Xi2zvfdgfLSx3DT3TH33NwY1%2fc0hhIWB7kUnIB9m6a9yYKw7%2bazW
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:12 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=testuser4&new_password=testuser4_password&old_password=testuser4_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '78'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -1873,13 +2376,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=VJNv3NXsz0n6MSmVTZziTHHN7A82TvIOwyJ%2fL9P9K86CZ%2bIaZy0%2fOzMS1VRUnpU22DH176gvdUQgONI%2f2j4ewozs%2fPoCxkR23MchdJoZGhlGVdOyGIKmnPxam7oyuNLBSXVhU5QME8qPQtlwn%2fFr5Yy4V%2f3B8SL928Mli9VflvUkqZet1Ov7DF36tCke91Cl;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=XSzq8GBLUOY9bQNq4%2bvEZMd5O1aD3rveUrtdvDHTL6DudY733XD7JU4RsGpw2uvpMpo07zu2SV44bjRIiiOZv8iEaPOHG4rPaxnQpJkA44a6k9YxBgXmqJsfh%2f8CKe1OQdpbp8KssO9jWYKap5MWLJfvxj0mqXPIPU5CdV0P%2byzUhKenmuxqbeNToQREEBU%2b;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1903,7 +2406,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=VJNv3NXsz0n6MSmVTZziTHHN7A82TvIOwyJ%2fL9P9K86CZ%2bIaZy0%2fOzMS1VRUnpU22DH176gvdUQgONI%2f2j4ewozs%2fPoCxkR23MchdJoZGhlGVdOyGIKmnPxam7oyuNLBSXVhU5QME8qPQtlwn%2fFr5Yy4V%2f3B8SL928Mli9VflvUkqZet1Ov7DF36tCke91Cl
+      - ipa_session=MagBearerToken=XSzq8GBLUOY9bQNq4%2bvEZMd5O1aD3rveUrtdvDHTL6DudY733XD7JU4RsGpw2uvpMpo07zu2SV44bjRIiiOZv8iEaPOHG4rPaxnQpJkA44a6k9YxBgXmqJsfh%2f8CKe1OQdpbp8KssO9jWYKap5MWLJfvxj0mqXPIPU5CdV0P%2byzUhKenmuxqbeNToQREEBU%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1930,7 +2433,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1945,8 +2448,8 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "group_add_member", "params": [["dummy-group"], {"all": true,
-      "raw": true, "user": ["testuser1", "testuser2", "testuser3"], "group": null}]}'
+    body: '{"method": "group_add_member_manager", "params": [["dummy-group"], {"all":
+      true, "raw": true, "user": ["testuser4"], "group": null}]}'
     headers:
       Accept:
       - application/json
@@ -1955,11 +2458,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '151'
+      - '133'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=VJNv3NXsz0n6MSmVTZziTHHN7A82TvIOwyJ%2fL9P9K86CZ%2bIaZy0%2fOzMS1VRUnpU22DH176gvdUQgONI%2f2j4ewozs%2fPoCxkR23MchdJoZGhlGVdOyGIKmnPxam7oyuNLBSXVhU5QME8qPQtlwn%2fFr5Yy4V%2f3B8SL928Mli9VflvUkqZet1Ov7DF36tCke91Cl
+      - ipa_session=MagBearerToken=XSzq8GBLUOY9bQNq4%2bvEZMd5O1aD3rveUrtdvDHTL6DudY733XD7JU4RsGpw2uvpMpo07zu2SV44bjRIiiOZv8iEaPOHG4rPaxnQpJkA44a6k9YxBgXmqJsfh%2f8CKe1OQdpbp8KssO9jWYKap5MWLJfvxj0mqXPIPU5CdV0P%2byzUhKenmuxqbeNToQREEBU%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1969,15 +2472,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xTTYvbMBD9K0KXXmzjjxjSQmDDdg8LDd1LSyGEokhjo2JLrj52NwT/92okpxt6
-        6ZLbjEfvvXnjmTM1YP3g6CdyplyP0wAORMiajNCOySEmZzrCeAQTQ29jsD+EF73Rfrok4fuz5BDT
-        eQ4frqj18Rdwdz8wa7FOnZ7oBa87xUawmCuwQT6xhlRODNWu80SEyaStfE2lQ6p9U/K3h8fPUQGg
-        bJo1rPKGd11eVcByVpZ13tbtqiyrj8eKNRHYS6H84m5Pq3Zdh3Kban9t76mXYiP8OJ4yrjbYlcWA
-        ca69cjYTfAOvDOeHYZgktogYFyzh8+pGXH0jrnkvDn1yFT1Gf/nbTJP9kSnW3zoFpBFguZGTkzrJ
-        bEmkIP8K6e6ySgIfhq42Vx2hUAz+JzlHQmtD03HZztSdJlxL+sKMkqqPmxZWDj99DxZCXztp7VJZ
-        oFjcPj2S5QFJO0JemCVKO2JBuYx02gROQfBymJNHOUh3ivXeM8OUAxAF2Vrrx8BO8ELAfLAEiZ8T
-        cUbqom5aVOZaoGzVhAXEITDH4vEk2M8FgI0lyDwf0CsYo/HvKD8MeAjiLZ6MVDxcxoAgJkITdw8/
-        trunLw/F/dcdal6Rrop1saLzHwAAAP//AwBVcb27EwQAAA==
+        H4sIAAAAAAAAA6xTTYvbMBD9K0KXXmwjJ/YmFAIN2z0sNHQvLYUlFEUaGxVbcvWxuyH4v1cjZUno
+        pe3S28w8vTearxO14MLg6XtyosKM0wAeZPTqgtCOqyE5JzrCeAA7cs17sCkSXDIe9/Fhb02YkjPP
+        0b2SNIcfIPztwJ1DnHoz0VeC6TQfwaGvwcW0WSa6auIof+1nIXQm49RLhvYZ+6LVzwD3H1MGWLFG
+        shWUDSx5WdfAS77oWNku2oaxlq2FqBNRghNWTV4ZnYhbIsM4HslFWmQghctLuFdSB2xHQm/W7Q1j
+        bJVFf+/TIw1KbpJCIfQGq3JocCFM0N4VUmzghWPf0YwTwBKR42NL8Hnzt7xL+v+St34jb/FG3vLf
+        6zTd6wJKnFSc1+ZqViiTjD8JzknQuTiytKQn6o8ToOAzt1rpPm1oXFUMfY0fjBuzU86dkTMVwe3D
+        PTk/IHlFyDN3RBtPHGhfkM7YqCkJXhr36qAG5Y8J7wO3XHsAWZGtc2GM6pFkn8C+cwSFn7JwQRbV
+        YtliZmEkpq2XjOG5Su55OrpM+34m4McyZZ73WCtYa3BHdBgGPCB5sSertIgXNSCJy/iJD3fftruH
+        T3fV7ecd5rwSbap11dD5FwAAAP//AwCTZxj9QwQAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -1990,7 +2493,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:12 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -2018,7 +2521,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=VJNv3NXsz0n6MSmVTZziTHHN7A82TvIOwyJ%2fL9P9K86CZ%2bIaZy0%2fOzMS1VRUnpU22DH176gvdUQgONI%2f2j4ewozs%2fPoCxkR23MchdJoZGhlGVdOyGIKmnPxam7oyuNLBSXVhU5QME8qPQtlwn%2fFr5Yy4V%2f3B8SL928Mli9VflvUkqZet1Ov7DF36tCke91Cl
+      - ipa_session=MagBearerToken=XSzq8GBLUOY9bQNq4%2bvEZMd5O1aD3rveUrtdvDHTL6DudY733XD7JU4RsGpw2uvpMpo07zu2SV44bjRIiiOZv8iEaPOHG4rPaxnQpJkA44a6k9YxBgXmqJsfh%2f8CKe1OQdpbp8KssO9jWYKap5MWLJfvxj0mqXPIPU5CdV0P%2byzUhKenmuxqbeNToQREEBU%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2045,7 +2548,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -2075,7 +2578,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2102,7 +2605,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -2131,7 +2634,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2141,18 +2644,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUbW/TQAz+K6d84UvbNWk7yqRJTDAhBNMmoSEEQpNzd0mPXe7CvazNpv537EvW
-        drCJT3X82I/tx74+ZE76qEN2wh725o+HjBv6zd7HpunYtZcu+zlimVC+1dAZaORzsDIqKNC+x66T
-        r5bc+ueCK/DcSQjKmqAGvmJaTKd5UeTTfD5dfk9xtvwleeAafE8TbJuhu5XOW0OWdTUYdZ+YQO/9
-        ysiA2FNHpPKUbr3aAOc2mkDft65snTJctaAhbgZXUPxWhtZqxbvBiwF9R8OH96tHTpzo0UTgi199
-        cDa2l9VVLD/JzpO/ke2lU7Uy5ya4rhethWjU7yiVSPNJcbxEAY7HM15V4zyXMF6+LhfjRbGYozhv
-        yhxmKZFaxvJr64TctMolAfYyzov8UEaMRglDuxZ8BaZ+WW8M5GCsURz0btGCdvf2/NvZxdXn88m7
-        y4sU6vtyu5XW6k6ap8eR/A0ofUAjN9C0Wk64bRIclTCxKZGEYvLFkppaFAPly5i2KKRfSd2TH5XK
-        HJXgVzt1Hhf6nzFWtpFCOdypxZ0kKnIdid0AcdjN3mP8cDza8lvEKjx7SXeFj0i6OykOfI2kAWx1
-        U9M9JCJaOsalm0ik4x5Lj4xUpZKnCRlxc5piyRiK+pHgp4OMZJKSW8rt7/mE5WgHFw2H8Fcr3kMt
-        ff/IQ9eSLtkanFGmpmYGqbKvWBDP6UJ5PyBDKoFnVx/ZEMD67bA1eGZsYF6aMGKVdcgpGPbV4lmW
-        SqvQJbyO4MAEKcWEnXkfG2RnSTH3yjMivuuJR6yYFLNFloYSVDaf4epJHwiQ/q/6tJshgRrrU7ZJ
-        CuRuIO0zyxkJyBoIfIVybBGVzlm6KRO1pkco9vbubCj134vBiIOK88lyMs+2fwAAAP//AwAQTPhS
+        H4sIAAAAAAAAA4RU72/TMBD9V6x84UvbJVnblUmTmGBCCKZNQkNoCE1X55qYOXbwj7Vh6v+Oz3Hb
+        DSb41Mu9d3e+5+c+Zgatly47ZY+H8NtjxhX9Zu982/bsxqLJvo9YVgnbSegVtPgSLJRwAqQdsJuY
+        q5Fr+xJ5BZYbBCe0ciL1K/Myz8viOF+Ur/P5beTp5Q/kjkuwQxunuyykOzRWK4q0qUGJX7ETyENe
+        KHQBe57wNJ7KtRUb4Fx75ej73iw7IxQXHUjwm5Rygt+j67QUvE/ZQBhOlD6sbXY9w0a7MACfbfPe
+        aN9dra798iP2lvItdldG1EJdKGf6QbQOvBI/PYoq7ofz+QliBeMpHsO4KBDGUOBiPCtn0zyf5QvO
+        i1hIRw7j19pUuOmEiQIcZJwlGU9ud+wgoevWFW9A1S/ofSDuldhfdEV39+bi6/nl9aeLydury0iV
+        OmxiG5Qyko6WQh0twTYRbEHIJ7W4gbaTOOG6jXCjW6yECULqIEQsp9RRZEeGT4IcMnZYb2+hWjyg
+        em7GXaXy7TKwKD9fzOZ5np/ku/U4KK0E/+969T/aKJvMIzW/D/gq2B7JV+ERoXnA6kmuRWqiV3c1
+        +SE2o0sPvOiJOHw8YPGR0Za0w1lERlydRS4FaagdVfwsKUohibql2sHPp6wIsTNecXB/HMVaqNEO
+        j9z1He2frcEooWo6TJIk+xIGBjtdCmsTkkoJPL/+wBKBDQqxNVimtGMWlRuxlTahZ8XCubpgy6WQ
+        wvURrz0YUC4YfMLOrfVt6M6iYuaVZdT4YWg8YuWkPJ5lcamKxgab5rRXBQ7i/9VQdpcK6GBDyTZK
+        EXq3EK2VFYwEZC043gQ5tgFFYzTdq/JS0iOsDvHe/VT6tzMC48nE6WQxmWbb3wAAAP//AwDSOksF
         SAUAAA==
     headers:
       Cache-Control:
@@ -2166,7 +2669,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -2195,7 +2698,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2205,14 +2708,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2RSTYvbMBD9K8KXXmwT2zGkhYWGZQ8LDd1TKZSyTKSJUbEkVyNlN4T892pk0xj2
-        Nm8+3nua0bXwSHEMxRdxXYfu+AdlkCMQJfyrCG4qSlEM3sXJnSwYJMYWKaDKWYZ6gkjo13gmYjA5
-        0u9z6ffSa/XfiFplBcRN1+1wW3XydKqaBqGCzaat+rbfbjbN52MDXR4ctLLRHNHnsabftanczzVp
-        c1JFYy7VXUshSa+noN1c34vcIe4dBpnxld3fGdh1SC/kbLMG7Rp0KwIDFoaPPNkDSyeDDytzZYI5
-        II5AShdtoFLJB3wHM43IoXSmuCWCM4wRmWP9uqxMlETzna5FuEy56Q281XbIR0rX4tQP9JQ2cNBE
-        S2UZ5eL+5VksDWJer3gDEtYFQWhDKU7OJ04lkp0Jgj7qUYdLrg8RPNiAqGqxJ4omsachf0b/iQQT
-        n2fiUrR12/WsLJ1i2aZLt+PlQID87+ax12WAjc0jtxvvMHEb8JeUtnEceSnovfML5k+l7vHktZXp
-        l43/d/b16ef+8PLtqX78fmATK5Vtvau3xe0fAAAA//8DACusL8MPAwAA
+        H4sIAAAAAAAAA3xSwYrbMBD9FeFLL7aRHXsTCgsNyx4WGrqnUihlUaSJUbEkVyNlN4T8ezWyaXzq
+        bd48vTdPI10LDxjHUHxm13Xpjr9BBjkKxIR/FsFNRcmKwbs4uZMVBpCwBQygcpegnkRE8Gs8GxGY
+        HOqPmfq1nLX6TwSt8gTY8k7xLVQdbETVNCAq0Z541bd9x3nPd1I2WagApddT0M5m4Z6paMyF3a3l
+        TOR2dW8PWtlojuAz+7DrHzjn29nUABFvlP6updQh3ZC6zRq0a7BZGRhhxfBfn26+AyVMOR9XGcsE
+        c4FUCSldtAFLJR/hQ5hpBCqlM8UtGZzFGIE81pfMMRBTgvxo1yJcpnzoXXir7ZBfLD0dtb6Dx7TB
+        g0ZcmEVK5P71hS0H2Lwy9i6QWRcYgg0lOzmfPBVLcSYR9FGPOlwyP0ThhQ0AqmZ7xGiSexL5M/hP
+        yMj4PBuXrK3bTU+TpVM0ttlw3tByRBD5E86yt0VAwWbJ7UY7TN5G+Etq2ziOtBTw3vkF0w9T93ry
+        2sr05cZ/O/vy/GN/eP36XD99O1CI1ZSu3tVdcfsLAAD//wMAs3nczxwDAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -2225,7 +2728,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -2254,7 +2757,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2264,23 +2767,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+yYbU/bMBDHv4qVN3vTlsRJuoCENLShadoQSINp2jQhx3FTj8TObAfaIb77fE76
-        BC0ND+INe1X37nx3/vt+TdtrTzFdF8bbQ9eL5c9rjwp49T7UZTlFZ5op71cPeRnXVUGmgpRsnZsL
-        bjgpdOM7c7acUanXBY+IpooRw6UwvM2Hfez7AcaBH0R+8sPFyfQ3o4YWRDdpjKw8a66Y0lLASqqc
-        CP7XZSLFws4FM9a3aqihPGyXmk8IpbIWBt5fqLRSXFBekYLUk9ZkOL1gppIFp9PWagOajto3Wo9n
-        Oe2JZkvr+KrHH5Wsq+PRSZ1+ZlMN9pJVx4rnXBwKo6aNaBWpBf9TM56587FsmFgBhv2Qjkb9IGCk
-        n7xN436M48iKs5sGJHQboWVb/kqqjE0qrpwACxkjHCzLaKOthKa6yuiYiHyz3jm/ZGL1hp1dN7nn
-        91cSXjhLBiHv2ISUVcEGVJbOXfNM1GVqgyEmiBOoFOOZb7FzfpaZ/PPaTeLD7wdHJ18OB++Pj9r+
-        Nicey5JlXNnbkVZd8O+AaWdRqJBWfD1mRdP7TsrFTkr0eNYFJUIKTrd2IXQ7PIWkFzZuZMeewVxZ
-        iJi6ZNmSrWTQrhyd5zAPLilcuo1zM+EK9BufgwyEBo32nadHxb6LhUVbVPcyut8qDksQ/aaH5tie
-        Mu0mPdiM7pqQFXxPb+O7ZsM2hAP/lSLMsiQhfrKEcJrG2WMRDoKOCM8CVxGeX9z9GJtZWEeUoxWU
-        zUqRtTgvCnRDOroX6dWCD8d6czcvgva8/FPwxtvxxg/FGz8A7+CV4j2K4tin/jM9oZ8Jb9wNb9wR
-        73gt3ng73rgj3nEnvPET8b7bzYvijZ+Cd7gd7/CheIf/8d6ON0n93bds+ek9ZOmj8cZd8cb34R12
-        wzvsiPdwLd7hdrzDjngPO+EdPhHvu928KN5hZ7xhfzPreyiya6NqQYm51Y7WJGe6+QVuphWc1bsi
-        SnCRQ0Pt8b1vtqAdtSOudetpt4Lz4OQTagNQcy/oimgkpEGaCdNDI6lszgzZvio7sikvuJk6f14T
-        RYSxX18H6EDrurTZkVNNvdEIEl82iXsID3AYe+5QGZQNQnvpoBExxP2Z0Gw7bzdAY82WGyeFzV0S
-        NxFehJyAqCSGjq0e9pPQY0pJGCdRFwUQmi3W88mEvXd/m9mIpZLRIBlE3s0/AAAA//8DADRUKbnm
-        EAAA
+        H4sIAAAAAAAAA+yYXW/bNhSG/wqhm97YjkTJtlwgwIItKIo2SIAmw9BhKI6pY5mLRKoklcQL8t9H
+        UvJXo8SOM+SmuzJ9vnjOq/MkkO8DhbouTPCe3K+Pf94HTLjP4Le6LBfkSqMK/uqRIOO6KmAhoMQu
+        NxfccCh047vythyZ1F3BM9BMIRguheFtPRrSMKRRHKZ0Eo6++jg5/RuZYQXopoyRVWDNFSothTtJ
+        lYPg//hKUKztXKCxvm1D7a536VLzO2BM1sK479dqWikuGK+ggPquNRnOrtFUsuBs0VptQNNR+0Xr
+        +bKmnWh5tI4vev5Bybo6n13U00+40M5eYnWueM7FqTBq0YhWQS349xp55ufD0WiMmEE/wRj6UYTQ
+        hwjT/pAOkzAchiljkU90Ldvrb6XK8K7iyguwlnHYyjj+uoy2EprqNmNzEHmH3m3gXJaYcWUnlLZD
+        F3XkTEeZe3zLUgyEFJxBsVoF7/7l9I+Ts4vPp4Nfz898qG4aWj30nN+g2F4fby+BFxtl8A7KqsAB
+        k2Wblom6nNoiLmaUDkdhGI5D76tb3db91c9EF9KKr+dYNNcdTbk4moKerxRdLsGOwYRul6eQ7NrG
+        zezao9srCxGqG8w2bCW6ZuTsW+72wRd1D93G+Z3wF/Qbn4fMaeaGOPaeHhPHPtYd2kt1L2PHrUju
+        6HR66JEVtpeo/aZHT6PbEbKF7+WP+HYk7ER48pMiPJ5lo1mIGwhP01F8MMKTfRGePI+wWT7CpzFe
+        hbwQ5cut0iuc1+X2Q5puIb3dbzfW9ECsnx70TdBeXf8avOluvOlL8ab/470T73REUzZLNvEeppND
+        8Y7CPfFeBu7Cm+7Gmx6IN+3Gm+6Jd9yJN30G7/iVeD8e9E3xpq/BO96Nd/xSvOP98V6u28+HN4Ms
+        isINvNMxPfi/93+Od7wb7/hAvONuvOM98U468Y6fwTt5Jd6PB31TvOO98Xb5za6/J4k9G1ULBuaH
+        drSGHHXzBm4WlZs1uAUluMhdQ+34we/2QrtqZ1zr1tOmOufJxUfSBpBGcXILmghpiEZhemQmla2Z
+        EdtXZVd2ygtuFt6f16BAGPv2OSAnWtelrU68auqdJq7wTVO4R+iAxsPAD5W5a+0Kh5HTCAz4HxOa
+        tG9tgmusSXnwUtjaJfjtDhLiBSQlGDa3eti/hAEqJd2iiLooHKHZ+rzaBZf7+N3MRmxcmQzSQRI8
+        /AsAAP//AwDgnlOk5hAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -2293,9 +2796,76 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "user_find", "params": [[],
+      {"uid": "dummy", "all": true}]}, {"method": "user_find", "params": [[], {"uid":
+      "testuser4", "all": true}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '185'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+RWbW/TMBD+K1a+8KXtkvRlHdIkJpgQgmmT2BAamibHuaZmjh1sZ2uZ+t85O07b
+        jFYDhMQHPuVy99yrz0/yGGkwtbDRS/IYMVVLJ6U9EtQG3748bjAoM+me0Zu6LJfkyoCObhCec1MJ
+        upS0hF1mLrnlVJjGduV1BTBldoFn1DAN1HIlLQ/x0jiN4zQZxtP0KJ5ce5zKvgKzTFDThLGqilBd
+        gTZKOknpgkr+3UeiYqPnEizauorapXfuyvAFZc0s8P1OZ5XmkvGKClovgspydge2UoKzZdAioKko
+        vBgzb2NiR62Iho9m/larujqfXdTZe1gapy+hOte84PJUWr1shlbRWvJvNfDc9weTySFATvsjGNJ+
+        kgDt0wSm/XE6HsXxOJ4ylnhHVzKmf1A6h0XFtR/AZozjMMbD6xaNI7TVQ87mVBY75h2Ac1VCzjV2
+        qLBChzpwqoPcHd86cTur9Sp486vTzydnFx9OB6/Pz5rT5/cgu+vi9ULhDMwchGgyZFweZNTM2/iM
+        SiU5eza+aRpeL1VJudiCw4KWlYABU6U31zyXdZkh2GEm0/EkjuPDuLVtPEPx+9HShOURit2hfYZr
+        D26v8BKBvod8S1eCC6Jmt4XbBx/MHTri/E74hP3G5i+Z68mVc+wtPSaPPdYJIanp5ew4NOdE19/K
+        +bZ3O0HZ6loyajulGIxI/bFGCXFRSUktmyMGjaC1cr3KWohVj+wkhEsw/g6N9pPCDkiHGC6fEsMO
+        h+fIIUn+U3I4mqYJHaZb5JBNJ8M/JYck/UVyaIH7yMG2R7ifINaQZ0jishPq94lif569ZLFx+TXC
+        GHcIo9v7btIY/1XS6LLEOv8/Ygo/SjCGFhB+JOyycmcRPVAtuSycRzie6BOWh5t4xo0JluDqjCcX
+        70gAkGaI5IEaIpUlBqTtkZnSGDMn2EWFG51xwe3S24uaaiotfjgH5MRg8Rid+KHqF4a4wPdN4B5J
+        B+lwHPkR5C4tbnjsppBTS/0PUuN2GxxcYY3LanWzetK8u6L5Rl5vvXP6+YuFiK2go8F0MIpWPwAA
+        AP//AwCxULk/nAkAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:12 GMT
+      Keep-Alive:
+      - timeout=30, max=96
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
@@ -2329,7 +2899,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -2337,20 +2907,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:12 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=EkX0tWxu19du3hU9%2bdcEvZM6HOsn7XqIdLB51n8f8RR36BiuAapx8T81wW8u4Ys%2fvxMQepeYE3fC6T%2fvryZD6ab8h5Vak84b4Blq%2bk07DtA%2fPbee%2fCEB0Kv21RydAvTZ9I1N%2f7LrNRBQkQoI5bKdcghXf1rlgwqJWV9mVzY9M175YQnX%2bH3dsAk6eCyI5PJ2;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=NAOCIN9mXeCVcDyiR9E%2fInYnKC9YXfX%2fd7KZcBMPFmntBjZoUVyeC65B4glsma50%2bkpL0vJU7ZVEtNK27QbnswQgRP9sGfjRfhXD%2bv0Spv%2bp6RR%2bBOWNWr9vBeHXaWQ7BI%2fKckVhoR42Fx9l9uBbR5LiIteLZakDQrMdFZLKm%2fFOkxH9ExBtR9xZZq0zMDfj;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -2372,7 +2942,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=EkX0tWxu19du3hU9%2bdcEvZM6HOsn7XqIdLB51n8f8RR36BiuAapx8T81wW8u4Ys%2fvxMQepeYE3fC6T%2fvryZD6ab8h5Vak84b4Blq%2bk07DtA%2fPbee%2fCEB0Kv21RydAvTZ9I1N%2f7LrNRBQkQoI5bKdcghXf1rlgwqJWV9mVzY9M175YQnX%2bH3dsAk6eCyI5PJ2
+      - ipa_session=MagBearerToken=NAOCIN9mXeCVcDyiR9E%2fInYnKC9YXfX%2fd7KZcBMPFmntBjZoUVyeC65B4glsma50%2bkpL0vJU7ZVEtNK27QbnswQgRP9sGfjRfhXD%2bv0Spv%2bp6RR%2bBOWNWr9vBeHXaWQ7BI%2fKckVhoR42Fx9l9uBbR5LiIteLZakDQrMdFZLKm%2fFOkxH9ExBtR9xZZq0zMDfj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2399,7 +2969,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -2427,7 +2997,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=EkX0tWxu19du3hU9%2bdcEvZM6HOsn7XqIdLB51n8f8RR36BiuAapx8T81wW8u4Ys%2fvxMQepeYE3fC6T%2fvryZD6ab8h5Vak84b4Blq%2bk07DtA%2fPbee%2fCEB0Kv21RydAvTZ9I1N%2f7LrNRBQkQoI5bKdcghXf1rlgwqJWV9mVzY9M175YQnX%2bH3dsAk6eCyI5PJ2
+      - ipa_session=MagBearerToken=NAOCIN9mXeCVcDyiR9E%2fInYnKC9YXfX%2fd7KZcBMPFmntBjZoUVyeC65B4glsma50%2bkpL0vJU7ZVEtNK27QbnswQgRP9sGfjRfhXD%2bv0Spv%2bp6RR%2bBOWNWr9vBeHXaWQ7BI%2fKckVhoR42Fx9l9uBbR5LiIteLZakDQrMdFZLKm%2fFOkxH9ExBtR9xZZq0zMDfj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2455,7 +3025,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -2483,7 +3053,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=EkX0tWxu19du3hU9%2bdcEvZM6HOsn7XqIdLB51n8f8RR36BiuAapx8T81wW8u4Ys%2fvxMQepeYE3fC6T%2fvryZD6ab8h5Vak84b4Blq%2bk07DtA%2fPbee%2fCEB0Kv21RydAvTZ9I1N%2f7LrNRBQkQoI5bKdcghXf1rlgwqJWV9mVzY9M175YQnX%2bH3dsAk6eCyI5PJ2
+      - ipa_session=MagBearerToken=NAOCIN9mXeCVcDyiR9E%2fInYnKC9YXfX%2fd7KZcBMPFmntBjZoUVyeC65B4glsma50%2bkpL0vJU7ZVEtNK27QbnswQgRP9sGfjRfhXD%2bv0Spv%2bp6RR%2bBOWNWr9vBeHXaWQ7BI%2fKckVhoR42Fx9l9uBbR5LiIteLZakDQrMdFZLKm%2fFOkxH9ExBtR9xZZq0zMDfj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2510,7 +3080,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -2540,7 +3110,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=q5oqgw%2bZv7kd9XtyniTklOo2WAJAPXfr9oJvbJzdoc2r%2bvCxZI0PHAAcJct1xBfAw6BBey6oVUu1QiD3ZkJH72mYtBKeF6H0Zx5%2f0FsmTYP%2bcaJhIEfNJC7pSalILNIL1c%2f%2fzuK2ZxM76CWGTEiF%2bgFTUv21SqL%2fQvz8aMPdgruVfuEsEGXjatL6vqDJovJD
+      - ipa_session=MagBearerToken=W9q%2fcSabjYCu2RsKQQmkTQ%2bBFEQFvlPif2nhhbtyvLb0eI%2fmZiU%2bH%2bteoxhX8443wTi2Ejya6qFMrVNk7zpzubaCvMDUnO4HX8TSevVgEDbJv3cxdTrUVhszTSG2BoOAltx65eV1D0OIfF5JrF11BWgQ%2bCXKOGuI%2f%2fFEjE%2bWlW2T2e0JwUpHaiEcF5QtFJmF
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2567,7 +3137,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -2605,7 +3175,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -2613,20 +3183,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:13 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=l19KCqBAzFm%2bIskZXQg8n5YtauiGJlLgIGhrR46bNoOPdmLaJ%2b%2bJLkLFDf38fU8TUzYxdWppEqSyJUMLD0zXKLGsHSiE0RNN630koQq3kZfYsGJL6KG6yoLQZZDkEktjNgs3uhOddjdsHD%2bzM0DY2Zvsix8ODlpaTDSoWlxVJjXkqjawwO5ReCug48q5f1y3;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=bjrEv1GoPBt%2bKXpFV7yNeWNFMOtbrUNzvnpRX9tyCx2%2fB0zCMdA7Pjqhe1ltZYZbundxeoou5%2fSSX7Y48TEM8BPXfcbeT5PWTgmxxUdwYqoQQFw5Qt%2fGWPI8oyqXYRmZ4XfsOK5RmLFCQvJIJwivxhmTT2hu8n4Jtkw%2bNF5PYk9xsaJkijhF8tmXmGQQbp5z;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -2648,7 +3218,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=l19KCqBAzFm%2bIskZXQg8n5YtauiGJlLgIGhrR46bNoOPdmLaJ%2b%2bJLkLFDf38fU8TUzYxdWppEqSyJUMLD0zXKLGsHSiE0RNN630koQq3kZfYsGJL6KG6yoLQZZDkEktjNgs3uhOddjdsHD%2bzM0DY2Zvsix8ODlpaTDSoWlxVJjXkqjawwO5ReCug48q5f1y3
+      - ipa_session=MagBearerToken=bjrEv1GoPBt%2bKXpFV7yNeWNFMOtbrUNzvnpRX9tyCx2%2fB0zCMdA7Pjqhe1ltZYZbundxeoou5%2fSSX7Y48TEM8BPXfcbeT5PWTgmxxUdwYqoQQFw5Qt%2fGWPI8oyqXYRmZ4XfsOK5RmLFCQvJIJwivxhmTT2hu8n4Jtkw%2bNF5PYk9xsaJkijhF8tmXmGQQbp5z
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2675,7 +3245,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -2704,7 +3274,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=l19KCqBAzFm%2bIskZXQg8n5YtauiGJlLgIGhrR46bNoOPdmLaJ%2b%2bJLkLFDf38fU8TUzYxdWppEqSyJUMLD0zXKLGsHSiE0RNN630koQq3kZfYsGJL6KG6yoLQZZDkEktjNgs3uhOddjdsHD%2bzM0DY2Zvsix8ODlpaTDSoWlxVJjXkqjawwO5ReCug48q5f1y3
+      - ipa_session=MagBearerToken=bjrEv1GoPBt%2bKXpFV7yNeWNFMOtbrUNzvnpRX9tyCx2%2fB0zCMdA7Pjqhe1ltZYZbundxeoou5%2fSSX7Y48TEM8BPXfcbeT5PWTgmxxUdwYqoQQFw5Qt%2fGWPI8oyqXYRmZ4XfsOK5RmLFCQvJIJwivxhmTT2hu8n4Jtkw%2bNF5PYk9xsaJkijhF8tmXmGQQbp5z
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2732,7 +3302,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:13 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -2760,7 +3330,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=l19KCqBAzFm%2bIskZXQg8n5YtauiGJlLgIGhrR46bNoOPdmLaJ%2b%2bJLkLFDf38fU8TUzYxdWppEqSyJUMLD0zXKLGsHSiE0RNN630koQq3kZfYsGJL6KG6yoLQZZDkEktjNgs3uhOddjdsHD%2bzM0DY2Zvsix8ODlpaTDSoWlxVJjXkqjawwO5ReCug48q5f1y3
+      - ipa_session=MagBearerToken=bjrEv1GoPBt%2bKXpFV7yNeWNFMOtbrUNzvnpRX9tyCx2%2fB0zCMdA7Pjqhe1ltZYZbundxeoou5%2fSSX7Y48TEM8BPXfcbeT5PWTgmxxUdwYqoQQFw5Qt%2fGWPI8oyqXYRmZ4XfsOK5RmLFCQvJIJwivxhmTT2hu8n4Jtkw%2bNF5PYk9xsaJkijhF8tmXmGQQbp5z
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2787,7 +3357,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -2838,13 +3408,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=h%2f5GlGDhI8PftUkwxKLRnvLrPpRmARBXlYheaVfORGHRh%2f7RDajQq0LVPtGfE6PmHlO3lvVjKy92JpRGrDyvSPBc%2bYctXLwtS6QP4b2BIUZvQqz0Ll5ZOP9A%2f2UvEzqDk5twmPTIWVUNuZlRgxFJ7OA9xPrzqGU9nrjUmy%2bAlIq%2flryLLyFkcp9njM%2f4tPPb;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=6Q3XPRQcB1T0Y1NJQubwV%2b9AofZbfEHkYQUGkDWKTjlKQu0yjtgsm8pQzemVKefmjijBK55maX%2fOrn2kBHKQLnj4IlafT9HSQ2TpmPKe7R%2fhC3%2bYLZNHWKblYMxmPCAedCk3zDWcKQONNwF4nOM%2bHbWf40eWcwD4atc%2f2bGRgkfJutlZQcm%2fHHmmWRVu3sgz;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -2868,7 +3438,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=h%2f5GlGDhI8PftUkwxKLRnvLrPpRmARBXlYheaVfORGHRh%2f7RDajQq0LVPtGfE6PmHlO3lvVjKy92JpRGrDyvSPBc%2bYctXLwtS6QP4b2BIUZvQqz0Ll5ZOP9A%2f2UvEzqDk5twmPTIWVUNuZlRgxFJ7OA9xPrzqGU9nrjUmy%2bAlIq%2flryLLyFkcp9njM%2f4tPPb
+      - ipa_session=MagBearerToken=6Q3XPRQcB1T0Y1NJQubwV%2b9AofZbfEHkYQUGkDWKTjlKQu0yjtgsm8pQzemVKefmjijBK55maX%2fOrn2kBHKQLnj4IlafT9HSQ2TpmPKe7R%2fhC3%2bYLZNHWKblYMxmPCAedCk3zDWcKQONNwF4nOM%2bHbWf40eWcwD4atc%2f2bGRgkfJutlZQcm%2fHHmmWRVu3sgz
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2895,7 +3465,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -2924,7 +3494,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=h%2f5GlGDhI8PftUkwxKLRnvLrPpRmARBXlYheaVfORGHRh%2f7RDajQq0LVPtGfE6PmHlO3lvVjKy92JpRGrDyvSPBc%2bYctXLwtS6QP4b2BIUZvQqz0Ll5ZOP9A%2f2UvEzqDk5twmPTIWVUNuZlRgxFJ7OA9xPrzqGU9nrjUmy%2bAlIq%2flryLLyFkcp9njM%2f4tPPb
+      - ipa_session=MagBearerToken=6Q3XPRQcB1T0Y1NJQubwV%2b9AofZbfEHkYQUGkDWKTjlKQu0yjtgsm8pQzemVKefmjijBK55maX%2fOrn2kBHKQLnj4IlafT9HSQ2TpmPKe7R%2fhC3%2bYLZNHWKblYMxmPCAedCk3zDWcKQONNwF4nOM%2bHbWf40eWcwD4atc%2f2bGRgkfJutlZQcm%2fHHmmWRVu3sgz
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -2952,7 +3522,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -2980,7 +3550,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=h%2f5GlGDhI8PftUkwxKLRnvLrPpRmARBXlYheaVfORGHRh%2f7RDajQq0LVPtGfE6PmHlO3lvVjKy92JpRGrDyvSPBc%2bYctXLwtS6QP4b2BIUZvQqz0Ll5ZOP9A%2f2UvEzqDk5twmPTIWVUNuZlRgxFJ7OA9xPrzqGU9nrjUmy%2bAlIq%2flryLLyFkcp9njM%2f4tPPb
+      - ipa_session=MagBearerToken=6Q3XPRQcB1T0Y1NJQubwV%2b9AofZbfEHkYQUGkDWKTjlKQu0yjtgsm8pQzemVKefmjijBK55maX%2fOrn2kBHKQLnj4IlafT9HSQ2TpmPKe7R%2fhC3%2bYLZNHWKblYMxmPCAedCk3zDWcKQONNwF4nOM%2bHbWf40eWcwD4atc%2f2bGRgkfJutlZQcm%2fHHmmWRVu3sgz
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -3007,227 +3577,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.example.com/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:14 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=uqeKOAY1xeqRb9zg40e%2bIrQMrLm2g6PfZBg6ZiduMWYZ2vcc8%2bn%2by7gy7ThO7%2fpdybcxDtAYY5onvUJUE0tmJ718AgGAZA4oopdWb5VCejrdk%2fyIyncECxs8X2pNKmJ%2bmtgGA5j0BJpQpD2XGRqs7kFGfHvayKKCadLgC8AxMTHAeGYQ8jXptSCqGXOG%2b6LP;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=uqeKOAY1xeqRb9zg40e%2bIrQMrLm2g6PfZBg6ZiduMWYZ2vcc8%2bn%2by7gy7ThO7%2fpdybcxDtAYY5onvUJUE0tmJ718AgGAZA4oopdWb5VCejrdk%2fyIyncECxs8X2pNKmJ%2bmtgGA5j0BJpQpD2XGRqs7kFGfHvayKKCadLgC8AxMTHAeGYQ8jXptSCqGXOG%2b6LP
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_del", "params": [["testuser2"], {"continue": false, "preserve":
-      false}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '89'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=uqeKOAY1xeqRb9zg40e%2bIrQMrLm2g6PfZBg6ZiduMWYZ2vcc8%2bn%2by7gy7ThO7%2fpdybcxDtAYY5onvUJUE0tmJ718AgGAZA4oopdWb5VCejrdk%2fyIyncECxs8X2pNKmJ%2bmtgGA5j0BJpQpD2XGRqs7kFGfHvayKKCadLgC8AxMTHAeGYQ8jXptSCqGXOG%2b6LP
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroazB2Wul6GKyspzFYy1BrtRgcJ0h2Sgj577OaQHuT9L0k
-        dYZJko/mFbrH8ozOk83l76GfgGnQJ9LORJKYhHhuDnlekgheSBTqTGxrJZkrcnDhYjIhYHkbfROL
-        q8LWiYzIKFVwtfuAkQAhlUdiuKJAqCIIhTiBc8XZ08KpKmuM7ui8i+0NvyRkDJHIFrASSWV2zyJu
-        iJ8E1LgZjCcwL+aLZ00+VVZjZ4vpdJZbixFvNw+yv1Ggiw2SvtdTs3eJ3Or4nTxFsqB/gP39JXtj
-        9FnEXHHmheR9bp291zW7cHI1erVBm7d92/ystrvPTbH+2upyD+nL4qVYmv4fAAD//wMA+NEMTaMB
-        AAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=uqeKOAY1xeqRb9zg40e%2bIrQMrLm2g6PfZBg6ZiduMWYZ2vcc8%2bn%2by7gy7ThO7%2fpdybcxDtAYY5onvUJUE0tmJ718AgGAZA4oopdWb5VCejrdk%2fyIyncECxs8X2pNKmJ%2bmtgGA5j0BJpQpD2XGRqs7kFGfHvayKKCadLgC8AxMTHAeGYQ8jXptSCqGXOG%2b6LP
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.22.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -3280,13 +3630,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
+      - Thu, 13 Feb 2020 08:29:14 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=9NL%2beN%2f9CwDy2rDtQFrqpZhHiJ7w5MbMbq21vSrHrpmWshcIwjeJNTwetAIKiAqmR9gohhOnzYA43OV%2fsz2S1346dE0LDYVrExMLtTd5EJ17oVs%2fKOlYhBBrpHskkeeY82QJJFokmpOVmgR69A3Ti9UNUHsblo7TitcqVbHza9IJTl749XV%2fmNQjY1P%2fDBXp;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=29BIWBvZj10GN0ETu7V%2b9ET4dIdXcIEdf7FVYJVd%2b1bJiAUTwm7fZtw%2bbEdLMg4tM1XQXWFeHBGyv%2bYCJ3RHwTo9ljQCAE7QY%2b9OdCnJNdU8%2f0PyuaSTaGQD7lHYNV0bTHBYVoO3OwaWksByP4gZibjsjaZfyTdq%2bSZysO3GGRVBvmQlucYeb7Wv%2f0kS0drT;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -3308,7 +3658,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9NL%2beN%2f9CwDy2rDtQFrqpZhHiJ7w5MbMbq21vSrHrpmWshcIwjeJNTwetAIKiAqmR9gohhOnzYA43OV%2fsz2S1346dE0LDYVrExMLtTd5EJ17oVs%2fKOlYhBBrpHskkeeY82QJJFokmpOVmgR69A3Ti9UNUHsblo7TitcqVbHza9IJTl749XV%2fmNQjY1P%2fDBXp
+      - ipa_session=MagBearerToken=29BIWBvZj10GN0ETu7V%2b9ET4dIdXcIEdf7FVYJVd%2b1bJiAUTwm7fZtw%2bbEdLMg4tM1XQXWFeHBGyv%2bYCJ3RHwTo9ljQCAE7QY%2b9OdCnJNdU8%2f0PyuaSTaGQD7lHYNV0bTHBYVoO3OwaWksByP4gZibjsjaZfyTdq%2bSZysO3GGRVBvmQlucYeb7Wv%2f0kS0drT
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -3335,7 +3685,227 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["testuser2"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=29BIWBvZj10GN0ETu7V%2b9ET4dIdXcIEdf7FVYJVd%2b1bJiAUTwm7fZtw%2bbEdLMg4tM1XQXWFeHBGyv%2bYCJ3RHwTo9ljQCAE7QY%2b9OdCnJNdU8%2f0PyuaSTaGQD7lHYNV0bTHBYVoO3OwaWksByP4gZibjsjaZfyTdq%2bSZysO3GGRVBvmQlucYeb7Wv%2f0kS0drT
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroazB2Wul6GKyspzFYy1BrtRgcJ0h2Sgj577OaQHuT9L0k
+        dYZJko/mFbrH8ozOk83l76GfgGnQJ9LORJKYhHhuDnlekgheSBTqTGxrJZkrcnDhYjIhYHkbfROL
+        q8LWiYzIKFVwtfuAkQAhlUdiuKJAqCIIhTiBc8XZ08KpKmuM7ui8i+0NvyRkDJHIFrASSWV2zyJu
+        iJ8E1LgZjCcwL+aLZ00+VVZjZ4vpdJZbixFvNw+yv1Ggiw2SvtdTs3eJ3Or4nTxFsqB/gP39JXtj
+        9FnEXHHmheR9bp291zW7cHI1erVBm7d92/ystrvPTbH+2upyD+nL4qVYmv4fAAD//wMA+NEMTaMB
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=29BIWBvZj10GN0ETu7V%2b9ET4dIdXcIEdf7FVYJVd%2b1bJiAUTwm7fZtw%2bbEdLMg4tM1XQXWFeHBGyv%2bYCJ3RHwTo9ljQCAE7QY%2b9OdCnJNdU8%2f0PyuaSTaGQD7lHYNV0bTHBYVoO3OwaWksByP4gZibjsjaZfyTdq%2bSZysO3GGRVBvmQlucYeb7Wv%2f0kS0drT
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=PuJ4h3hDKJohD%2bTgFqOUYs0Sg0c3uD9QZVVwqvJ%2fSHUtwt3XIgiajOHbfaIPi6Ix93ZEKSo%2bBk0VzM6ahxcfVZN0nTfSIWr277P7oJ6g7damWBzEwmxvcjYcBARYZ0zjZZPWQhFTDiixRAEg%2bf6nobKEDijlcr6mWHtHnvmz420cEU4J7tpBfXPia27iR7HS;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=PuJ4h3hDKJohD%2bTgFqOUYs0Sg0c3uD9QZVVwqvJ%2fSHUtwt3XIgiajOHbfaIPi6Ix93ZEKSo%2bBk0VzM6ahxcfVZN0nTfSIWr277P7oJ6g7damWBzEwmxvcjYcBARYZ0zjZZPWQhFTDiixRAEg%2bf6nobKEDijlcr6mWHtHnvmz420cEU4J7tpBfXPia27iR7HS
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:15 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -3364,7 +3934,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9NL%2beN%2f9CwDy2rDtQFrqpZhHiJ7w5MbMbq21vSrHrpmWshcIwjeJNTwetAIKiAqmR9gohhOnzYA43OV%2fsz2S1346dE0LDYVrExMLtTd5EJ17oVs%2fKOlYhBBrpHskkeeY82QJJFokmpOVmgR69A3Ti9UNUHsblo7TitcqVbHza9IJTl749XV%2fmNQjY1P%2fDBXp
+      - ipa_session=MagBearerToken=PuJ4h3hDKJohD%2bTgFqOUYs0Sg0c3uD9QZVVwqvJ%2fSHUtwt3XIgiajOHbfaIPi6Ix93ZEKSo%2bBk0VzM6ahxcfVZN0nTfSIWr277P7oJ6g7damWBzEwmxvcjYcBARYZ0zjZZPWQhFTDiixRAEg%2bf6nobKEDijlcr6mWHtHnvmz420cEU4J7tpBfXPia27iR7HS
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -3392,7 +3962,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
+      - Thu, 13 Feb 2020 08:29:15 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -3420,7 +3990,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9NL%2beN%2f9CwDy2rDtQFrqpZhHiJ7w5MbMbq21vSrHrpmWshcIwjeJNTwetAIKiAqmR9gohhOnzYA43OV%2fsz2S1346dE0LDYVrExMLtTd5EJ17oVs%2fKOlYhBBrpHskkeeY82QJJFokmpOVmgR69A3Ti9UNUHsblo7TitcqVbHza9IJTl749XV%2fmNQjY1P%2fDBXp
+      - ipa_session=MagBearerToken=PuJ4h3hDKJohD%2bTgFqOUYs0Sg0c3uD9QZVVwqvJ%2fSHUtwt3XIgiajOHbfaIPi6Ix93ZEKSo%2bBk0VzM6ahxcfVZN0nTfSIWr277P7oJ6g7damWBzEwmxvcjYcBARYZ0zjZZPWQhFTDiixRAEg%2bf6nobKEDijlcr6mWHtHnvmz420cEU4J7tpBfXPia27iR7HS
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -3447,7 +4017,227 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 22 Jan 2020 10:14:15 GMT
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=NI1SrnLtlceHWPhOWnSxbU%2btyxXLaEoDIVC22MAKqmbgXBaHwkHaGbjC6RuBZCvPHJhHZq7CHYQB6NUC%2fjsRIFB8QC8iOTOhTMkQK%2bqcnecN53O9el3LKBpYAo%2bSGiElvIDdkJL7LHcArQssgve5TbPJsG0uhEd9iOQDjYNmDSw%2f5W6kdX9D6n3OSiUAH%2bk0;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NI1SrnLtlceHWPhOWnSxbU%2btyxXLaEoDIVC22MAKqmbgXBaHwkHaGbjC6RuBZCvPHJhHZq7CHYQB6NUC%2fjsRIFB8QC8iOTOhTMkQK%2bqcnecN53O9el3LKBpYAo%2bSGiElvIDdkJL7LHcArQssgve5TbPJsG0uhEd9iOQDjYNmDSw%2f5W6kdX9D6n3OSiUAH%2bk0
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:16 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["testuser4"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NI1SrnLtlceHWPhOWnSxbU%2btyxXLaEoDIVC22MAKqmbgXBaHwkHaGbjC6RuBZCvPHJhHZq7CHYQB6NUC%2fjsRIFB8QC8iOTOhTMkQK%2bqcnecN53O9el3LKBpYAo%2bSGiElvIDdkJL7LHcArQssgve5TbPJsG0uhEd9iOQDjYNmDSw%2f5W6kdX9D6n3OSiUAH%2bk0
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoI4Ox00rXw2BhPY3BWoZaq8XgOEGyW0rJf5+VBtqbpO8l
+        6WqYJPloXuH6WB7QebK5/N32BZgT+kTamUgSkxBXZpvnDYngkUShq4mXTknmjBxcOJpMCNgMo29i
+        cW2onciIjFIFF+sPGAkQUrMjhjMKhDaCUIgFHFrOnhb2bdNhdDvnXbwM+DEhY4hEtoSFSGqyexbx
+        ifhJQI1PN+MCZuVs/qzJ+9Zq7HQ+mUxzazHicPNN9jcKdLGbpO/11OzdIF90/E6eIlnQP8Dm/pKN
+        MfosYm4580LyPrfO3uuOXdi7Dr3aoM3bvq1+FvX6c1Uuv2pd7iG9Kl/KyvT/AAAA//8DABCklcGj
+        AQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:16 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NI1SrnLtlceHWPhOWnSxbU%2btyxXLaEoDIVC22MAKqmbgXBaHwkHaGbjC6RuBZCvPHJhHZq7CHYQB6NUC%2fjsRIFB8QC8iOTOhTMkQK%2bqcnecN53O9el3LKBpYAo%2bSGiElvIDdkJL7LHcArQssgve5TbPJsG0uhEd9iOQDjYNmDSw%2f5W6kdX9D6n3OSiUAH%2bk0
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 13 Feb 2020 08:29:16 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/securitas/tests/unit/controller/test_group.py
+++ b/securitas/tests/unit/controller/test_group.py
@@ -37,6 +37,10 @@ def test_group(client, dummy_user_as_group_manager, make_user):
         make_user(username)
     ipa_admin.group_add_member("dummy-group", users=test_users)
 
+    # Add another user, but only as a membermanager
+    make_user("testuser4")
+    ipa_admin.group_add_member_manager("dummy-group", users=["testuser4"])
+
     result = client.get('/group/dummy-group/')
     assert result.status_code == 200
     page = BeautifulSoup(result.data, 'html.parser')
@@ -47,9 +51,11 @@ def test_group(client, dummy_user_as_group_manager, make_user):
     assert title.find_next_sibling("div").get_text(strip=True) == "A dummy group"
     # Check the sponsors list
     sponsors = page.select("div[data-section='sponsors'] .row > div")
-    assert len(sponsors) == 1, str(sponsors)
+    assert len(sponsors) == 2, str(sponsors)
     assert sponsors[0].find("a")["href"] == "/user/dummy/"
     assert sponsors[0].find("a").get_text(strip=True) == "dummy"
+    assert sponsors[1].find("a")["href"] == "/user/testuser4/"
+    assert sponsors[1].find("a").get_text(strip=True) == "testuser4"
     # Check the members list
     members = page.select("div[data-section='members'] ul li")
     assert len(members) == len(test_users) + 1

--- a/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch.yaml
+++ b/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch.yaml
@@ -1,0 +1,1171 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=tKHveElUJqPYo4g6yxbByq113EI9TqQtVTPjNkSwZ8JTCc0eQts4s%2ft%2fbg1B3GOBWKZ8CGXyYig4rBB%2blLoGwYOXd1yod5ojYcKum4knhDQY3CRSQw3wnLZTsQWYPc%2bgRxlMj5sbRquk8de5zpx7pDAWbNZLAhqWn9EWzgHKrm%2bqq9wBvksTgSTLSysa5bct;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tKHveElUJqPYo4g6yxbByq113EI9TqQtVTPjNkSwZ8JTCc0eQts4s%2ft%2fbg1B3GOBWKZ8CGXyYig4rBB%2blLoGwYOXd1yod5ojYcKum4knhDQY3CRSQw3wnLZTsQWYPc%2bgRxlMj5sbRquk8de5zpx7pDAWbNZLAhqWn9EWzgHKrm%2bqq9wBvksTgSTLSysa5bct
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-02-14T01:50:05Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tKHveElUJqPYo4g6yxbByq113EI9TqQtVTPjNkSwZ8JTCc0eQts4s%2ft%2fbg1B3GOBWKZ8CGXyYig4rBB%2blLoGwYOXd1yod5ojYcKum4knhDQY3CRSQw3wnLZTsQWYPc%2bgRxlMj5sbRquk8de5zpx7pDAWbNZLAhqWn9EWzgHKrm%2bqq9wBvksTgSTLSysa5bct
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU227aQBD9FcsvfeFiO5BLpUilKYmqhoSqTVqljdB4d4At6113L4CL+Pfurg0k
+        Uto8MZ7LmZkzZ9nECrXlJn4bbZ6aRLifH/EHWxRVdKdRxY+tKKZMlxwqAQW+FGaCGQZc17G74Jsh
+        kfqlZJn/QmIIB12HjSxj5y5RaSm8JdUMBPsDhkkB/OBnAo2LPXdYD+vLpWZrIERaYfz3QuWlYoKw
+        EjjYdeMyjCzQlJIzUjVel1BP1HxoPd9hTkHvTBf4oudXStrydjq2+SestPcXWN4qNmNiKIyqajJK
+        sIL9tsho2K+fQZ7S/nG7h4S00xShfXYCtN3P+r0k6Z0iZnko9CO79iupKK5LpgIBASJLsiTJ0l6S
+        9l3Fwy7bUWjKFSVzEDP8XyKujQIKBnzSJp5MctB43JtM3Hc8GFyPusN7JMXZkl6czR+u0jJfvL/8
+        Nry8uRuuL68XN+Ovnwfn8faxXrgAATOkGDb2XYk4p/7GLWfMPEXaW80xdIuSc1xDUXL0JpFFrQ+2
+        RPFcUME/lwVSptxBZAPf9a4u3We4hQgIKRgBvgcI4XfD74PR+HrYubgdhVRd87fXHpfuVHqOnNfI
+        ORNdx8U8BC2jwha5Sw1nS08cl8nxaYgVwPiTPs0+ncMy/y51KiIKwzENK164U39/p71iX1nLNtI6
+        cFK6J4xqid4/dS8RPZOgJztBObdRduddYGUgP/gK9LPL6SRcL0B7FTtEXT9/T6PverhzCL5y5q0r
+        XQK3fpVm1tBMa6cfXWvRVGUIr0AJJmY+oVk+vncdHGkjpnUTaUqDascfoyYhqqmPVqAjIU2knTJb
+        0VQqh0kjN0jpyM8ZZ6YK8ZkFBcIg0k400NoWDj0K7Kk3OvLAyxq4FWWd7KjvOxNJfdv0KElST0j9
+        ljZxXTZpCvxgdck2PBaHXUBQcTygFGnkWYt+1lz8jANBqJT0shGWc//vQQ/2Xg4eAKib85kSPLuH
+        vr3OaacXb/8CAAD//wMAZ8o3RNgFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tKHveElUJqPYo4g6yxbByq113EI9TqQtVTPjNkSwZ8JTCc0eQts4s%2ft%2fbg1B3GOBWKZ8CGXyYig4rBB%2blLoGwYOXd1yod5ojYcKum4knhDQY3CRSQw3wnLZTsQWYPc%2bgRxlMj5sbRquk8de5zpx7pDAWbNZLAhqWn9EWzgHKrm%2bqq9wBvksTgSTLSysa5bct
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=A8pXYvN4b010ArFhG0JFXTLBH9t4ZnxWNsyxip0yaz4EBYkjOTVMWHT9M3%2fQ%2bN4jnljD1XHeLJRSHK4Z4fnuotOlNr4PSENWVzFx3KazE6khSqU2ZhxSOWUUoFsY47cMhnyTSSas5jhp2VZ4iYQdnShQZZLrPKBeh8gHcr7AxKf4W5QbU0Gg4ChhqJ6%2fuDk4;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=OlogBLtC21PvCTi0KfFGBeix958bjOAIkPGRkXmq4yhvJhJ94IpksQXmaMc%2bAZumchE6bFs3EntNNd2SC%2bjKV2ou5esnKJHAiobJeQn8E0haCWTV%2fAR1R1ZxA9s9MKKHfcuQjQdiXHEeQ6e9IAk7D7j6DtgvGFhwensbWQ2UZvWXsVZhg16CSQGrWxRUZxYN;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OlogBLtC21PvCTi0KfFGBeix958bjOAIkPGRkXmq4yhvJhJ94IpksQXmaMc%2bAZumchE6bFs3EntNNd2SC%2bjKV2ou5esnKJHAiobJeQn8E0haCWTV%2fAR1R1ZxA9s9MKKHfcuQjQdiXHEeQ6e9IAk7D7j6DtgvGFhwensbWQ2UZvWXsVZhg16CSQGrWxRUZxYN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_add", "params": [["dummy-group"], {"all": true, "description":
+      "A dummy group", "nonposix": false, "external": false, "no_members": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '158'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OlogBLtC21PvCTi0KfFGBeix958bjOAIkPGRkXmq4yhvJhJ94IpksQXmaMc%2bAZumchE6bFs3EntNNd2SC%2bjKV2ou5esnKJHAiobJeQn8E0haCWTV%2fAR1R1ZxA9s9MKKHfcuQjQdiXHEeQ6e9IAk7D7j6DtgvGFhwensbWQ2UZvWXsVZhg16CSQGrWxRUZxYN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xSTWvjMBD9K0KXvdjGdpxsulDYUHpY2LA9lYVtKYo0MSq25NVIaUPIf69GMsS3
+        +XrvjZ7mwh1gGDz/wS7L0B7eQXo5CMSY/+PeTrxgvHc2TPZoxAhIuQH0oFKVUj2JgOCWeSaiZLKo
+        P3PrdZ41+n8ArZLCetV17eYIZQdSlk0Dotxu1LZct+uurrstQHtIQAUonZ68tiYBd0yFcTyzG7XM
+        jVQub+VeKxPGA7is13xv67re3GVSgkTg/QJUxDQFSJGQ0gbjsVDyHj7FOA1AobQjv0aCkxgCEMdS
+        NdajUSh6SC5euD9PaehDOKNNnyyMXlLpGRzGJ+014tyZodTcPf1i8wDLb2AfApmxniEYX7CjdZFT
+        sbjOJLw+6EH7c+r3QThhPICq2A4xjJE9gtwJ3DdkRHzKxAVrq3a1JmVpFck2q7puyBzhRbqKDHub
+        AbRYhlyv5GHkHoU7p32VApV/hL0sLXnhyS1wztI3mDAMdAvqFk9OGxmPYyAeoeK6Px//7vZPvx+r
+        hz972m4h31XbquPXLwAAAP//AwCAgqcxxgIAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OlogBLtC21PvCTi0KfFGBeix958bjOAIkPGRkXmq4yhvJhJ94IpksQXmaMc%2bAZumchE6bFs3EntNNd2SC%2bjKV2ou5esnKJHAiobJeQn8E0haCWTV%2fAR1R1ZxA9s9MKKHfcuQjQdiXHEeQ6e9IAk7D7j6DtgvGFhwensbWQ2UZvWXsVZhg16CSQGrWxRUZxYN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A8pXYvN4b010ArFhG0JFXTLBH9t4ZnxWNsyxip0yaz4EBYkjOTVMWHT9M3%2fQ%2bN4jnljD1XHeLJRSHK4Z4fnuotOlNr4PSENWVzFx3KazE6khSqU2ZhxSOWUUoFsY47cMhnyTSSas5jhp2VZ4iYQdnShQZZLrPKBeh8gHcr7AxKf4W5QbU0Gg4ChhqJ6%2fuDk4
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "user_find", "params": [[],
+      {"uid": "dummy", "all": true}]}, {"method": "group_find", "params": [["dummy-group"],
+      {}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '168'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A8pXYvN4b010ArFhG0JFXTLBH9t4ZnxWNsyxip0yaz4EBYkjOTVMWHT9M3%2fQ%2bN4jnljD1XHeLJRSHK4Z4fnuotOlNr4PSENWVzFx3KazE6khSqU2ZhxSOWUUoFsY47cMhnyTSSas5jhp2VZ4iYQdnShQZZLrPKBeh8gHcr7AxKf4W5QbU0Gg4ChhqJ6%2fuDk4
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6xU32/TMBD+V6y88NJ2SdbsB9IkKpgQgmmT0BACTZNjX1OzxA62s7ZM/d+5c9ym
+        hU288JTLfXff3X0++ymx4LraJ6/ZUyJMp8nKRyy6Hf59fxpi0Baavsm7rmnW7NaBTe4wXCrX1nyt
+        eQPPwUorr3jteuw2+CoQxj0XPOdOWOBeGe1V5MvTPE3zbJpmRZoW30KcKX+A8KLmrqfxpk3Q3YJ1
+        RpNlbMW1+hWYeD34lQaP2KGjo/KUbpxacdFrgf8Ptmyt0kK1vObdKrq8Eg/gW1MrsY5eDOg7ij/O
+        LbacONHWROCzW7y3pmuv5zdd+RHWjvwNtNdWVUpfam/XvWgt77T62YGSYb4i52Umi5PxFIQYZxnw
+        8fkpl+MiL6ZpOj0DyMuQSC1j+aWxElatskGAQcbiUEaMRgl9u5RiwXX1st4NV3UAJZ3XG1jxpq1h
+        IkwT4C62GdD+hNUj6MOVCP7a4JxuAXVPd1QqfVRytwjgwjQglUUdDeoQcHIdDbRYSHdNiXoGVbJT
+        bDU9OYslX8b2T3LXVT/L5dfZ1c2ny8nb66ttqODaaCX+Gep6ZXfbq11cntqIB4TmuPZAe4WXCOwj
+        yD1fA9Sqmd9XtA+Bhw4d41x/q4ib5r0ItUdCXwSQjFjFjaS4iEdBJp3GhnK3lzlD29tOC+4Pajtk
+        5EHhJGPEyhruxQJjEARrDUmou7rejNjhCyAB76dqd0s1Y6E71g8RautBsPHgfv5wzvdGxbn2kmjM
+        YPz/gQPtixOHbQfneAXxBfTrlpYgWXKrla4oI+5F8gUPBKW4Us5FJKYSOLv5wGIA62dnS+6YNp45
+        0H7E5sYip2Q4Rov3tFS18uuAVx23XHsAOWEzh90jOwsrZF85RsSPPfGI5ZP8uEiCBpLKZsdpSjJI
+        7nl42fu0+5hAjfUpm83d5o/h6eGRg727MZT09w3AiD3S6eRsMk02vwEAAP//AwDwlEqGVQYAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=3nGiTDqSDOF1Ig2mMibb68Eu2h9H5rpk6ZGxT879%2ftUpHeIe8xC0JbHbrz2XpQUQaHFZrb%2bMaU1yMbAmXbv0lAuzh10W5pSD6DzNT0RuZRgbaJAdoqfnZuaKQ7moGAXEwWyvWS8LgnfC%2f7KjOuBrCb2ea8DmV7G6WCQ2vl4dgRoYBrln%2fpIr%2fY1VYJWjmWX9;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=3nGiTDqSDOF1Ig2mMibb68Eu2h9H5rpk6ZGxT879%2ftUpHeIe8xC0JbHbrz2XpQUQaHFZrb%2bMaU1yMbAmXbv0lAuzh10W5pSD6DzNT0RuZRgbaJAdoqfnZuaKQ7moGAXEwWyvWS8LgnfC%2f7KjOuBrCb2ea8DmV7G6WCQ2vl4dgRoYBrln%2fpIr%2fY1VYJWjmWX9
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_del", "params": [["dummy-group"], {"continue": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=3nGiTDqSDOF1Ig2mMibb68Eu2h9H5rpk6ZGxT879%2ftUpHeIe8xC0JbHbrz2XpQUQaHFZrb%2bMaU1yMbAmXbv0lAuzh10W5pSD6DzNT0RuZRgbaJAdoqfnZuaKQ7moGAXEwWyvWS8LgnfC%2f7KjOuBrCb2ea8DmV7G6WCQ2vl4dgRoYBrln%2fpIr%2fY1VYJWjmWX9
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXbrQ12DstND1MFhZT2OwlqHWajD4EWS7JZT891lpYL1J+h76
+        pKtiitkm9QLX+/KExpIu5c++n4A6o80kndLZue6x4ZBbtS+IoxixoSjgVaWuFZq6IHvjG1UIHt0w
+        +iKOJviNiXFERqmA9fYdRgL47A7EcMEIPiSI5NMEToGLp4ZjcC0mczDWpG7Am4yMPhHpCuoYsyvu
+        RcRn4ocIYny+GU9gXs0XT7L5GLSsnS2m01lpNSYcrr7JfkeBBLtJ+l5OLd4OuZPxG1lKpGH4A+zu
+        v7JTSj5GzIEL1WdrS2v0f92y8UfTohUn1CXw6/q73mw/1tXqcyP57gIsq+dqqfo/AAAA//8DAB91
+        s4CoAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=3nGiTDqSDOF1Ig2mMibb68Eu2h9H5rpk6ZGxT879%2ftUpHeIe8xC0JbHbrz2XpQUQaHFZrb%2bMaU1yMbAmXbv0lAuzh10W5pSD6DzNT0RuZRgbaJAdoqfnZuaKQ7moGAXEwWyvWS8LgnfC%2f7KjOuBrCb2ea8DmV7G6WCQ2vl4dgRoYBrln%2fpIr%2fY1VYJWjmWX9
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A8pXYvN4b010ArFhG0JFXTLBH9t4ZnxWNsyxip0yaz4EBYkjOTVMWHT9M3%2fQ%2bN4jnljD1XHeLJRSHK4Z4fnuotOlNr4PSENWVzFx3KazE6khSqU2ZhxSOWUUoFsY47cMhnyTSSas5jhp2VZ4iYQdnShQZZLrPKBeh8gHcr7AxKf4W5QbU0Gg4ChhqJ6%2fuDk4
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
+        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
+        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
+        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
+        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=eLGVji7Yte75LncF%2fjzWccsvXJ1jSSCchA0nIj8il%2fVaNn64BpdB6Z9GWGP5CV3qKcF3NYDdofHxFd%2fdmo%2feNO%2fgZ5%2bWdhcaDbxd3OrX2HQbmQKxUUP4Orf48NxdG46T5ktyBxJjlBpVT8oflpaxM5gzcm6AbBXqRCorkDmXOmJCwnZ0ve7mcQUlkreuMADE;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=eLGVji7Yte75LncF%2fjzWccsvXJ1jSSCchA0nIj8il%2fVaNn64BpdB6Z9GWGP5CV3qKcF3NYDdofHxFd%2fdmo%2feNO%2fgZ5%2bWdhcaDbxd3OrX2HQbmQKxUUP4Orf48NxdG46T5ktyBxJjlBpVT8oflpaxM5gzcm6AbBXqRCorkDmXOmJCwnZ0ve7mcQUlkreuMADE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=eLGVji7Yte75LncF%2fjzWccsvXJ1jSSCchA0nIj8il%2fVaNn64BpdB6Z9GWGP5CV3qKcF3NYDdofHxFd%2fdmo%2feNO%2fgZ5%2bWdhcaDbxd3OrX2HQbmQKxUUP4Orf48NxdG46T5ktyBxJjlBpVT8oflpaxM5gzcm6AbBXqRCorkDmXOmJCwnZ0ve7mcQUlkreuMADE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
+        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
+        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
+        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
+        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=eLGVji7Yte75LncF%2fjzWccsvXJ1jSSCchA0nIj8il%2fVaNn64BpdB6Z9GWGP5CV3qKcF3NYDdofHxFd%2fdmo%2feNO%2fgZ5%2bWdhcaDbxd3OrX2HQbmQKxUUP4Orf48NxdG46T5ktyBxJjlBpVT8oflpaxM5gzcm6AbBXqRCorkDmXOmJCwnZ0ve7mcQUlkreuMADE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_unknown_method.yaml
+++ b/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_unknown_method.yaml
@@ -1,0 +1,722 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=t5hdLNpdFrm2rAnCF2aQiQeabEj6SCLTTbqOeuOZeGrqkR40dN2T5V1jHXyPGmFfrSfJaSZgkwuam%2fC2w4imQwghKhVjgN9DTOvSdPNzX3vXt9Rd%2fmfRHFr3j%2f2aYV3aONGF7MdzkNrfS1GS0Qep3E9rd%2bt2pg%2fy6EneY8tMo8VWwK2vxzUKEuALhfnElvDM;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=t5hdLNpdFrm2rAnCF2aQiQeabEj6SCLTTbqOeuOZeGrqkR40dN2T5V1jHXyPGmFfrSfJaSZgkwuam%2fC2w4imQwghKhVjgN9DTOvSdPNzX3vXt9Rd%2fmfRHFr3j%2f2aYV3aONGF7MdzkNrfS1GS0Qep3E9rd%2bt2pg%2fy6EneY8tMo8VWwK2vxzUKEuALhfnElvDM
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-02-14T01:50:07Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=t5hdLNpdFrm2rAnCF2aQiQeabEj6SCLTTbqOeuOZeGrqkR40dN2T5V1jHXyPGmFfrSfJaSZgkwuam%2fC2w4imQwghKhVjgN9DTOvSdPNzX3vXt9Rd%2fmfRHFr3j%2f2aYV3aONGF7MdzkNrfS1GS0Qep3E9rd%2bt2pg%2fy6EneY8tMo8VWwK2vxzUKEuALhfnElvDM
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUW2/TMBT+K1FeeOkl6VK6IU2ijG5C7FIEG2hsqhz7NDV1bONL21D1v2M7SbtJ
+        gz315Dv373zuNlagLTPxu2j71MTc/fyMP9qyrKJbDSp+7EQxoVoyVHFUwktuyqmhiOnadxuwArDQ
+        LwWL/BdggxnStdsIGTtYgtKCe0uoAnH6BxkqOGIHnHIwzvccsL6sTxeabhDGwnLjv5cql4pyTCVi
+        yG4ayFC8BCMFo7hqUBdQT9R8aL1oa86Rbk3n+KoXF0pYeTOf2vwzVNrjJcgbRQvKJ9yoqiZDIsvp
+        bwuUhP2G2XCUZ9lxNwOMu2kKqJsnR3l3OBhmSZIdAwzykOhHdu3XQhHYSKoCAaHEIBkkySDNknSY
+        JKP7NtpRaOSa4AXiBfwvEDZGIYIM8kHbeDbLkYa32WzmvuPx+HLan9wBLk9W5OxkcX+Rynz54fz7
+        5Pz6drI5v1xeT799GZ/Gu8d64RJxVACBsLHvivkp8TfuOKPwFGlvNcfQHYJPYYNKycCbWJRhLEcu
+        VhB2NLT89/hMOHb1AhgLIf2c8r4bfxGclhJuy9zdKDCdjlx+MkpqAf7Hp2te95q0za3CGvtjtPrZ
+        yz64309+jK+ml5Pe2c1VG4oRF5ziV0MLugL+/BUFfCFKIFQ5FYqG076H+od5SkTZk8INob2WTeme
+        MKgV+DXm7iWCL4r0rBWUg42yLbqEyqD8gJXgeRLzWbheaONV7Crq+vl7ujxJhzsH5ytn3rnUFWLW
+        b9tQG5pp7fSjay2aSgb3GilOeeEDGn7iO9fBqeOKat14mtSg2umnqAmI6jNHa6QjLkyknTI70Vwo
+        V5NEbhDpVJZTRk0V/IVFCnEDQHrRWGtbuupRYE+90ZEvvKoLd6JBb3A09J2xIL5tepQkqSekfkvb
+        uE6bNQl+sDplFx6Lq12icNB4TAiQyLMWPdRcPMSBIFBKeIlyy5j/9yAHey9AXwARN+czQXl2D32z
+        3nEvi3d/AQAA//8DAPY6AWvYBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=t5hdLNpdFrm2rAnCF2aQiQeabEj6SCLTTbqOeuOZeGrqkR40dN2T5V1jHXyPGmFfrSfJaSZgkwuam%2fC2w4imQwghKhVjgN9DTOvSdPNzX3vXt9Rd%2fmfRHFr3j%2f2aYV3aONGF7MdzkNrfS1GS0Qep3E9rd%2bt2pg%2fy6EneY8tMo8VWwK2vxzUKEuALhfnElvDM
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=B5UnZWMhvxPC8f7ioK3UG4z4VwxytlCIXJ36EiSLufEWgzHi1U5EsR6S2FP%2f0wlnv8thnz4%2b8Uo4fFi1eIMgXh0w4ELtd5Q%2b%2foNknx2IafGHpxoW5BlVrYZiV%2bP8lwLt0N9wHXoJj1TBOavd%2btVg7jPvYk8%2fu%2fEkBS5YOVrzKTW5mauq6z6JDh9vQ5OlG5yx;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=B5UnZWMhvxPC8f7ioK3UG4z4VwxytlCIXJ36EiSLufEWgzHi1U5EsR6S2FP%2f0wlnv8thnz4%2b8Uo4fFi1eIMgXh0w4ELtd5Q%2b%2foNknx2IafGHpxoW5BlVrYZiV%2bP8lwLt0N9wHXoJj1TBOavd%2btVg7jPvYk8%2fu%2fEkBS5YOVrzKTW5mauq6z6JDh9vQ5OlG5yx
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "user_findy", "params": [[],
+      {}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=B5UnZWMhvxPC8f7ioK3UG4z4VwxytlCIXJ36EiSLufEWgzHi1U5EsR6S2FP%2f0wlnv8thnz4%2b8Uo4fFi1eIMgXh0w4ELtd5Q%2b%2foNknx2IafGHpxoW5BlVrYZiV%2bP8lwLt0N9wHXoJj1TBOavd%2btVg7jPvYk8%2fu%2fEkBS5YOVrzKTW5mauq6z6JDh9vQ5OlG5yx
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWsCMRCG/8qQixdZ/IS2p4p4ECr1VAqlSNxECW4my0zissj+9ya7UXubj/d5
+        5+MmSHOovHiDmyhdwBRNx5DLHLOfm9BEjmIoAl7QNQils1aiglFgTYeTQdWORKR64aF0Skf162T5
+        KKG0qSTWA7jpDR/dS9PPv4uepqLrfqPKamZ51nkb39a9rJGEBs/J5k5+aWLjcGeYcyejqbnabyEL
+        AIM9aoJGMqDzwBr9GE6OoqdK19XSm6OpjG/7/jlIkui1VgWsmION7hGiq6YRQzK+DsZjmBWz+TJN
+        zl+YzieT9FAlveyvHLBDBtJiAxJP7e4fiVUMVRVTo55xTQZLU8sqQSpY275vvle7/cemWH/u0sx/
+        povipViI7g8AAP//AwBdsZj34QEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=B5UnZWMhvxPC8f7ioK3UG4z4VwxytlCIXJ36EiSLufEWgzHi1U5EsR6S2FP%2f0wlnv8thnz4%2b8Uo4fFi1eIMgXh0w4ELtd5Q%2b%2foNknx2IafGHpxoW5BlVrYZiV%2bP8lwLt0N9wHXoJj1TBOavd%2btVg7jPvYk8%2fu%2fEkBS5YOVrzKTW5mauq6z6JDh9vQ5OlG5yx
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
+        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
+        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
+        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
+        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:08 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:09 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=ZR9cB2Xo0RGh5A6M9Ek5PPilKi9lDFyEQJAAk%2bIM0iubgyGwNYcboEbBfe%2b8SN4Cw68P%2fYLf%2ftRAwd1PcoBM63fvqzWsO3ilReHX%2bvRnJ%2flc21n1aS5Dj9qHlCHEVTPN4doyNq2t2rgZ70jLX0H4dE74XrpvD8JpPJwc8e5%2bYNhGajDIaupKn0ZF%2b0DlnYIS;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ZR9cB2Xo0RGh5A6M9Ek5PPilKi9lDFyEQJAAk%2bIM0iubgyGwNYcboEbBfe%2b8SN4Cw68P%2fYLf%2ftRAwd1PcoBM63fvqzWsO3ilReHX%2bvRnJ%2flc21n1aS5Dj9qHlCHEVTPN4doyNq2t2rgZ70jLX0H4dE74XrpvD8JpPJwc8e5%2bYNhGajDIaupKn0ZF%2b0DlnYIS
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:09 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ZR9cB2Xo0RGh5A6M9Ek5PPilKi9lDFyEQJAAk%2bIM0iubgyGwNYcboEbBfe%2b8SN4Cw68P%2fYLf%2ftRAwd1PcoBM63fvqzWsO3ilReHX%2bvRnJ%2flc21n1aS5Dj9qHlCHEVTPN4doyNq2t2rgZ70jLX0H4dE74XrpvD8JpPJwc8e5%2bYNhGajDIaupKn0ZF%2b0DlnYIS
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
+        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
+        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
+        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
+        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:09 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ZR9cB2Xo0RGh5A6M9Ek5PPilKi9lDFyEQJAAk%2bIM0iubgyGwNYcboEbBfe%2b8SN4Cw68P%2fYLf%2ftRAwd1PcoBM63fvqzWsO3ilReHX%2bvRnJ%2flc21n1aS5Dj9qHlCHEVTPN4doyNq2t2rgZ70jLX0H4dE74XrpvD8JpPJwc8e5%2bYNhGajDIaupKn0ZF%2b0DlnYIS
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:09 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_unknown_option.yaml
+++ b/securitas/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_unknown_option.yaml
@@ -1,0 +1,722 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:09 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=GfdOApXeNYg1SvSyWhjzBNvfFavd5RymrJ8fU8JX9JupGSgxQjDZL%2buLEonq7ULasDrzgOk93MfvqOUzqjIA3s5PiRCnZZzEL6hB2qWuMojIjmFhRcIdi25HsP%2frYjpbKL58L%2bryZLkPZ5B7RgW2YIv5KULMoVuqD9kmAB2p%2bnJlcPIdLuU4NESW%2btgu22CT;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=GfdOApXeNYg1SvSyWhjzBNvfFavd5RymrJ8fU8JX9JupGSgxQjDZL%2buLEonq7ULasDrzgOk93MfvqOUzqjIA3s5PiRCnZZzEL6hB2qWuMojIjmFhRcIdi25HsP%2frYjpbKL58L%2bryZLkPZ5B7RgW2YIv5KULMoVuqD9kmAB2p%2bnJlcPIdLuU4NESW%2btgu22CT
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-02-14T01:50:09Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=GfdOApXeNYg1SvSyWhjzBNvfFavd5RymrJ8fU8JX9JupGSgxQjDZL%2buLEonq7ULasDrzgOk93MfvqOUzqjIA3s5PiRCnZZzEL6hB2qWuMojIjmFhRcIdi25HsP%2frYjpbKL58L%2bryZLkPZ5B7RgW2YIv5KULMoVuqD9kmAB2p%2bnJlcPIdLuU4NESW%2btgu22CT
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUWU/bQBD+K5Zf+pLDNg6FSkhNaUBVOdIDWlFQNN6dONvYu+4eSdwo/727aycB
+        icKTZ+eeb77xOpSoTKHDd8H6sUi4/fwKP5qyrIMbhTJ86AQhZaoqoOZQ4nNmxplmUKjGduN1ORKh
+        nnMW2W8kmhSgGrMWVWjVFUoluJOEzIGzv6CZ4FDs9YyjtranCuPSunCh2AoIEYZr957LrJKME1ZB
+        AWbVqjQjc9SVKBipW611aDpqH0rNtjmnoLaiNXxTs3MpTHU9HZvsM9bK6UusriXLGR9xLesGjAoM
+        Z38MMurnGwwOE0wJdFMkpBvHCN0sOsi6g2SQRlF6hJhkPtC1bMsvhaS4qpj0APgUSZREURKnUTyI
+        ouO7rbeFUFdLSmbAc3zJEVdaAgUNzmkdTiYZKDxMJxP7DofDi6/90S2S8nhBT49nd+dxlc0/nP0Y
+        nV3djFZnF/Or8fcvw5Nw89AMXAKHHCn6iV1Vwk+o23HHCrmDSDmpXYbqUHKCKyirAp1IROnbMoxy
+        U2YWXg9S/NZ2Hr2Nd0hsl7fjnC/xfvRzeDm+GPVOry+9awmseGRuC/W2VewKiUSPpGbl/0FSDdA7
+        ktoOCHDBGXm1g5kokTJpGSRaPPpO1ffezSm8MKppWfLYe4H86aV5fSEszdQMi2befsZ43+5x5o2V
+        PWGUC3TJpvYS0TUGarIllFVrabbaOdYasr2uRNedmE789nx6x2KbUTXn79Bxre737I2vrHljQxdQ
+        GDdJO6AvppTlj2q4qOvKm5cgOeO5c2hnD29tBbu3S6ZUa2lDPWvHn4LWIWjADZagAi50oCwzO8FU
+        SJuTBraRyu4/YwXTtbfnBiRwjUh7wVApU9rsgUdPvlGBS7xoEneCpJccDFxlIqgrGx9EUewAaW5p
+        HTZhkzbANdaEbPyx2NwleFKEQ0qRBg614L7B4j70AKGUwhGDm6Jwfw+6l3c34BIAtX0+IZ9Dd183
+        7R310nDzDwAA//8DAKPaYy7YBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=GfdOApXeNYg1SvSyWhjzBNvfFavd5RymrJ8fU8JX9JupGSgxQjDZL%2buLEonq7ULasDrzgOk93MfvqOUzqjIA3s5PiRCnZZzEL6hB2qWuMojIjmFhRcIdi25HsP%2frYjpbKL58L%2bryZLkPZ5B7RgW2YIv5KULMoVuqD9kmAB2p%2bnJlcPIdLuU4NESW%2btgu22CT
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=wjofQpeUuaTZ5TditRhyMFka7bDyQq4qMKikLcW%2bh%2fZ3eQJIjvmjFH%2bImq0p90ZVARqBB35Da1G%2fSeinu4%2fZikMP1J686%2fQlp0lkO49u59A%2b%2f9gRbLdA7v4mDfNbNaldV6OF7sxays2pa%2fwGFNGpI4v3uPqgyq3CFvBF8SsS1zH9HAW2%2fNNZImpEDoug94SI;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wjofQpeUuaTZ5TditRhyMFka7bDyQq4qMKikLcW%2bh%2fZ3eQJIjvmjFH%2bImq0p90ZVARqBB35Da1G%2fSeinu4%2fZikMP1J686%2fQlp0lkO49u59A%2b%2f9gRbLdA7v4mDfNbNaldV6OF7sxays2pa%2fwGFNGpI4v3uPqgyq3CFvBF8SsS1zH9HAW2%2fNNZImpEDoug94SI
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "user_find", "params": [[],
+      {"pants": "pants"}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wjofQpeUuaTZ5TditRhyMFka7bDyQq4qMKikLcW%2bh%2fZ3eQJIjvmjFH%2bImq0p90ZVARqBB35Da1G%2fSeinu4%2fZikMP1J686%2fQlp0lkO49u59A%2b%2f9gRbLdA7v4mDfNbNaldV6OF7sxays2pa%2fwGFNGpI4v3uPqgyq3CFvBF8SsS1zH9HAW2%2fNNZImpEDoug94SI
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2yQy2rDMBBFf2XQJptg8iqErBqCF4WaZtNSKCUolhpErJHQI8YE/3tHtpJm0d28
+        zr0zc2VO+tgEtoErq03EFM2nkMuesq8rk84ZRyFTeOGNEjCx3HHtJxt4xzOaFsHYoAxuwHIkigQG
+        5lAbIQlczmbrew25TjW2M3iRzhNWDvr3gXM7rHObG73u7VT637Xvv2lIS+/5SebVQ2cHkZY7VHhK
+        Kjfdj9G8Ut7nTkZTc7t/gTwAGPVROmi5BzQBvMQwhR/jSFNAbbTlQR1Vo0I39E+RFsYgpShg633U
+        pE6Qo2MnHpJwPnsKi2KxfErO+U9zelT6vuCBDz8YsUMG0mIjQqf2Dw/B2DSUKvEXW6ewVpY3CRJR
+        6+65/NxW+9ey2L1VyfNBdFWsixXrfwEAAP//AwAPlcC5DgIAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wjofQpeUuaTZ5TditRhyMFka7bDyQq4qMKikLcW%2bh%2fZ3eQJIjvmjFH%2bImq0p90ZVARqBB35Da1G%2fSeinu4%2fZikMP1J686%2fQlp0lkO49u59A%2b%2f9gRbLdA7v4mDfNbNaldV6OF7sxays2pa%2fwGFNGpI4v3uPqgyq3CFvBF8SsS1zH9HAW2%2fNNZImpEDoug94SI
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
+        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
+        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
+        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
+        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:10 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=569WNMaQ3FUxZVa8WBKb4xx%2f8fcs47rLmmSrBdlZr7UJjwpgJGDif5mDPETJtGbbWrFJNde4wnUjKV0y65s043BPTOpfzGhB2q%2bJYYr6%2fjea9YgE%2btAGIR83mYe%2bTczc8X7UKYJyyGXyL3KBKIPWzpKDTWb7PGZIRMfofbzkCR7M2ey9a01cDm4cG5KZyi9A;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=569WNMaQ3FUxZVa8WBKb4xx%2f8fcs47rLmmSrBdlZr7UJjwpgJGDif5mDPETJtGbbWrFJNde4wnUjKV0y65s043BPTOpfzGhB2q%2bJYYr6%2fjea9YgE%2btAGIR83mYe%2bTczc8X7UKYJyyGXyL3KBKIPWzpKDTWb7PGZIRMfofbzkCR7M2ey9a01cDm4cG5KZyi9A
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:11 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=569WNMaQ3FUxZVa8WBKb4xx%2f8fcs47rLmmSrBdlZr7UJjwpgJGDif5mDPETJtGbbWrFJNde4wnUjKV0y65s043BPTOpfzGhB2q%2bJYYr6%2fjea9YgE%2btAGIR83mYe%2bTczc8X7UKYJyyGXyL3KBKIPWzpKDTWb7PGZIRMfofbzkCR7M2ey9a01cDm4cG5KZyi9A
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
+        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
+        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
+        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
+        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:11 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=569WNMaQ3FUxZVa8WBKb4xx%2f8fcs47rLmmSrBdlZr7UJjwpgJGDif5mDPETJtGbbWrFJNde4wnUjKV0y65s043BPTOpfzGhB2q%2bJYYr6%2fjea9YgE%2btAGIR83mYe%2bTczc8X7UKYJyyGXyL3KBKIPWzpKDTWb7PGZIRMfofbzkCR7M2ey9a01cDm4cG5KZyi9A
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2020 01:50:11 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1


### PR DESCRIPTION
Previously, if a user was a membermanager (i.e. a sponsor) of
a group, but not a member of the group, they would not show up
in the list of membermanagers (sponsors) on the group listing
page. However, if that user was logged in and looking at the
group page, they still could edit the other members of the group.

This commit corrects the group page to show membermanagers(sponsors)
that happen to not be members of the group.

Related: #108

Signed-off-by: Ryan Lerch <rlerch@redhat.com>