### PR TITLE
Make the templates a little nicer

### DIFF
--- a/securitas/controller/user.py
+++ b/securitas/controller/user.py
@@ -6,6 +6,7 @@ from securitas.form.edit_user import EditUserForm
 from securitas.representation.group import Group
 from securitas.representation.user import User
 from securitas.utility import with_ipa, user_or_404
+from securitas.form.password_reset import PasswordResetForm
 
 
 @app.route('/user/<username>/')
@@ -35,6 +36,7 @@ def user_edit(ipa, username):
 
     user = User(user_or_404(ipa, username))
     form = EditUserForm(obj=user)
+    password_reset_form = PasswordResetForm()
 
     if form.validate_on_submit():
         try:
@@ -74,4 +76,6 @@ def user_edit(ipa, username):
             form.gpgkeys.append_entry()
             form.sshpubkeys.append_entry()
 
-    return render_template('user-edit.html', user=user, form=form)
+    return render_template(
+        'user-edit.html', user=user, form=form, password_reset_form=password_reset_form
+    )

--- a/securitas/templates/404.html
+++ b/securitas/templates/404.html
@@ -4,13 +4,10 @@
 
 {% block content %}
   {{ super() }}
-  <div class="container section pt-4">
+  <div class="container section py-4">
     <div class="row">
-      <div class="col s12">
-        <h3 class="header light-red-text text-darken-4 fw300">404</h3>
-        <p>
-          That page wasn't found. You've gone and ruined everything.
-        </p>
+      <div class="col">
+        <div class="alert alert-danger"><b>404</b> That page wasn't found. You've gone and ruined everything.</div>
       </div>
     </div>
   </div>

--- a/securitas/templates/_form_macros.html
+++ b/securitas/templates/_form_macros.html
@@ -4,7 +4,7 @@
     {% set css_class = css_class + ' is-invalid ' %}
   {% endif %}
   {% if kwargs.pop('label', True) %}
-    <label for="{{ field.name }}" class="mb-0 font-weight-bold">{{ field.label }}</label>
+    {{ field.label }}
   {% endif %}
   {{ field(class=css_class, **kwargs) }}
   {% if field.errors %}
@@ -17,7 +17,7 @@
 {% macro with_errors(field) %}
   {% if field.type == 'FieldList' %}
     {% if kwargs.pop('label', True) %}
-      <label for="{{ field.name }}" class="mb-0 font-weight-bold">{{ field.label }}</label>
+      {{ field.label }}
     {% endif %}
     {% for subfield in field %}
       {{ form_field(subfield, label=False, **kwargs) }}

--- a/securitas/templates/_login_form.html
+++ b/securitas/templates/_login_form.html
@@ -1,22 +1,17 @@
 {% import '_form_macros.html' as macros %}
 <form action="{{ url_for('login') }}" method="post" novalidate>
   {{ login_form.csrf_token }}
-  <div class="h4 text-center">
-    Log In
-  </div>
-  <div class="row">
-    <div class="input-field col-12">
-      {{ macros.with_errors(login_form.username, class="validate", placeholder="username", tabindex="1", label=False) }}
+  <div class="card-body">
+    <div class="form-group">
+      {{ macros.with_errors(login_form.username, class="validate", placeholder="Username", tabindex="1", label=False) }}
     </div>
