### PR TITLE
Add translation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ docs/_build/
 
 # Vagrant
 .vagrant
+
+# Translations
+*.mo

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ The primary purpose of the portal is to allow users to sign up and manage their
 account information and group membership.
 
 The documentation is available online at https://noggin-aaa.readthedocs.io/
+
+## Update pot
+
+To update the pot file for translators, just run:
+`pybabel extract -F babel.cfg -o noggin/po/messages.pot noggin`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,3 @@ The primary purpose of the portal is to allow users to sign up and manage their
 account information and group membership.
 
 The documentation is available online at https://noggin-aaa.readthedocs.io/
-
-## Update pot
-
-To update the pot file for translators, just run:
-`pybabel extract -F babel.cfg -o noggin/po/messages.pot noggin`

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,3 @@
+[python: **.py]
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.i18n,jinja2.ext.autoescape,jinja2.ext.with_

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -45,6 +45,11 @@
   become: yes
   become_user: vagrant
 
+- name: compile the translations
+  shell: poetry run pybabel compile -d /vagrant/noggin/translations
+  become: yes
+  become_user: vagrant
+
 - name: Install the systemd unit files for noggin services
   copy:
       src: "{{ item }}"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -206,23 +206,23 @@ When cutting a new release, follow these steps:
 Translations
 ------------
 
-* To extract the messages.pot that is in noggin/translations/messages.pot, use:
+To extract the messages.pot that is in noggin/translations/messages.pot, use::
 
-  ``poetry run pybabel extract -F babel.cfg -o noggin/translations/messages.pot noggin``
+  poetry run pybabel extract -F babel.cfg -o noggin/translations/messages.pot noggin
 
-  This will update the messages.pot with the newest strings that have been flagged in the
-  templates and code.
+This will update the messages.pot with the newest strings that have been flagged in the
+templates and code.
 
-* To add a new language, use the command:
+To add a new language, use the command::
 
-  ``poetry run pybabel init -i noggin/translations/messages.pot -d noggin/translations/ -l fr_FR``
+  poetry run pybabel init -i noggin/translations/messages.pot -d noggin/translations/ -l fr_FR
 
-* To update all created languages with the newest strings in messages.pot, use:
+To update all created languages with the newest strings in messages.pot, use::
 
-  ``poetry run pybabel update -i noggin/translations/messages.pot -d noggin/translations``
+  poetry run pybabel update -i noggin/translations/messages.pot -d noggin/translations
 
-* To compile the translations in updated .mo files into what noggin can use, use the command:
+To compile the translations in updated .mo files into what noggin can use, use the command::
 
-  ``poetry run pybabel compile -d noggin/translations``
+  poetry run pybabel compile -d noggin/translations
 
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -201,3 +201,28 @@ When cutting a new release, follow these steps:
 #. Tag the commit with ``-s`` to generate a signed tag
 #. Push those changes to the upstream Github repository (via a PR or not)
 #. Generate a tarball and push to PyPI with the command ``poetry --build publish``
+
+
+Translations
+------------
+
+* To extract the messages.pot that is in noggin/translations/messages.pot, use:
+
+  ``poetry run pybabel extract -F babel.cfg -o noggin/translations/messages.pot noggin``
+
+  This will update the messages.pot with the newest strings that have been flagged in the
+  templates and code.
+
+* To add a new language, use the command:
+
+  ``poetry run pybabel init -i noggin/translations/messages.pot -d noggin/translations/ -l fr_FR``
+
+* To update all created languages with the newest strings in messages.pot, use:
+
+  ``poetry run pybabel update -i noggin/translations/messages.pot -d noggin/translations``
+
+* To compile the translations in updated .mo files into what noggin can use, use the command:
+
+  ``poetry run pybabel compile -d noggin/translations``
+
+

--- a/noggin/__init__.py
+++ b/noggin/__init__.py
@@ -1,4 +1,5 @@
-from flask import Flask, Blueprint
+from flask import Flask, Blueprint, request
+from flask_babel import Babel
 from flask_wtf.csrf import CSRFProtect
 from flask_mail import Mail
 from whitenoise import WhiteNoise
