### PR TITLE
Refactor controller errors

### DIFF
--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -4,6 +4,7 @@ import python_freeipa
 from noggin import app
 from noggin.form.login_user import LoginUserForm
 from noggin.security.ipa import maybe_ipa_login, maybe_ipa_session
+from noggin.utility import FormError, handle_form_errors
 
 
 @app.route('/logout')
@@ -24,23 +25,25 @@ def login():
     if form.validate_on_submit():
         username = form.username.data
         password = form.password.data
-        try:
-            # This call will set the cookie itself, we don't have to.
-            ipa = maybe_ipa_login(app, session, username, password)
-        except python_freeipa.exceptions.PasswordExpired:
-            flash('Password expired. Please reset it.', 'danger')
-            return redirect(url_for('password_reset', username=username))
-        except python_freeipa.exceptions.Unauthorized as e:
-            form.errors['non_field_errors'] = [e.message]
-        except python_freeipa.exceptions.FreeIPAError as e:
-            # If we made it here, we hit something weird not caught above. We didn't
-            # bomb out, but we don't have IPA creds, either.
-            app.logger.error(
-                f'An unhandled error {e.__class__.__name__} happened while logging in user '
-                f'{username}: {e.message}'
-            )
-            form.errors['non_field_errors'] = ['Could not log in to the IPA server.']
-        else:
+        with handle_form_errors(form):
+            try:
+                # This call will set the cookie itself, we don't have to.
+                ipa = maybe_ipa_login(app, session, username, password)
+            except python_freeipa.exceptions.PasswordExpired:
+                flash('Password expired. Please reset it.', 'danger')
+                return redirect(url_for('password_reset', username=username))
+            except python_freeipa.exceptions.Unauthorized as e:
+                raise FormError("non_field_errors", e.message)
+            except python_freeipa.exceptions.FreeIPAError as e:
+                # If we made it here, we hit something weird not caught above. We didn't
+                # bomb out, but we don't have IPA creds, either.
+                app.logger.error(
+                    f'An unhandled error {e.__class__.__name__} happened while logging in user '
+                    f'{username}: {e.message}'
+                )
+                raise FormError(
+                    "non_field_errors", "Could not log in to the IPA server."
+                )
             if ipa:
                 flash(f'Welcome, {username}!', 'success')
                 return redirect(url_for('user', username=username))
@@ -49,7 +52,8 @@ def login():
                     f'An unhandled situation happened while logging in user {username}: '
                     f'could not connect to the IPA server'
                 )