-    <div class="input-field col-12">
-      {{ macros.with_errors(login_form.password, class="validate", placeholder="password", tabindex="2", label=False) }}
-    </div>
-    <div class="col-12 mt-2">
-      {{ macros.non_field_errors(login_form) }}
-      <button class="btn btn-block btn-primary" id="submit" type="submit" tabindex="3">Log In</button>
-    </div>
-    <div class="col-12 mt-2 d-flex justify-content-between">
+    <div class="form-group mb-0">
+      {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
       <small><a href="{{ url_for('forgot_password_ask') }}">Forgot password?</a></small>
     </div>
+  </div>
+  <div class="card-footer d-flex justify-content-between">
+    <div>{{ macros.non_field_errors(login_form) }}</div>
+    <button class="btn btn-primary" id="submit" type="submit" tabindex="3">Log In</button>
   </div>
 </form>

--- a/securitas/templates/_password_reset_form.html
+++ b/securitas/templates/_password_reset_form.html
@@ -1,0 +1,20 @@
+{% import '_form_macros.html' as macros %}
+        {% if current_user %}
+        <form action="{{ url_for('auth_password_reset', username=current_user.username) }}" method="post">
+          <div class="card-body">
+            <h5 id="pageheading" >Change Password</h5>
+        {% else %}
+        <form action="{{ url_for('password_reset', username=username) }}" method="post">
+          <div class="card-body">
+            <h5 id="pageheading">Expired Password Reset for {{username}}</h5>
+        {% endif %}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <div class="form-group">{{ macros.with_errors(password_reset_form.current_password, tabindex="2")}}</div>
+            <div class="form-group">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
+            <div class="form-group">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
+          </div>
+          <div class="card-footer d-flex justify-content-between">
+            <div>{{ macros.non_field_errors(password_reset_form) }}</div>
+            <button class="btn btn-primary" id="submit" type="submit" tabindex="14">Submit</button>
+          </div>
+        </form>

--- a/securitas/templates/_register_form.html
+++ b/securitas/templates/_register_form.html
@@ -1,23 +1,18 @@
 {% import '_form_macros.html' as macros %}
 
-<div class="h4 text-center mb-4">
-    Create New Account
-</div>
 <form action="{{ url_for('register') }}" method="post" novalidate>
   {{ register_form.csrf_token }}
-  <div class="form-row">
-    <div class="form-group col">{{ macros.with_errors(register_form.username, tabindex="4") }}</div>
-    <div class="form-group col">{{ macros.with_errors(register_form.firstname, tabindex="5") }}</div>
-    <div class="form-group col">{{ macros.with_errors(register_form.lastname, tabindex="6") }}</div>
-  </div>
-  <div class="form-row">
-    <div class="form-group col">{{ macros.with_errors(register_form.password, class="validate", tabindex="7") }}</div>
-    <div class="form-group col">{{ macros.with_errors(register_form.password_confirm, class="validate", tabindex="8") }}</div>
-  </div>
-  <div class="form-row">
-    {{ macros.non_field_errors(register_form) }}
-    <div class="form-group col">
-      <button class="btn btn-outline-primary btn-block" id="submit" type="submit" tabindex="9">Submit</button>
+  <div class="card-body">
+    <div class="form-group">{{ macros.with_errors(register_form.username, tabindex="4") }}</div>
+    <div class="form-row">
+      <div class="form-group col">{{ macros.with_errors(register_form.firstname, tabindex="5") }}</div>
+      <div class="form-group col">{{ macros.with_errors(register_form.lastname, tabindex="6") }}</div>
     </div>
+    <div class="form-group">{{ macros.with_errors(register_form.password, class="validate", tabindex="7") }}</div>
+    <div class="form-group mb-0">{{ macros.with_errors(register_form.password_confirm, class="validate", tabindex="8") }}</div>
+  </div>
+  <div class="card-footer d-flex justify-content-between">
+    <div>{{ macros.non_field_errors(register_form) }}</div>
+    <button class="btn btn-primary" id="submit" type="submit" tabindex="9">Submit</button>
   </div>
 </form>

--- a/securitas/templates/forgot-password-ask.html
+++ b/securitas/templates/forgot-password-ask.html
@@ -1,30 +1,28 @@
 {% extends "main.html" %}
-{% block title %}Forgotten Password?{% endblock %}
+{% block title %}Password Recovery{% endblock %}
 
 {% block content %}
   {{ super() }}
 
 {% import '_form_macros.html' as macros %}
 
-  <div class="container">
+  <div class="container py-4">
     <div class="row">
       <div class="col-6 mx-auto">
-        <div class="h4 text-center mb-4" id="pageheading">Did you forget your password?</div>
-
-        <p>Enter your username and an email will be sent to your address with further instructions.</p>
-
-        <form action="{{ url_for('forgot_password_ask') }}" method="post" novalidate>
-          {{ form.csrf_token }}
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.username, autofocus="true")}}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">
-              {{ macros.non_field_errors(form) }}
-              <button class="btn btn-outline-primary btn-block" id="submit" type="submit" tabindex="5">Submit</button>
+        <div class="card">
+          <form action="{{ url_for('forgot_password_ask') }}" method="post" novalidate>
+            {{ form.csrf_token }}
+            <div class="card-body">
+              <h5 id="pageheading">Did you forget your password?</h5>
+              <p>Enter your username and an email will be sent to your address with further instructions.</p>
+              <div class="form-group mb-0">{{ macros.with_errors(form.username, autofocus="true")}}</div>
             </div>
-          </div>
-        </form>
+            <div class="card-footer d-flex justify-content-between">
+              <div>{{ macros.non_field_errors(form) }}</div>
+              <button class="btn btn-primary" id="submit" type="submit" tabindex="5">Submit</button>
+            </div>
+          </form>
+        </div>
       </div>
     </div> <!-- ./row -->
   </div>

