### PR TITLE
Use libravatar with the Gravatar-compatible API endpoint

### DIFF
--- a/securitas/utility/__init__.py
+++ b/securitas/utility/__init__.py
@@ -9,7 +9,7 @@ from securitas.security.ipa import maybe_ipa_session
 
 def gravatar(email, size):
     return (
-        "https://www.gravatar.com/avatar/"
+        "https://seccdn.libravatar.org/avatar/"
         + hashlib.md5(email.lower().encode('utf8')).hexdigest()  # nosec
         + "?s="
         + str(size)


### PR DESCRIPTION
The libravatar service provides a FOSS drop-in replacement to
Gravatar, and is already in use by many other Fedora services.
Thus, we should be use it to provide consistency in avatar
representation.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>