@@ -6,7 +7,10 @@ from whitenoise import WhiteNoise
 from noggin.security.ipa_admin import IPAAdmin
 
 app = Flask(__name__)
+app.jinja_env.add_extension('jinja2.ext.i18n')
 csrf = CSRFProtect(app)
+
+LANGUAGES = ["en_US", "fr_FR"]
 
 # Load defaults
 app.config.from_pyfile('defaults.cfg')
@@ -32,6 +36,15 @@ app.register_blueprint(blueprint)
 # Flask-Mail
 mailer = Mail(app)
 
+
+babel = Babel(app)
+
+
+@babel.localeselector
+def get_locale():
+    return request.accept_languages.best_match(LANGUAGES)
+
+
 # Whitenoise for static files
 app.wsgi_app = WhiteNoise(
     app.wsgi_app, root=f"{app.root_path}/static", prefix="/static"
@@ -39,7 +52,6 @@ app.wsgi_app = WhiteNoise(
 app.wsgi_app.add_files(
     f"{app.root_path}/themes/{themename}/static/", prefix="/theme/static"
 )
-
 
 # Set the version
 try:

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -1,4 +1,5 @@
 from flask import flash, redirect, session, url_for, render_template
+from flask_babel import _
 import python_freeipa
 
 from noggin import app

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -27,14 +27,14 @@ def handle_login_form(form):
             f'An unhandled error {e.__class__.__name__} happened while logging in user '
             f'{username}: {e.message}'
         )
-        raise FormError("non_field_errors", "Could not log in to the IPA server.")
+        raise FormError("non_field_errors", _('Could not log in to the IPA server.'))
 
     if not ipa:
         app.logger.error(
             f'An unhandled situation happened while logging in user {username}: '
             f'could not connect to the IPA server'
         )
-        raise FormError("non_field_errors", "Could not log in to the IPA server.")
+        raise FormError("non_field_errors", _('Could not log in to the IPA server.'))
 
     flash(f'Welcome, {username}!', 'success')
     return redirect(url_for('user', username=username))

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from flask import flash, redirect, render_template, session, url_for, Markup
+from flask_babel import _
 import python_freeipa
 
 from noggin import app
@@ -193,7 +194,7 @@ def user_settings_otp_disable(ipa, username):
                 e.message
                 == "Server is unwilling to perform: Can't disable last active token"
             ):
