### PR TITLE
Abstract out the index.html text

### DIFF
--- a/noggin/templates/index.html
+++ b/noggin/templates/index.html
@@ -7,12 +7,7 @@
     <div class="container section">
       <div class="row">
         <div class="col-md-7">
-          <h2 class="display-4">Welcome to noggin!</h2>
-          <p class="lead">
-            This is the open source, community self-service portal for FreeIPA.
-            It allows you to do things like create an account, change your
-            password, manage group membership, and more.
-          </p>
+          {{ front_page_blurb() }}
         </div>
         <div class="col">
           <div class="card">

--- a/noggin/themes/default/templates/main.html
+++ b/noggin/themes/default/templates/main.html
@@ -69,6 +69,18 @@
 {% endblock %}
 
 
+{# a required macro defining text to show on the unlogged in index page #}
+{% macro front_page_blurb() %}
+<h2 class="display-4">Welcome to noggin!</h2>
+<p class="lead">
+  This is the open source, community self-service portal for FreeIPA.
+  It allows you to do things like create an account, change your
+  password, manage group membership, and more.
+</p>
+{% endmacro %}
+
+
+
 {# an optional macro defining an element to show for editing group details #}
 {# typically, it used to link to a ticket tracker for an admin to edit a group #}
 {#
@@ -88,3 +100,5 @@
 {% macro lost_otp_token() %}
 {% endmacro %}
 #}
+
+

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -80,6 +80,15 @@
     </li>
 {% endblock %}
 
+
+{% macro front_page_blurb() %}
+<h2 class="display-4">Fedora Accounts</h2>
+<p class="lead">
+  Fedora Accounts allows you to create and manage an account for Fedora Tools and Infrastructure.
+</p>
+{% endmacro %}
+
+
 {# an optional macro defining an element to show for editing group details #}
 {# typically, it used to link to a ticket tracker for an admin to edit a group #}
 {% macro edit_group_details() %}

--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -86,6 +86,15 @@
     </li>
 {% endblock %}
 
+{% macro front_page_blurb() %}
+<h2 class="display-4">Welcome to noggin!</h2>
+<p class="lead">
+  This is the open source, community self-service portal for FreeIPA.
+  It allows you to do things like create an account, change your
+  password, manage group membership, and more.
+</p>
+{% endmacro %}
+
 {# an optional macro defining an element to show for editing group details #}
 {# typically, it used to link to a ticket tracker for an admin to edit a group #}
 {% macro edit_group_details() %}


### PR DESCRIPTION
Previously, the text that shows on the front page
to users that arent logged in was generic noggin
boilerplate. This converts that text into a required
macro for the themes, so they can define their own
text to put there.

Resolves: #185

Signed-off-by: Ryan Lerch <rlerch@redhat.com>