-                form.errors['non_field_errors'] = [
-                    'Could not log in to the IPA server.'
-                ]
+                raise FormError(
+                    "non_field_errors", "Could not log in to the IPA server."
+                )
+
     return render_template('login.html', login_form=form)

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -12,7 +12,13 @@ from noggin.form.edit_user import (
 from noggin.representation.group import Group
 from noggin.representation.user import User
 from noggin.representation.otptoken import OTPToken
-from noggin.utility import with_ipa, user_or_404, FormError, handle_form_errors
+from noggin.utility import (
+    with_ipa,
+    user_or_404,
+    FormError,
+    handle_form_errors,
+    require_self,
+)
 
 
 @app.route('/user/<username>/')
@@ -50,12 +56,8 @@ def _user_mod(ipa, form, username, details):
 
 @app.route('/user/<username>/settings/profile/', methods=['GET', 'POST'])
 @with_ipa(app, session)
+@require_self
 def user_settings_profile(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     user = User(user_or_404(ipa, username))
     form = UserSettingsProfileForm(obj=user)
 
@@ -88,12 +90,8 @@ def user_settings_profile(ipa, username):
 
 @app.route('/user/<username>/settings/keys/', methods=['GET', 'POST'])
 @with_ipa(app, session)
+@require_self
 def user_settings_keys(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     user = User(user_or_404(ipa, username))
     form = UserSettingsKeysForm(obj=user)
 
@@ -122,12 +120,8 @@ def user_settings_keys(ipa, username):
 
 @app.route('/user/<username>/settings/otp/')
 @with_ipa(app, session)
+@require_self
 def user_settings_otp(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     addotpform = UserSettingsAddOTPForm()
     user = User(user_or_404(ipa, username))
 
@@ -153,12 +147,8 @@ def user_settings_otp(ipa, username):
 
 @app.route('/user/<username>/settings/otp/add/', methods=['POST'])
 @with_ipa(app, session)
+@require_self
 def user_settings_otp_add(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     form = UserSettingsAddOTPForm()
     user = User(user_or_404(ipa, username))
 
@@ -195,12 +185,8 @@ def user_settings_otp_add(ipa, username):
 
 @app.route('/user/<username>/settings/otp/disable/', methods=['POST'])
 @with_ipa(app, session)
+@require_self
 def user_settings_otp_disable(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     form = UserSettingsDisableOTPForm()
 
     if form.validate_on_submit():
@@ -234,12 +220,8 @@ def user_settings_otp_disable(ipa, username):
 
 @app.route('/user/<username>/settings/otp/delete/', methods=['POST'])
 @with_ipa(app, session)
+@require_self
 def user_settings_otp_delete(ipa, username):
-    # TODO: Maybe make this a decorator some day?
-    if session.get('noggin_username') != username:
-        flash('You do not have permission to edit this account.', 'danger')
-        return redirect(url_for('user', username=username))
-
     form = UserSettingsDeleteOTPForm()
 
     if form.validate_on_submit():

--- a/noggin/tests/unit/utility/test___init__.py
+++ b/noggin/tests/unit/utility/test___init__.py
@@ -5,7 +5,14 @@ from flask import current_app, g, session, get_flashed_messages
 from werkzeug.exceptions import NotFound
 
 from noggin.security.ipa import maybe_ipa_login
-from noggin.utility import user_or_404, group_or_404, with_ipa
+from noggin.utility import (
+    user_or_404,
+    group_or_404,
+    with_ipa,
+    FormError,
+    handle_form_errors,
+)
+from noggin.form.login_user import LoginUserForm
 
 
 @pytest.mark.vcr()
@@ -73,3 +80,49 @@ def test_with_ipa_anonymous(client):
         category, message = messages[0]
         assert message == "Please log in to continue."
         assert category == "warning"
+
+
+def test_formerror(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
+        form.validate()
+        error = FormError("username", "error message")
+        error.populate_form(form)
+    assert form.errors == {"username": ["error message"]}
+
+
+def test_formerror_unknown_field(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
+        form.validate()
+        error = FormError("non_form_errors", "error message")
+        error.populate_form(form)
+    assert form.errors == {"non_form_errors": ["error message"]}
+
+
+def test_formerror_existing_field(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        form.validate()
+        error = FormError("username", "error message")
+        error.populate_form(form)
+    assert form.errors["username"] == ["You must provide a user name", "error message"]
+
+
+def test_formerror_unknown_field_append(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        form.validate()
+        FormError("non_form_errors", "error message 1").populate_form(form)
+        FormError("non_form_errors", "error message 2").populate_form(form)
+    assert form.errors["non_form_errors"] == ["error message 1", "error message 2"]
+
+
+def test_handle_form_errors(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        error = FormError("username", "error_message")
+        with mock.patch.object(error, "populate_form") as populate_form:
+            with handle_form_errors(form):
+                raise error
+    populate_form.assert_called_once_with(form)

--- a/noggin/tests/unit/utility/test___init__.py
+++ b/noggin/tests/unit/utility/test___init__.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 from flask import current_app, g, session, get_flashed_messages
-from werkzeug.exceptions import NotFound
+from werkzeug.exceptions import NotFound, InternalServerError
 
 from noggin.security.ipa import maybe_ipa_login
 from noggin.utility import (
@@ -11,6 +11,7 @@ from noggin.utility import (
     with_ipa,
     FormError,
     handle_form_errors,
+    require_self,
 )
 from noggin.form.login_user import LoginUserForm
 
@@ -126,3 +127,10 @@ def test_handle_form_errors(client):
             with handle_form_errors(form):
                 raise error
     populate_form.assert_called_once_with(form)
+
+
+def test_require_self_wrong_route(client):
+    view = mock.Mock()
+    with current_app.test_request_context('/password-reset'):
+        with pytest.raises(InternalServerError):
+            require_self(view)()


### PR DESCRIPTION
The first commit implements a context manager that, I think, makes form error handling a little simpler when working with mutiple API calls in the same form submission controller.

Before that, we hand to handle API exceptions and populate the form's errors on the first step, and then use `else` statement on the exception handling to go to the next step. It means that each API call would be indenting the code one more time, which is manageable when there are only two steps but can quickly get out of hand.
With this commit, form errors are propagated through exceptions, which break the code flow right there and don't require further indentation.
I think it makes the codeflow clearer to read and write, and may thus prevent mistakes where a 2nd API call would be executed after the first one failed. But that may just be my way of thinking, so I'm happy to hear your opinions.

The second commit implements a decorator for checking the current username against the user being edited, it has been flagged as a TODO for a while and duplicated multiple times. It is unrelated to the first commit.