--- a/securitas/templates/forgot-password-change.html
+++ b/securitas/templates/forgot-password-change.html
@@ -6,23 +6,20 @@
 
 {% import '_form_macros.html' as macros %}
 
-  <div class="container">
+  <div class="container py-4">
     <div class="row">
       <div class="col-6 mx-auto">
-        <div class="h4 text-center mb-4" id="pageheading">Password Reset for {{username}}</div>
+        <div class="card">
         <form action="{{ url_for('forgot_password_change') }}?token={{ token }}" method="post" novalidate>
           {{ form.csrf_token }}
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.password, tabindex="1")}}</div>
+          <div class="card-body">
+            <h5 id="pageheading">Password Reset for {{username}}</h5>
+            <div class="form-group">{{ macros.with_errors(form.password, tabindex="1")}}</div>
+            <div class="form-group">{{ macros.with_errors(form.password_confirm, tabindex="2")}}</div>
           </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.password_confirm, tabindex="2")}}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">
-              {{ macros.non_field_errors(form) }}
-              <button class="btn btn-outline-primary btn-block" id="submit" type="submit" tabindex="5">Submit</button>
-            </div>
+          <div class="card-footer d-flex justify-content-between">
+            <div>{{ macros.non_field_errors(form) }}</div>
+            <button class="btn btn-outline-primary btn-block" id="submit" type="submit" tabindex="5">Submit</button>
           </div>
         </form>
       </div>

