### PR TITLE
remove unecessary import of script

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -59,11 +59,3 @@
     name: securitas
     daemon_reload: yes
     enabled: yes
-
-- name: Copy SAR script
-  copy:
-      src: /vagrant/devel/ansible/roles/dev/files/sar.py
-      dest: /usr/bin/securitas-sar.py
-      remote_src: yes
-      owner: vagrant
-      group: vagrant


### PR DESCRIPTION
I moved this script but forgot to move the task that loads it to the dev environment. Its pointless anyway because we don't need it in the dev env.

Signed-off-by: Stephen Coady <scoady@redhat.com>