### PR TITLE
Add email field to register form

### DIFF
--- a/securitas/controller/registration.py
+++ b/securitas/controller/registration.py
@@ -25,6 +25,7 @@ def register():
                 form.lastname.data,
                 f'{form.firstname.data} {form.lastname.data}',  # TODO ???
                 user_password=password,
+                mail=form.mail.data,
                 login_shell='/bin/bash',
                 fascreationtime=f"{now.isoformat()}Z",
                 faslocale=guess_locale(),

--- a/securitas/form/register_user.py
+++ b/securitas/form/register_user.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField
-from wtforms.validators import DataRequired, EqualTo
+from wtforms.fields.html5 import EmailField
+from wtforms.validators import DataRequired, EqualTo, Email
 
 
 class RegisterUserForm(FlaskForm):
@@ -28,3 +29,11 @@ class RegisterUserForm(FlaskForm):
     )
 
     password_confirm = PasswordField('Confirm Password')
+
+    mail = EmailField(
+        'E-mail Address',
+        validators=[
+            DataRequired(message='Email must not be empty'),
+            Email(message='Email must be valid'),
+        ],
+    )

--- a/securitas/templates/_register_form.html
+++ b/securitas/templates/_register_form.html
@@ -8,8 +8,11 @@
       <div class="form-group col">{{ macros.with_errors(register_form.firstname, tabindex="5") }}</div>
       <div class="form-group col">{{ macros.with_errors(register_form.lastname, tabindex="6") }}</div>
     </div>
-    <div class="form-group">{{ macros.with_errors(register_form.password, class="validate", tabindex="7") }}</div>
-    <div class="form-group mb-0">{{ macros.with_errors(register_form.password_confirm, class="validate", tabindex="8") }}</div>
+    <div class="form-row">
+      <div class="form-group col">{{ macros.with_errors(register_form.mail, tabindex="7") }}</div>
+    </div>
+    <div class="form-group">{{ macros.with_errors(register_form.password, class="validate", tabindex="8") }}</div>
+    <div class="form-group mb-0">{{ macros.with_errors(register_form.password_confirm, class="validate", tabindex="9") }}</div>
   </div>
   <div class="card-footer d-flex justify-content-between">
     <div>{{ macros.non_field_errors(register_form) }}</div>

--- a/securitas/tests/unit/controller/test_registration.py
+++ b/securitas/tests/unit/controller/test_registration.py
@@ -28,6 +28,7 @@ def test_register(client, cleanup_dummy_user):
         data={
             "firstname": "First",
             "lastname": "Last",
+            "mail": "firstlast@name.org",
             "username": "dummy",
             "password": "password",
             "password_confirm": "password",
@@ -52,6 +53,7 @@ def test_register_short_password(client, cleanup_dummy_user):
         data={
             "firstname": "First",
             "lastname": "Last",
+            "mail": "firstlast@name.org",
             "username": "dummy",
             "password": "42",
             "password_confirm": "42",
@@ -77,6 +79,7 @@ def test_register_duplicate(client, dummy_user):
         data={
             "firstname": "First",
             "lastname": "Last",
+            "mail": "dummy@dummy.org",
             "username": "dummy",
             "password": "password",
             "password_confirm": "password",
@@ -97,6 +100,7 @@ def test_register_invalid_username(client):
         data={
             "firstname": "First",
             "lastname": "Last",
+            "mail": "firstlast@name.org",
             "username": "this is invalid",
             "password": "password",
             "password_confirm": "password",
@@ -110,7 +114,7 @@ def test_register_invalid_username(client):
 
 
 def test_register_invalid_first_name(client):
-    """Register a user with an unhandled invalid value"""
+    """Register a user with an invalid first name"""
     with mock.patch("securitas.controller.registration.ipa_admin") as ipa_admin:
         ipa_admin.user_add.side_effect = python_freeipa.exceptions.ValidationError(
             message="invalid first name", code="4242"
@@ -120,12 +124,50 @@ def test_register_invalid_first_name(client):
             data={
                 "firstname": "This \n is \n invalid",
                 "lastname": "Last",
+                "mail": "firstlast@name.org",
                 "username": "dummy",
                 "password": "password",
                 "password_confirm": "password",
             },
         )
     assert_form_generic_error(result, 'invalid first name')
+
+
+@pytest.mark.vcr()
+def test_register_invalid_email(client):
+    """Register a user with an invalid email address"""
+    result = client.post(
+        '/register',
+        data={
+            "firstname": "First",
+            "lastname": "Last",
+            "mail": "firstlast at name dot org",
+            "username": "dummy",
+            "password": "password",
+            "password_confirm": "password",
+        },
+    )
+    assert_form_field_error(
+        result, field_name="mail", expected_message='Email must be valid'
+    )
+
+
+@pytest.mark.vcr()
+def test_register_empty_email(client):
+    """Register a user with an empty email address"""
+    result = client.post(
+        '/register',
+        data={
+            "firstname": "First",
+            "lastname": "Last",
+            "username": "dummy",
+            "password": "password",
+            "password_confirm": "password",
+        },
+    )
+    assert_form_field_error(
+        result, field_name="mail", expected_message='Email must not be empty'
+    )
 
 
 def test_register_generic_error(client):
@@ -139,6 +181,7 @@ def test_register_generic_error(client):
             data={
                 "firstname": "First",
                 "lastname": "Last",
+                "mail": "firstlast@name.org",
                 "username": "dummy",
                 "password": "password",
                 "password_confirm": "password",
@@ -164,6 +207,7 @@ def test_register_generic_pwchange_error(client, cleanup_dummy_user):
             data={
                 "firstname": "First",
                 "lastname": "Last",
+                "mail": "firstlast@name.org",
                 "username": "dummy",
                 "password": "password",
                 "password_confirm": "password",
@@ -197,6 +241,7 @@ def test_register_default_values(client, cleanup_dummy_user):
         data={
             "firstname": "First",
             "lastname": "Last",
+            "mail": "firstlast@name.org",
             "username": "dummy",
             "password": "password",
             "password_confirm": "password",


### PR DESCRIPTION
Previously, the email field was not present on the
register form. This commit adds the field.

Resolves: #127

Signed-off-by: Ryan Lerch <rlerch@redhat.com>