--- a/securitas/templates/group.html
+++ b/securitas/templates/group.html
@@ -2,7 +2,7 @@
 
 {# Here it is relatively safe to assume that 'ipa' exists and is valid. We would not be here otherwise. #}
 
-{% block title %}Group: {{ group.name }}{% endblock %}
+{% block title %}{{ group.name }} Group{% endblock %}
 
 {% block content %}
   {{ super() }}
@@ -36,14 +36,17 @@
     <div class="row">
       <div class="col-12 my-4" data-section="sponsors">
         <h4>Sponsors <span class="badge badge-secondary">{{sponsors|length}}</span></h4>
-        <ul class="list-group">
         {% if sponsors|length == 0 %}
-        <li class="list-group-item text-center bg-light text-muted">
-          <strong>no sponsors</strong>
-        </li>
+        <ul class="list-group">
+          <li class="list-group-item text-center bg-light text-muted">
+            <strong>no sponsors</strong>
+          </li>
+        </ul>
         {% else %}
+        <ul class="list-unstyled row">
           {% for sponsor in sponsors|sort(attribute='username') %}
-            <li class="list-group-item d-flex justify-content-between align-items-center">
+            <li class="col-lg-3 col-md-4 col-sm-6">
+              <div class="card card-body mb-4">
               <div class="media align-items-center">
                 <img src="{{ gravatar(sponsor.mail if sponsor.mail else 'default', 50) }}">
                 <div class="media-body ml-2">
@@ -54,6 +57,7 @@
                     </div>
                     <div>{{ sponsor.name }}</div>
                 </div>
+              </div>
               </div>
             </li>
           {% endfor %}
@@ -80,10 +84,11 @@
         {% else %}
         <form action="{{ url_for('group_remove_member', groupname=group.name) }}" method="post">
           {{ sponsor_form.hidden_tag() }}
-          <ul class="list-group">
+          <ul class="list-unstyled row">
             {% set sponsor_usernames = sponsors|map(attribute='username') %}
             {% for member in members|sort(attribute='username') %}
-              <li class="list-group-item d-flex justify-content-between align-items-center">
+              <li class="col-lg-3 col-md-4 col-sm-6">
+              <div class="card card-body mb-4">
                 <div class="media align-items-center">
                   <img src="{{ gravatar(member.mail if member.mail else 'default', 50) }}">
                   <div class="media-body ml-2">
@@ -101,6 +106,7 @@
                       <i class="fa fa-trash"></i>
                     </button>
                   {% endif %}
+                </div>
                 </div>
               </li>
             {% endfor %}

--- a/securitas/templates/groups.html
+++ b/securitas/templates/groups.html
@@ -6,9 +6,9 @@
 
 {% block content %}
   {{ super() }}
-  <div class="container pt-4">
+  <div class="container py-4">
     <div class="row">
-      <div class="col">
+      <div class="col-md-8 mx-auto">
         <h4>Group List</h4>
 
         <ul class="list-group">

--- a/securitas/templates/index.html
+++ b/securitas/templates/index.html
@@ -1,5 +1,4 @@
 {% extends "main.html" %}
-{% block title %}Self-Service Portal{% endblock %}
 
 {% block content %}
   {{ super() }}
@@ -7,7 +6,7 @@
   <div class="bg-light border-bottom py-5">
     <div class="container section">
       <div class="row">
-        <div class="col-8">
+        <div class="col-md-7">
           <h2 class="display-4">Welcome to sēcūritās!</h2>
           <p class="lead">
             This is the open source, community self-service portal for FreeIPA.
@@ -16,15 +15,21 @@
           </p>
         </div>
         <div class="col">
-            {% include '_login_form.html' %}
+          <div class="card">
+          <ul class="card-header nav nav-tabs pb-0" role="tablist">
+            <li class="nav-item">
+              <a class="nav-link active" id="login-tab" data-toggle="pill" href="#login" role="tab">Login</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" id="register-tab" data-toggle="pill" href="#register" role="tab">Register</a>
+            </li>
+          </ul>
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="login" role="tabpanel">{% include '_login_form.html' %}</div>
+            <div class="tab-pane fade" id="register" role="tabpanel">{% include '_register_form.html' %}</div>
+          </div>
+          </div>
         </div>
-      </div>
-    </div>
-  </div>
-  <div class="container">
-    <div class="row py-5">
-      <div class="col s5">
-        {% include '_register_form.html' %}
       </div>
     </div>
   </div>

--- a/securitas/templates/login.html
+++ b/securitas/templates/login.html
@@ -1,13 +1,15 @@
 {% extends "main.html" %}
-{% block title %}User Login{% endblock %}
+{% block title %}Login{% endblock %}
 
 {% block content %}
   {{ super() }}
 
-  <div class="container pt-4">
+  <div class="container py-4">
     <div class="row">
-      <div class="col-5 mx-auto">
-        {% include '_login_form.html' %}
+      <div class="col-6 mx-auto">
+        <div class="card">
+          {% include '_login_form.html' %}
+        </div>
       </div>
     </div>
   </div>

--- a/securitas/templates/master.html
+++ b/securitas/templates/master.html
@@ -6,7 +6,7 @@
     {% block head %}
     {% endblock %}
     <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet" type="text/css">
-    <title>{% block title %}{% endblock %} - {{ project }}</title>
+    <title>{% block title %}{% endblock %}{% if self.title() %} - {% endif %}{{ project }}</title>
   </head>
   <body>
     {% block navbar %} {% endblock %}

--- a/securitas/templates/password-reset.html
+++ b/securitas/templates/password-reset.html
@@ -6,33 +6,12 @@
 
 {% import '_form_macros.html' as macros %}
 
-  <div class="container pt-4">
+  <div class="container py-4">
     <div class="row">
       <div class="col-6 mx-auto">
-        {% if current_user %}
-        <div class="h4 text-center mb-4" id="pageheading" >Password Reset for {{current_user.username}}</div>
-        <form action="{{ url_for('auth_password_reset', username=current_user.username) }}" method="post">
-        {% else %}
-        <div class="h4 text-center mb-4" id="pageheading">Expired Password Reset for {{username}}</div>
-        <form action="{{ url_for('password_reset', username=username) }}" method="post">
-        {% endif %}
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(password_reset_form.current_password, tabindex="2")}}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">
-              {{ macros.non_field_errors(password_reset_form) }}
-              <button class="btn btn-outline-primary btn-block" id="submit" type="submit" tabindex="5">Submit</button>
-            </div>
-          </div>
-        </form>
+        <div class="card">
+          {% include '_password_reset_form.html' %}
+        </div>
       </div>
     </div> <!-- ./row -->
   </div>

--- a/securitas/templates/register.html
+++ b/securitas/templates/register.html
@@ -1,13 +1,15 @@
 {% extends "main.html" %}
-{% block title %}User Registration{% endblock %}
+{% block title %}Registration{% endblock %}
 
 {% block content %}
   {{ super() }}
 
-  <div class="container pt-4">
+  <div class="container py-4">
     <div class="row">
-      <div class="col">
-        {% include '_register_form.html' %}
+      <div class="col-6 mx-auto">
+        <div class="card">
+          {% include '_register_form.html' %}
+        </div>
       </div>
     </div>
   </div>

--- a/securitas/templates/user-edit.html
+++ b/securitas/templates/user-edit.html
@@ -1,56 +1,77 @@
 {% extends "main.html" %}
 
-{% block title %}Edit User: {{ user.username }}{% endblock %}
+{% block title %}{{ user.username }}'s Settings{% endblock %}
 
 {% import '_form_macros.html' as macros %}
 {% block content %}
   {{ super() }}
-  <div class="container pt-4 section">
+  <div class="container py-4 section">
     <div class="row form-group">