-                flash('Sorry, You cannot disable your last active token.', 'warning')
+                flash(_('Sorry, You cannot disable your last active token.'), 'warning')
             else:
                 flash('Cannot disable the token.', 'danger')
                 app.logger.error(

--- a/noggin/po/fr/LC_MESSAGES/messages.po
+++ b/noggin/po/fr/LC_MESSAGES/messages.po
@@ -1,0 +1,33 @@
+# French translations for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-03-21 16:28+0100\n"
+"PO-Revision-Date: 2020-03-21 16:28+0100\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+#: noggin/controller/authentication.py:42
+#: noggin/controller/authentication.py:53
+msgid "Could not log in to the IPA server."
+msgstr ""
+
+#: noggin/templates/404.html:3
+msgid "404: You've ruined everything."
+msgstr ""
+
+#: noggin/templates/404.html:10
+msgid "That page wasn't found. You've gone and ruined everything."
+msgstr ""
+

--- a/noggin/po/messages.pot
+++ b/noggin/po/messages.pot
@@ -1,0 +1,32 @@
+# Translations template for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-03-21 16:28+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.6.0\n"
+
+#: noggin/controller/authentication.py:42
+#: noggin/controller/authentication.py:53
+msgid "Could not log in to the IPA server."
+msgstr ""
+
+#: noggin/templates/404.html:3
+msgid "404: You've ruined everything."
+msgstr ""
+
+#: noggin/templates/404.html:10
+msgid "That page wasn't found. You've gone and ruined everything."
+msgstr ""
+

--- a/noggin/templates/404.html
+++ b/noggin/templates/404.html
@@ -1,13 +1,13 @@
 {% extends "main.html" %}
 
-{% block title %}404: You've ruined everything.{% endblock %}
+{% block title %}{% trans %}404: You've ruined everything.{% endtrans %}{% endblock %}
 
 {% block content %}
   {{ super() }}
   <div class="container section py-4">
     <div class="row">
       <div class="col">
-        <div class="alert alert-danger"><b>404</b> That page wasn't found. You've gone and ruined everything.</div>
+        <div class="alert alert-danger"><b>404</b> {% trans %}That page wasn't found. You've gone and ruined everything.{% endtrans %}</div>
       </div>
     </div>
   </div>

--- a/noggin/tests/unit/translations/cassettes/test_translations/test_translation_in_code_french.yaml
+++ b/noggin/tests/unit/translations/cassettes/test_translations/test_translation_in_code_french.yaml
@@ -1,0 +1,1064 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:19 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=fNzCkBuRo7QGYJTyiIAmiuLgGOi%2fnQBs1J1amqcFthzBKBizZhB6ErII07Ez6KEfQ8hc4J23wJrU%2fhHAx%2fMMKEm%2fV%2f21Bu5YMREGmAyloC%2ffrXM%2bzVlVnG4IKbJ9bh98ZLjA8bagBiQpkGgGWYwwBYVgDngHQMkwwnkCR6rG68scqWMGbVxbhTewGp8zaJ3R;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=fNzCkBuRo7QGYJTyiIAmiuLgGOi%2fnQBs1J1amqcFthzBKBizZhB6ErII07Ez6KEfQ8hc4J23wJrU%2fhHAx%2fMMKEm%2fV%2f21Bu5YMREGmAyloC%2ffrXM%2bzVlVnG4IKbJ9bh98ZLjA8bagBiQpkGgGWYwwBYVgDngHQMkwwnkCR6rG68scqWMGbVxbhTewGp8zaJ3R
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:19 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-04-02T04:17:19Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=fNzCkBuRo7QGYJTyiIAmiuLgGOi%2fnQBs1J1amqcFthzBKBizZhB6ErII07Ez6KEfQ8hc4J23wJrU%2fhHAx%2fMMKEm%2fV%2f21Bu5YMREGmAyloC%2ffrXM%2bzVlVnG4IKbJ9bh98ZLjA8bagBiQpkGgGWYwwBYVgDngHQMkwwnkCR6rG68scqWMGbVxbhTewGp8zaJ3R
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbU/bMBD+K1G+7EspaUmBTkJaxwraxkunDTYxUHWxr6nXxM5sp7RD/e/z2Qkd
+        EoMvcLmX587PPdeHWKOpCxu/jR7+NZl0/37GH+qyXEdXBnV814liLkxVwFpCic+FhRRWQGFC7Mr7
+        cmTKPJessl/ILCvAhLBVVezcFWqjJFlK5yDFH7BCSSi2fiHRuthTR02wVK6MWAFjqpaWvhc6q7SQ
+        TFRQQL1qXFawBdpKFYKtG69LCBM1H8bMW8wZmNZ0ga9mfqpVXV3OJnX2GdeG/CVWl1rkQo6l1etA
+        RgW1FL9rFNy/jx/uIQ5hf+cgHR7u9HoIO8MMBzuD/iBNksM04QC+kEZ27e+V5riqhPYEeIh+0k+S
+        1P1Jewe94U2b7Si01T1nc5A5vpSIK6uBgwVKeoin0wwM7qfTqfuOR6NPk5v0Glk5XPLj4fzmtFdl
+        i/cn38cnF1fj1cnZ4mLy7cvoKN7chQeXICFHjv7F1JXJI0477jgjJ4oMWc0yTIezI1xBWRVIJlOl
+        H6tu6aFK75mrErnQbhWqAd4l1+42owRRbIveNajdFtIEth6V5vbHNHoarSj/z5AbRdZl5qooY3jQ
+        d3tJ9g8el9Lq6FH+of34x+h8cjbuHl+e+9RCOR2YORZhxt1MyF1H9Dycwws9crFE+fS22t4MpJKC
+        vdq7cieMeonE6cxdIhKfYKatoJzb6rr1LnBtIdv6SqTJ1Gzqt+fbkIodognnT8QSTds9++Ara964
+        0iUUNQ3e7Nk3M8bpxwQt2nXlw/egpZA5JTRPja9dB7e6c2FME2lKvWonH6MmIQrERvdgIqlsZJwy
+        O9FMaYfJIzdI5SSQiULYtY/nNWiQFpF3o5ExdenQI8+efmMiAl4G4E7U7/b3BtSZKU5te3tJ0iNC
+        wi09xKFs2hTQYKFk44/FYZfgtRyPOEceEWvRbeDiNvYEodaKRCHroqBfD761H4VHAMDdnE/2Tuxu
+        +6bdw24ab/4CAAD//wMAimfoUtgFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:19 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=fNzCkBuRo7QGYJTyiIAmiuLgGOi%2fnQBs1J1amqcFthzBKBizZhB6ErII07Ez6KEfQ8hc4J23wJrU%2fhHAx%2fMMKEm%2fV%2f21Bu5YMREGmAyloC%2ffrXM%2bzVlVnG4IKbJ9bh98ZLjA8bagBiQpkGgGWYwwBYVgDngHQMkwwnkCR6rG68scqWMGbVxbhTewGp8zaJ3R
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_add", "params": [[], {"ipatokenowner": "dummy", "ipatokenotpalgorithm":
+      "sha512", "description": "dummy''s token"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '136'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTXW/aMBT9K1aksRc+kpCQDinaIvpBKyJSRhndOlVObMBa4mS2A0OI/75rw1o6
+        Xvpm+9xzfM699s4SVNa5svpod7pkFVblL8rLDacCTn5YpC6KrfWziSxCZSZYpVjJX5GPEhmCqfjH
+        rjn7XVNGTJlLnN7CcexW2k29lrcI3BZ23EXLdj+RIEh927/Ab9ilqghbMiUNvfcGUwAqVlCpaGXg
+        rv0/F+fLUjC1KgwuV9h3XFNTCwZHli6p1arf6Wixjknx5Woexcnoqj0Yx/33GP7MpKypCA37g2ef
+        8BuSZoKqcDzz455/eTcZeMNRcD0MHh5n8V08HLnBJIluppc33/3H8XVwP0qi0aw7+PZwO0nu5/PG
+        IXzYa7wkCb8OI0jRqKhgJQkhM8RR24rqPNPxNNH7AnO8pCTdPtfyfHZ6ZGfzCd8TtZnxEBrVJFlI
+        /+CiyqleZmVh7UF4jfNa2+B1nmsTVEpwYUa3e7G4wYIzvtQuOS7M0YwKCQ8phj4ekSNVg1Fyi44F
+        IFykVKANlgimiyS8gSZalAI0CQIXEImlLGdqa/BljQXmilLSRhHMqAB1IIk1FfBUtfD6INxEbtvt
+        +vrmrCT6Wqdr247uFVbYfIYD7flI0MYOlP1etxS0Cyy2xi8hlCCYw+EvoCfryTLdoUKU4rU75kcc
+        15VgPIOB5Frg7BFqWyf3eu2Ltmft/wIAAP//AwCb1tmrtgMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU224TMRD9FWtfeMllN02apFIlKqgQgqqVUBEqQtWsPdmYeu3Flyahyr/j8W4u
+        pRW8JJM5M2c8x8d5yiy6oHx2xp4O4fenjGv6zt6Hut6wW4c2+9FjmZCuUbDRUONrsNTSS1CuxW5T
+        rkJu3GvFC3DcInhptJcd3ygf5fk4foyLaTG/S3Wm/InccwWupfGmyWK6QeuMpsjYCrT8nZhAHfJS
+        o4/Y80Sg8dRunFwD5yZoT78fbNlYqblsQEFYdykv+QP6xijJN102FrQn6n44t9xxxo12YQS+uOUH
+        a0JzvbgJ5SfcOMrX2FxbWUl9qb3dtKI1ELT8FVCKtJ+YnSDO4bQ/Hc9n/aJA6M9LnPQno8k4z2fj
+        XACkRjpyHL8yVuC6kTYJcJBxmhck4yi/21VHCX2zEnwJunqp966wko+on9/wjoCDNlpyUHtYEPz2
+        8tvF1c3ny8G766tUujQ1CmmjSCYuSXVDSg3FMdle7v+Q1SDVEYxrqBuFA27qBAcpdKjLKDvVzKej
+        KFJ+Ok2Ya+XYW676R60y8VbcElU7bFhKPSzBLXdDDkdIGe068yjDHyK2iLZH8lV8RGgfURzlaqSZ
+        ZnFfkR8SEV16rHPtq6Jj0ozzxN/j+jyBFHRTXE/w8251Cmn7LfW2Bj5jRYy9DZqD/2u2c1Cha1+1
+        3zQkdbYCq6WuyJGd+tnXODD650o61yFdK4EXNx9ZV8BaBdkKHNPGM4fa99jC2MgpWDxXE31YSiX9
+        JuFVAAvaI4oBu3Au1JGdJYnsG8eI+LEl7rHRYHQyydJSgsYWJ3lOewnwkP6g2rb7roEO1rZskxSR
+        u4bkt6xgJCCrwfNllGMbUbTW0L3roBS9OnGI906k1pcmjBVHE8eD2WCcbf8AAAD//wMAhSox+zkF
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_mod", "params": [[], {"ipatokenuniqueid": "2d16f110-b3b4-4f72-a12f-029d77b5058a",
+      "ipatokendisabled": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '130'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RPMY4CMQz8ipXmmtMKHVsgKhBsB+IkGlqzMcgicVZ2ltMJ8XeSbSjp7JnxjOfh
+        lGwM2S1BxhC+wZFq0rI+XJ88laH9mc0LHskMrxVwR9I7KbDBKH8cAssVcoKB9JI0LmGD8pXBs+E5
+        EAS0DNhnvlNR3UhccfOYcQrxZP1nz3rCcklV+cn9WbSCcfp0W2LOaNRNpSrD/l11UJaeBwxV6scY
+        /1fdab3/3XXN5rCvmeUl4ySVb5tF07rnCwAA//8DAGKviwgxAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:20 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=2YLCoqjUJW5dA6lMwUCvP3nmyw3tDaMZ9ZQNIRi6OiwdlzBB%2bVPQxRkrk3EzAPrFLi4vT1i300CKqKFpj4EfWUIDAFniTBSPkR3YMlTKQWxuasNCfXTe1Z9xPJLmJjU7eCZOTn7ZfmgChCgAPlluW6Rm5dcsiGCX5NR1JmZkazFDu6I614385JVGDAjH6cwD;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=2YLCoqjUJW5dA6lMwUCvP3nmyw3tDaMZ9ZQNIRi6OiwdlzBB%2bVPQxRkrk3EzAPrFLi4vT1i300CKqKFpj4EfWUIDAFniTBSPkR3YMlTKQWxuasNCfXTe1Z9xPJLmJjU7eCZOTn7ZfmgChCgAPlluW6Rm5dcsiGCX5NR1JmZkazFDu6I614385JVGDAjH6cwD
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [[], {"ipatokenuniqueid": "2d16f110-b3b4-4f72-a12f-029d77b5058a"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=2YLCoqjUJW5dA6lMwUCvP3nmyw3tDaMZ9ZQNIRi6OiwdlzBB%2bVPQxRkrk3EzAPrFLi4vT1i300CKqKFpj4EfWUIDAFniTBSPkR3YMlTKQWxuasNCfXTe1Z9xPJLmJjU7eCZOTn7ZfmgChCgAPlluW6Rm5dcsiGCX5NR1JmZkazFDu6I614385JVGDAjH6cwD
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4yQTWvCQBCG/8qwl15MSGKstqdK66FQ0UMphSpl4k5k6WY3zG4Ukfz37mqgHnub
+        r+d9Z+YsmFynvXiE821Yo9IkQ/i17UcgDqg7ipkoZH5f53mWVOOqTMp6WiSYF3WSFQ9yOq0m2WSG
+        YhuQhpzDPblInYU/tZEXR2SjzF6EAYPNpfRB7JQ1S+Xc0BnQ2JyvX2EYANM1FTEc0YGxHhwZP4La
+        ctCUsLNNi15VSit/uvT3HTIaTyRTmDvXNUE9QHwgvnMQhQ9X4REUaTGeROedldE2H2dZHlKJHi/v
+        uGLfAxAXuyJ9H08N2g3yKZZfSJMnCav3NXj7QwY2/3rZRoj4Z2K2HHRMp3VIlfyLW1Zmp1rU0QZl
+        uOZp8Tlfrt8W6fNqGZe/2a5MZ2kp+l8AAAD//wMAU7YwC94BAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=2YLCoqjUJW5dA6lMwUCvP3nmyw3tDaMZ9ZQNIRi6OiwdlzBB%2bVPQxRkrk3EzAPrFLi4vT1i300CKqKFpj4EfWUIDAFniTBSPkR3YMlTKQWxuasNCfXTe1Z9xPJLmJjU7eCZOTn7ZfmgChCgAPlluW6Rm5dcsiGCX5NR1JmZkazFDu6I614385JVGDAjH6cwD
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JCI1%2bcDr63W5WyxgaZfcTYuLmaVyWMiz3xDplFISOjI4FNvdtqOHojRX3tL24mjMC%2f95gs48xq5lyfuStLozCS60Vqh1trro8h5YvtLOOrQYDNWS%2fNq5EvgpHknCEQh%2fhCqPTwfdEy0EtA1efEbC2t8VYVmmT9OvimZ9SZBtcTSAMF7iPAErrqrrYgis87in
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
+        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
+        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
+        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
+        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=wvVKX4foBordOjVZaKAkIEm9eAgDTlBquF%2bllDXKNwt11dxu6TeqKzMg795CpPbEVawtup6MI35LZJ0vJEcEk1LjMLTbc9rqccYzvIGsoGNns8YF%2f7fL6fdFoQO1epxg770%2b29XhAV4O2kA0OoD7FWzT9D6%2bMhUmXT%2bTLM0SCLWqEGvYYDkfuNBHUzauDYaw;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wvVKX4foBordOjVZaKAkIEm9eAgDTlBquF%2bllDXKNwt11dxu6TeqKzMg795CpPbEVawtup6MI35LZJ0vJEcEk1LjMLTbc9rqccYzvIGsoGNns8YF%2f7fL6fdFoQO1epxg770%2b29XhAV4O2kA0OoD7FWzT9D6%2bMhUmXT%2bTLM0SCLWqEGvYYDkfuNBHUzauDYaw
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
+        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
+        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
+        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
+        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wvVKX4foBordOjVZaKAkIEm9eAgDTlBquF%2bllDXKNwt11dxu6TeqKzMg795CpPbEVawtup6MI35LZJ0vJEcEk1LjMLTbc9rqccYzvIGsoGNns8YF%2f7fL6fdFoQO1epxg770%2b29XhAV4O2kA0OoD7FWzT9D6%2bMhUmXT%2bTLM0SCLWqEGvYYDkfuNBHUzauDYaw
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
+        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
+        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
+        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
+        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wvVKX4foBordOjVZaKAkIEm9eAgDTlBquF%2bllDXKNwt11dxu6TeqKzMg795CpPbEVawtup6MI35LZJ0vJEcEk1LjMLTbc9rqccYzvIGsoGNns8YF%2f7fL6fdFoQO1epxg770%2b29XhAV4O2kA0OoD7FWzT9D6%2bMhUmXT%2bTLM0SCLWqEGvYYDkfuNBHUzauDYaw
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
+        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
+        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
+        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
+        BzX+AQAA//8DADhciJlYAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Apr 2020 04:17:21 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/translations/test_translations.py
+++ b/noggin/tests/unit/translations/test_translations.py
@@ -1,11 +1,25 @@
+import os
+
 import pytest
 from bs4 import BeautifulSoup
+from babel.messages.frontend import compile_catalog
 
+import noggin
 from noggin.tests.unit.utilities import assert_redirects_with_flash
 
 
+@pytest.fixture
+def compile_catalogs():
+    cmd = compile_catalog()
+    cmd.directory = os.path.abspath(os.path.join(noggin.__path__[0], "translations"))
+    cmd.domain = ["messages"]
+    cmd.run()
+
+
 @pytest.mark.vcr()
-def test_translation_in_code_french(client, logged_in_dummy_user, dummy_user_with_otp):
+def test_translation_in_code_french(
+    client, logged_in_dummy_user, dummy_user_with_otp, compile_catalogs
+):
     """Test translations are working if the string is in the code"""
     headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}
     result = client.post(
@@ -21,7 +35,7 @@ def test_translation_in_code_french(client, logged_in_dummy_user, dummy_user_wit
     )
 
 
-def test_translation_in_template_french(client):
+def test_translation_in_template_french(client, compile_catalogs):
     """Test translations are working if the string is in the template"""
     headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}
     result = client.get("/this-should-give-a-404", headers=headers)
@@ -30,5 +44,5 @@ def test_translation_in_template_french(client):
     message = page.select_one(".alert.alert-danger")
     assert (
         message.get_text(strip=True)
-        == "404Cette page n'a pas été trouvée. Tu es parti et tu as tout gâché."
+        == "404Cette page n'a pas été trouvée. Et voilà, tu as tout gâché."
     )

--- a/noggin/tests/unit/translations/test_translations.py
+++ b/noggin/tests/unit/translations/test_translations.py
@@ -1,0 +1,34 @@
+import pytest
+from bs4 import BeautifulSoup
+
+from noggin.tests.unit.utilities import assert_redirects_with_flash
+
+
+@pytest.mark.vcr()
+def test_translation_in_code_french(client, logged_in_dummy_user, dummy_user_with_otp):
+    """Test translations are working if the string is in the code"""
+    headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}
+    result = client.post(
+        "/user/dummy/settings/otp/disable/",
+        data={"token": dummy_user_with_otp.uniqueid},
+        headers=headers,
+    )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="Désolé, vous ne pouvez pas désactiver votre dernier jeton actif.",
+        expected_category="warning",
+    )
+
+
+def test_translation_in_template_french(client):
+    """Test translations are working if the string is in the template"""
+    headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}
+    result = client.get("/this-should-give-a-404", headers=headers)
+    assert result.status_code == 404
+    page = BeautifulSoup(result.data, 'html.parser')
+    message = page.select_one(".alert.alert-danger")
+    assert (
+        message.get_text(strip=True)
+        == "404Cette page n'a pas été trouvée. Tu es parti et tu as tout gâché."
+    )

