### PR TITLE
Use mergify to enforce the stricter review policy for security files

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,8 +6,23 @@ pull_request_rules:
       rebase_fallback: null
       strict: true
   conditions:
+  - -files~=^securitas/security/
   - label!=WIP
   - approved-reviews-by=@fedora-infra/authdev
   - "#approved-reviews-by>=1"
+  - status-success=DCO
+  - status-success=CI on f31
+
+- name: Sensitive files
+  actions:
+    merge:
+      method: rebase
+      rebase_fallback: null
+      strict: true
+  conditions:
+  - files~=^securitas/security/
+  - label!=WIP
+  - approved-reviews-by=@fedora-infra/authdev
+  - "#approved-reviews-by>=2"
   - status-success=DCO
   - status-success=CI on f31


### PR DESCRIPTION
In the developer docs we ask for files in the `securitas/security` directory to be reviewed by at least 2 team members. This changeset configures mergify to respect that.