-      <div class="col s12">
-        <h3 class="header light-blue-text text-darken-4 fw300">
-          Edit user: {{ user.username }}
-        </h3>
-        
-        <form class="needs-validation" action="{{ url_for('user_edit', username=user.username) }}" method="post" novalidate>
-          {{ form.csrf_token }}
-          
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.firstname) }}</div>
-            <div class="form-group col">{{ macros.with_errors(form.lastname) }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.mail) }}</div>
-            <div class="form-group col">{{ macros.with_errors(form.locale, class="custom-select") }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.ircnick) }}</div>
-            <div class="form-group col">{{ macros.with_errors(form.timezone, class="custom-select") }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.github) }}</div>
-            <div class="form-group col">{{ macros.with_errors(form.gitlab) }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.rhbz_mail) }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.gpgkeys, maxlength="16", class="text-monospace mb-1", placeholder="add a GPG Key ID") }}</div>
-          </div>
-          <div class="form-row">
-            <div class="form-group col">{{ macros.with_errors(form.sshpubkeys, class="text-monospace mb-1", placeholder="add a SSH Public Key") }}</div>
-          </div>
-          <div class="form-row">
-            {{ macros.non_field_errors(form) }}
-            <div class="form-group col">
-              <button class="btn btn-primary" id="submit" type="submit" tabindex="9">Submit</button>
+      <div class="col-md-8 mx-auto">
+        <div class="card">
+          <ul class="card-header nav nav-pills" role="tablist">
+            <li class="nav-item">
+              <a class="nav-link active" data-toggle="pill" href="#settings-personal" role="tab">Personal</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" data-toggle="pill" href="#settings-contact" role="tab">Contact</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" data-toggle="pill" href="#settings-security" role="tab">Privacy and Security</a>
+            </li>
+          </ul>
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="settings-personal" role="tabpanel">
+              <form class="needs-validation" action="{{ url_for('user_edit', username=user.username) }}" method="post" novalidate>
+                {{ form.csrf_token }}
+                <div class="card-body">
+                  <div class="form-group">
+                    <label for="username">Username</label>
+                    <input class="form-control" disabled id="username" name="username" type="text" value="{{ user.username }}">
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group col">{{ macros.with_errors(form.firstname) }}</div>
+                    <div class="form-group col">{{ macros.with_errors(form.lastname) }}</div>
+                  </div>
+                  <div class="form-group">{{ macros.with_errors(form.locale, class="custom-select") }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.timezone, class="custom-select") }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.gpgkeys, maxlength="16", class="text-monospace mb-1", placeholder="GPG Key ID") }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.sshpubkeys, class="text-monospace mb-1", placeholder="SSH Public Key") }}</div>
+                </div>
+                <div class="card-footer d-flex justify-content-between">
+                  <div>{{ macros.non_field_errors(form) }}</div>
+                  <button class="btn btn-primary" id="submit" type="submit" tabindex="9">Save</button>
+                </div>
+              </form>
+            </div>
+            <div class="tab-pane fade" id="settings-contact" role="tabpanel">
+              <form class="needs-validation" action="{{ url_for('user_edit', username=user.username) }}" method="post" novalidate>
+                {{ form.csrf_token }}
+                <div class="card-body">
+                  <div class="form-group">{{ macros.with_errors(form.mail) }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.ircnick) }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.github) }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.gitlab) }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.rhbz_mail) }}</div>
+                </div>
+                <div class="card-footer d-flex justify-content-between">
+                  <div>{{ macros.non_field_errors(form) }}</div>
+                  <button class="btn btn-primary" id="submit" type="submit" tabindex="10">Save</button>
+                </div>
+              </form>
+            </div>
+            <div class="tab-pane fade" id="settings-security" role="tabpanel">
+              {% include '_password_reset_form.html' %}
+              {%- if request_disable_account is defined  %}
+              <div class="border-top">
+                <h5>Personal data requests</h5>
+                {{ request_disable_account() }}
+              {%- endif %}
+              </div>
             </div>
           </div>
-        </form>
+        </div>
       </div>
-    </div>
-    <div class="row form-group">
-      {{ request_disable_account() if request_disable_account is defined }}
     </div>
   </div>
 {% endblock %}

--- a/securitas/templates/user.html
+++ b/securitas/templates/user.html
@@ -1,84 +1,106 @@
 {% extends "main.html" %}
 
-{% block title %}User: {{ user.username }}{% endblock %}
+{% block title %}{{ user.username }}'s Profile{% endblock %}
 
 {% block content %}
   {{ super() }}
-  <div class="container pt-4">
+  <div class="container py-4">
     <div class="row">