--- a/noggin/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/noggin/translations/fr_FR/LC_MESSAGES/messages.po
@@ -1,0 +1,37 @@
+# French (France) translations for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-04-01 10:26+0000\n"
+"PO-Revision-Date: 2020-04-01 10:26+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr_FR\n"
+"Language-Team: fr_FR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: noggin/controller/authentication.py:30
+#: noggin/controller/authentication.py:37
+msgid "Could not log in to the IPA server."
+msgstr "Impossible de se connecter au serveur IPA."
+
+#: noggin/controller/user.py:197
+msgid "Sorry, You cannot disable your last active token."
+msgstr "Désolé, vous ne pouvez pas désactiver votre dernier jeton actif."
+
+#: noggin/templates/404.html:3
+msgid "404: You've ruined everything."
+msgstr "404: Vous avez tout gâché."
+
+#: noggin/templates/404.html:10
+msgid "That page wasn't found. You've gone and ruined everything."
+msgstr "Cette page n'a pas été trouvée. Tu es parti et tu as tout gâché."
+

--- a/noggin/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/noggin/translations/fr_FR/LC_MESSAGES/messages.po
@@ -33,5 +33,5 @@ msgstr "404: Vous avez tout gâché."
 
 #: noggin/templates/404.html:10
 msgid "That page wasn't found. You've gone and ruined everything."
