### PR TITLE
remove redirect from user settings edit

### DIFF
--- a/noggin/templates/user-settings.html
+++ b/noggin/templates/user-settings.html
@@ -8,7 +8,7 @@
     <div class="row form-group">
       <div class="col-md-8 mx-auto">
         <div class="row">
-          <h3>Settings for {{user.username}}</h3>
+            <h3>Settings for <a href="{{url_for('user', username=user.username)}}">{{user.username}}</a></h3>
         </div>
         <div class="card">
           <ul class="card-header nav nav-tabs pb-0" role="tablist">

--- a/noggin/tests/unit/controller/test_user.py
+++ b/noggin/tests/unit/controller/test_user.py
@@ -75,8 +75,8 @@ def test_user_edit_post(client, logged_in_dummy_user):
     result = client.post('/user/dummy/settings/profile/', data=POST_CONTENTS)
     assert_redirects_with_flash(
         result,
-        expected_url="/user/dummy/",
-        expected_message="Profile has been succesfully updated.",
+        expected_url="/user/dummy/settings/profile/",
+        expected_message="Profile Updated: <a href=\"/user/dummy/\">view your profile</a>",
         expected_category="success",
     )
 
@@ -142,8 +142,8 @@ def test_user_settings_keys_post(client, logged_in_dummy_user):
     result = client.post('/user/dummy/settings/keys/', data=POST_CONTENTS_KEYS)
     assert_redirects_with_flash(
         result,
-        expected_url="/user/dummy/",
-        expected_message="Profile has been succesfully updated.",
+        expected_url="/user/dummy/settings/keys/",
+        expected_message="Profile Updated: <a href=\"/user/dummy/\">view your profile</a>",
         expected_category="success",
     )
 

--- a/noggin/tests/unit/utilities.py
+++ b/noggin/tests/unit/utilities.py
@@ -15,8 +15,12 @@ def assert_redirects_with_flash(
     messages = get_flashed_messages(with_categories=True)
     assert len(messages) == 1
     category, message = messages[0]
-    assert message == expected_message
-    assert category == expected_category
+    assert (
+        message == expected_message
+    ), f"\nExpected message: {expected_message}\nActual message:   {message}"
+    assert (
+        category == expected_category
+    ), f"\nExpected category: {expected_category}\nActual category:   {category}"
 
 
 def assert_form_field_error(response, field_name, expected_message):

--- a/noggin/themes/default/templates/main.html
+++ b/noggin/themes/default/templates/main.html
@@ -35,7 +35,7 @@
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
             <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash|striptags }}
+                {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -37,7 +37,7 @@
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
             <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash|striptags }}
+                {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -47,7 +47,7 @@
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
             <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash|striptags }}
+                {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>


### PR DESCRIPTION
previously, when editng the user settings (profile or gpg keys)
after a successful POST, noggin would redirect back to the profile
page, rather than to the settings page like with other settings pages
like OTP. This changes noggin to return to the settings edit form
rather than the profile page

Signed-off-by: Ryan Lerch <rlerch@redhat.com>