-      <div class="col-4">
-        <h4 class="" id="user_username">{{ user.username }}</h4>
-        <div id="user_fullname">{{ user.name if user.name else user.username }}</div>
-        <img class="img-thumbnail" src="{{ gravatar(user.mail if user.mail else 'default', 400) }}">
-        {% if user.username == current_user.username %}
-          <a href="{{ url_for('user_edit', username=user.username) }}" class="btn btn-outline-primary btn-block mb-2 mt-1">Edit profile</a>
-          <a href="{{ url_for('auth_password_reset', username=user.username) }}" class="btn btn-outline-primary btn-block mb-2 mt-1">Change Password</a>
-        {% endif %}
-        <div>
-              {% if user.timezone %}
-                <div><b>Timezone:</b> {{ user.timezone }}</div>
+      <div class="col-md-6 mx-auto">
+        <div class="row mb-3">
+          <div class="col-4">
+            <img class="w-100 border rounded" src="{{ gravatar(user.mail if user.mail else 'default', 400) }}">
+          </div>
+          <div class="col my-auto">
+            <h3 class="mb-0" id="user_fullname">{{ user.name if user.name else user.username }}</h3>
+            <h5 class="mb-0" id="user_username">{{ user.username }}</h5>
+          </div>
+        </div>
+        <ul class="nav nav-pills mb-3 justify-content-center" role="tablist">
+          <li class="nav-item">
+            <a class="nav-link active" data-toggle="pill" href="#profile" role="tab">Profile</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" data-toggle="pill" href="#groups" role="tab">Groups <span class="badge badge-primary badge-pill">{{groups | count }}</span></a>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div class="tab-pane fade show active" id="profile" role="tabpanel">
+            <div class="card">
+                  <ul class="list-group list-group-flush">
+                  {% if user.timezone %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center"><b>Timezone</b> {{ user.timezone }}</li>
+                  {% endif %}
+                  {% if user.ircnick %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center"><b>IRC Nickname</b> {{ user.ircnick }}</li>
+                  {% endif %}
+                  {% if user.locale %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center"><b>Locale</b> {{ user.locale }}</li>
+                  {% endif %}
+                  {% if user.gpgkeys %}
+                    <li class="list-group-item d-flex justify-content-between"><b>GPG Keys</b> <div class="text-right">{% for pgpkey in user.gpgkeys %}<pre class="mb-0">{{ pgpkey }}</pre>{% endfor %}</div></li>
+                  {% endif %}
+                  {% if user.rhbz_mail %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center"><b>RHBZ E-Mail</b> {{ user.rhbz_mail }}</li>
+                  {% endif %}
+                  {% if user.github %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <b>GitHub</b>
+                      <a href="https://github.com/{{ user.github }}">@{{ user.github }}</a>
+                    </li>
+                  {% endif %}
+                  {% if user.gitlab %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <b>GitLab</b>
+                      <a href="https://gitlab.com/{{ user.gitlab }}">@{{ user.gitlab }}</a>
+                    </li>
+                  {% endif %}
+                  {# TODO: What all do we want to link to here? #}
+                  {# TODO: And should these links be configurable somehow for other deployments? #}
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <b>Wiki</b>
+                    <a href="https://fedoraproject.org/wiki/User:{{ user.username }}">User:{{ user.username }}</a>
+                  </li>
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <b>Fedora People</b>
+                    <a href="https://{{ user.username }}.fedorapeople.org/">{{ user.username }}</a>
+                  </li>
+              </ul>
+              {% if user.username == current_user.username %}
+              <div class="card-footer">
+                <a href="{{ url_for('user_edit', username=user.username) }}" class="btn btn-secondary btn-block">Settings</a>
+              </div>
               {% endif %}
-              {% if user.ircnick %}
-                <div><b>IRC Nickname:</b> {{ user.ircnick }}</div>
-              {% endif %}
-              {% if user.locale %}
-                <div><b>Locale:</b> {{ user.locale }}</div>
-              {% endif %}
-              {% if user.gpgkeys %}
-                <div><b>GPG Keys:</b> {{ user.gpgkeys|join(', ') }}</div>
-              {% endif %}
-              {% if user.rhbz_mail %}
-                <div><b>RHBZ E-Mail:</b> {{ user.rhbz_mail }}</div>
-              {% endif %}
-              {% if user.github %}
-                <div>
-                  <b>GitHub:</b>
-                  <a href="https://github.com/{{ user.github }}">@{{ user.github }}</a>
-                </div>
-              {% endif %}
-              {% if user.gitlab %}
-                <div>
-                  <b>GitLab:</b>
-                  <a href="https://gitlab.com/{{ user.gitlab }}">@{{ user.gitlab }}</a>
-                </div>
-              {% endif %}
-            <div>
-              {# TODO: What all do we want to link to here? #}
-              {# TODO: And should these links be configurable somehow for other deployments? #}
-              <a href="https://fedoraproject.org/wiki/User:{{ user.username }}">Wiki</a> | 
-              <a href="https://{{ user.username }}.fedorapeople.org/">Fedora People</a>
             </div>
+          </div>
+          <div class="tab-pane fade" id="groups" role="tabpanel">
+            <div>
+              <ul class="list-group">
+                {% for group in groups %}
+                  {% with is_sponsor = group in managed_groups %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                      <div class="media align-items-center">
+                        <i class="fa fa-group fa-2x text-muted mr-3"></i>
+                        <div class="media-body">
+                            <div class="my-0 font-weight-bold">
+                              <a href="{{ url_for('group', groupname=group.name) }}">
+                                <span class="title">{{ group.name }}</span>
+                              </a>
+                            </div>
+                            {% if group.description %}
+                              <div>{{ group.description }}</div>
+                            {% endif %}  
+                        </div>
+                      </div>
+                      <div class=" {{ 'text-warning' if is_sponsor else 'text-success' }}">{{ 'sponsor' if is_sponsor else 'member' }} </div>
+                    </li>
+                  {% endwith %}
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
         </div>
       </div> 
-      <div class="col">
-
-        <div>
-          <h4>{{groups | count }} Groups</h4>
-          <ul class="list-group">
-            {% for group in groups %}
-              {% with is_sponsor = group in managed_groups %}
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                  <div class="media align-items-center">
-                    <i class="fa fa-group fa-2x text-muted mr-3"></i>
-                    <div class="media-body">
-                        <div class="my-0 font-weight-bold">
-                          <a href="{{ url_for('group', groupname=group.name) }}">
-                            <span class="title">{{ group.name }}</span>
-                          </a>
-                        </div>
-                        {% if group.description %}
-                          <div>{{ group.description }}</div>
-                        {% endif %}  
-                    </div>
-                  </div>
-                  <div class=" {{ 'text-warning' if is_sponsor else 'text-success' }}">{{ 'sponsor' if is_sponsor else 'member' }} </div>
-                </li>
-              {% endwith %}
-            {% endfor %}
-          </ul>
-        </div>
-
-      </div>
     </div>
 
   </div>

--- a/securitas/tests/unit/controller/test_group.py
+++ b/securitas/tests/unit/controller/test_group.py
@@ -45,12 +45,14 @@ def test_group(client, dummy_user_as_group_manager, make_user):
     assert result.status_code == 200
     page = BeautifulSoup(result.data, 'html.parser')
     assert page.title
-    assert page.title.string == 'Group: dummy-group - The Fedora Project'
+    assert page.title.string == 'dummy-group Group - The Fedora Project'
     title = page.select_one("div[data-section='identity'] > .col > h3")
     assert title.get_text(strip=True) == "dummy-group"
     assert title.find_next_sibling("div").get_text(strip=True) == "A dummy group"
     # Check the sponsors list
-    sponsors = page.select("div[data-section='sponsors'] .list-group .list-group-item")
+    sponsors = page.select(
+        "div[data-section='sponsors'] .list-unstyled.row .col-lg-3.col-md-4.col-sm-6"
+    )
     assert len(sponsors) == 2, str(sponsors)
     assert sponsors[0].find("a")["href"] == "/user/dummy/"
     assert sponsors[0].find("a").get_text(strip=True) == "dummy"

--- a/securitas/tests/unit/controller/test_password_reset.py
+++ b/securitas/tests/unit/controller/test_password_reset.py
@@ -35,7 +35,7 @@ def test_password_reset_user(client, logged_in_dummy_user):
     result = client.get('/password-reset', follow_redirects=True)
     page = BeautifulSoup(result.data, 'html.parser')
     pageheading = page.select("#pageheading")[0]
-    assert pageheading.get_text(strip=True) == "Password Reset for dummy"
+    assert pageheading.get_text(strip=True) == "Change Password"
 
 
 @pytest.mark.vcr()

--- a/securitas/tests/unit/controller/test_root.py
+++ b/securitas/tests/unit/controller/test_root.py
@@ -8,7 +8,7 @@ def test_root(client):
     assert result.status_code == 200
     page = BeautifulSoup(result.data, 'html.parser')
     assert page.title
-    assert page.title.string == 'Self-Service Portal - The Fedora Project'
+    assert page.title.string == 'The Fedora Project'
 
 
 @pytest.mark.vcr()

--- a/securitas/tests/unit/controller/test_user.py
+++ b/securitas/tests/unit/controller/test_user.py
@@ -30,7 +30,7 @@ def test_user(client, logged_in_dummy_user):
     assert result.status_code == 200
     page = BeautifulSoup(result.data, 'html.parser')
     assert page.title
-    assert page.title.string == 'User: dummy - The Fedora Project'
+    assert page.title.string == 'dummy\'s Profile - The Fedora Project'
     user_fullname = page.select("#user_fullname")
     assert len(user_fullname) == 1
     assert user_fullname[0].get_text(strip=True) == "Dummy User"
@@ -54,12 +54,12 @@ def test_user_edit(client, logged_in_dummy_user):
     page = BeautifulSoup(result.data, 'html.parser')
     # print(page.prettify())
     assert page.title
-    assert page.title.string == 'Edit User: dummy - The Fedora Project'
+    assert page.title.string == 'dummy\'s Settings - The Fedora Project'
     form = page.select("form[action='/user/dummy/edit/']")
-    assert len(form) == 1
+    assert len(form) == 2
     assert form[0].find("input", attrs={"name": "firstname"})["value"] == "Dummy"
     assert form[0].find("input", attrs={"name": "lastname"})["value"] == "User"
-    assert form[0].find("input", attrs={"name": "mail"})["value"] == "dummy@example.com"
+    assert form[1].find("input", attrs={"name": "mail"})["value"] == "dummy@example.com"
     assert (
         form[0].find("textarea", attrs={"name": "sshpubkeys-0"}).get_text(strip=True)
         == ""

--- a/securitas/themes/default/templates/main.html
+++ b/securitas/themes/default/templates/main.html
@@ -23,6 +23,7 @@
                 </a>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
                     <a class="dropdown-item" href="{{ url_for('user', username=current_user.username) }}">Profile</a>
+                    <a class="dropdown-item" href="{{ url_for('user_edit', username=current_user.username) }}">Settings</a>
                     <a class="dropdown-item" href="{{ url_for('logout') }}">Log Out</a>
                 </div>
             </li>

--- a/securitas/themes/fas/templates/main.html
+++ b/securitas/themes/fas/templates/main.html
@@ -25,6 +25,7 @@
                 </a>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownMenuLink">
                     <a class="dropdown-item" href="{{ url_for('user', username=current_user.username) }}">Profile</a>
+                    <a class="dropdown-item" href="{{ url_for('user_edit', username=current_user.username) }}">Settings</a>
                     <a class="dropdown-item" href="{{ url_for('logout') }}">Log Out</a>
                 </div>
             </li>


### PR DESCRIPTION
**Combined login and register dialog on the index page**
![Index](https://user-images.githubusercontent.com/30577011/75090349-4fab3e00-5562-11ea-9f6a-9f103a31a8c8.png)
![Index(1)](https://user-images.githubusercontent.com/30577011/75090348-4f12a780-5562-11ea-85f2-e18dfc26e707.png)

**Narrower profile for easier consumption of information**
![Profile](https://user-images.githubusercontent.com/30577011/75090357-51750180-5562-11ea-8330-493c3fda16aa.png)
![Profile(1)](https://user-images.githubusercontent.com/30577011/75090353-50dc6b00-5562-11ea-824c-e2479d25c095.png)

**Settings split into 3 parts (and password change integrated into them)**
![Settings](https://user-images.githubusercontent.com/30577011/75090352-5043d480-5562-11ea-80dc-7391973548ba.png)
![Settings(1)](https://user-images.githubusercontent.com/30577011/75090351-5043d480-5562-11ea-87ea-1678c2d6836f.png)
![Settings(2)](https://user-images.githubusercontent.com/30577011/75090350-4fab3e00-5562-11ea-9a3c-7eddf22141f7.png)

**Group view with a little space saving applied**
![Group](https://user-images.githubusercontent.com/30577011/75090355-51750180-5562-11ea-9559-4192145d1392.png)

**Narrower Group List**
![Group List](https://user-images.githubusercontent.com/30577011/75090354-50dc6b00-5562-11ea-90c3-9b7a5c0aefa8.png)

**The rest of the views got cards now**
![Screenshot_2020-02-22 Password Recovery - The Fedora Project](https://user-images.githubusercontent.com/30577011/75090347-4e7a1100-5562-11ea-9c28-dcb1c148ff71.png)

Outside of that, title fixes so they are more compact and a little more human parsable.

Signed-off-by: Stasiek Michalski <stasiek@michalski.cc>