-msgstr "Cette page n'a pas été trouvée. Tu es parti et tu as tout gâché."
+msgstr "Cette page n'a pas été trouvée. Et voilà, tu as tout gâché."
 

--- a/noggin/translations/messages.pot
+++ b/noggin/translations/messages.pot
@@ -1,0 +1,36 @@
+# Translations template for PROJECT.
+# Copyright (C) 2020 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2020-04-01 10:26+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: noggin/controller/authentication.py:30
+#: noggin/controller/authentication.py:37
+msgid "Could not log in to the IPA server."
+msgstr ""
+
+#: noggin/controller/user.py:197
+msgid "Sorry, You cannot disable your last active token."
+msgstr ""
+
+#: noggin/templates/404.html:3
+msgid "404: You've ruined everything."
+msgstr ""
+
+#: noggin/templates/404.html:10
+msgid "That page wasn't found. You've gone and ruined everything."
+msgstr ""
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -53,7 +53,7 @@ six = "*"
 visualize = ["graphviz (>0.5.1)", "Twisted (>=16.1.1)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Internationalization utilities"
 name = "babel"
 optional = false
@@ -314,6 +314,20 @@ itsdangerous = ">=0.24"
 dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
 docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
 dotenv = ["python-dotenv"]
+
+[[package]]
+category = "main"
+description = "Adds i18n/l10n support to Flask applications"
+name = "flask-babel"
+optional = false
+python-versions = "*"
+version = "1.0.0"
+
+[package.dependencies]
+Babel = ">=2.3"
+Flask = "*"
+Jinja2 = ">=2.5"
+pytz = "*"
 
 [[package]]
 category = "main"
@@ -1186,7 +1200,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 deploy = ["gunicorn"]
 
 [metadata]
-content-hash = "0715a0585aef39a8653f466c4fc47c51ea1595f96f773dd2c7651c50da97f1c0"
+content-hash = "bf2adec017b24cf792b3bc9f5f77c17805e8f036d600a47fdf088a6f216653bb"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1371,6 +1385,10 @@ flake8 = [
 flask = [
     {file = "Flask-1.1.1-py2.py3-none-any.whl", hash = "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"},
     {file = "Flask-1.1.1.tar.gz", hash = "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52"},
+]
+flask-babel = [
+    {file = "Flask-Babel-1.0.0.tar.gz", hash = "sha256:d6a70468f9a8919d59fba2a291a003da3a05ff884275dddbd965f3b98b09ab3e"},
+    {file = "Flask_Babel-1.0.0-py3-none-any.whl", hash = "sha256:247f4ec34cf605d03781f480bccb1a5acb719df1d1a2a743c091ab3db5d5fde2"},
 ]
 flask-mail = [
     {file = "Flask-Mail-0.9.1.tar.gz", hash = "sha256:22e5eb9a940bf407bcf30410ecc3708f3c56cc44b29c34e1726fe85006935f41"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ fedora-messaging = "^2.0.1"
 backoff = "^1.10.0"
 noggin-messages = {git = "https://github.com/fedora-infra/noggin-messages.git"}
 whitenoise = "^5.0.1"
+flask-babel = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"


### PR DESCRIPTION
This takes the commit from PR #172 and updates it to make translation fully functional. #172 was a proof of concept of extracting the strings, but we need to fully functioning to be able to pass the tests, so here we are.

I have not flagged many more strings for translation, figured that I could do that in my next PR. 

a couple of notes:

* the comment in the commit of #172 about f-strings still applies. it looks like we will have to convert these back to format()

* the translated strings in this PR were done with an automated translation tool. Apologies if these translations make you laugh.