### PR TITLE
Add dirty form checking to user settings

### DIFF
--- a/noggin/static/js/vendor/jquery.dirty-0.7.2/LICENSE
+++ b/noggin/static/js/vendor/jquery.dirty-0.7.2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Simon Taite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/noggin/static/js/vendor/jquery.dirty-0.7.2/README.md
+++ b/noggin/static/js/vendor/jquery.dirty-0.7.2/README.md
@@ -1,0 +1,41 @@
+# jquery.dirty
+
+A jQuery plugin to determine when a form has been modified (dirtied) and act accordingly
+
+All state information about the form is held in the data object for the form rather than adding `data-` attributes to the DOM
+
+# Gitter
+
+[https://gitter.im/jquerydirty/Lobby](https://gitter.im/jquerydirty/Lobby)
+
+
+# Usage
+
+`$("#myForm").dirty();`
+
+# Options
+* `preventLeaving` - boolean indicating whether on not to show a warning if the user attempts to navigate away from the form with pending changes
+
+    * Default: false
+* `leavingMessage` - message to display when preventLeaving is true
+
+    * Default: 'There are unsaved changes on this page which will be discarded if you continue.'
+* `onDirty` - function called when form is modified
+
+* `onClean` - function called when form is restored to original state
+
+# Methods
+`$("#myForm").dirty("isDirty");` returns true if a form has been modified
+
+`$("#myForm").dirty("isClean");` returns true if a form has not been modified
+
+`$("#myForm").dirty("refreshEvents");` remove and reapply events. Can be used if content is dynamically added to form
+
+`$("#myForm").dirty("resetForm");` reset the form to the original state when `$("#myForm").dirty();` was called
+
+`$("#myForm").dirty("setAsClean");` set the current state of the formas the 'clean' state. Calling `resetForm` after this will restore the form to the state when `setAsClean`was called
+
+`$("#myForm").dirty("showDirtyFields");` returns jQuery array of all modified fields in the form
+
+# Credits
+Thanks to Tomasz Świenty for feedback and a fix for an issue where a value could resolve as `null`

--- a/noggin/static/js/vendor/jquery.dirty-0.7.2/jquery.dirty.js
+++ b/noggin/static/js/vendor/jquery.dirty-0.7.2/jquery.dirty.js
@@ -1,0 +1,319 @@
+/*
+ * Dirty 
+ * jquery plugin to detect when a form is modified
+ * (c) 2016 Simon Taite - https://github.com/simontaite/jquery.dirty
+ * originally based on jquery.dirrty by Ruben Torres - https://github.com/rubentd/dirrty
+ * Released under the MIT license
+ */
+
+(function($) {
+
+    //Save dirty instances
+    var singleDs = [];
+    var dirty = "dirty";
+    var clean = "clean";
+    var dataInitialValue = "dirtyInitialValue";
+    var dataIsDirty = "isDirty";
+
+    var getSingleton = function(id) {
+        var result;
+        singleDs.forEach(function(e) {
+            if (e.id === id) {
+                result = e;
+            }
+        });
+        return result;
+    };
+
+    var setSubmitEvents = function(d) {
+        d.form.on("submit", function() {
+            d.submitting = true;
+        });
+
+        if (d.options.preventLeaving) {
+            $(window).on("beforeunload", function() {
+                if (d.isDirty && !d.submitting) {
+                    return d.options.leavingMessage;
+                }
+            });
+        }
+    };
+
+    var setNamespacedEventTriggers = function(d) {
+
+        d.form.find("input, select, textarea").on("change click keyup keydown blur", function(e) {
+            $(this).trigger(e.type + ".dirty");
+        });
+    };
+
+    var setNamespacedEvents = function(d) {
+
+        d.form.find("input, select, textarea").on("change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty", function(e) {
+            d.checkValues(e);
+        });
+
+        d.form.on("dirty", function() {
+            d.options.onDirty();
+        });
+
+        d.form.on("clean", function() {
+            d.options.onClean();
+        });
+    };
+
+    var clearNamespacedEvents = function(d) {
+        d.form.find("input, select, textarea").off("change.dirty click.dirty keyup.dirty keydown.dirty blur.dirty");
+
+        d.form.off("dirty");
+
+        d.form.off("clean");
+    };
+
+    var Dirty = function(form, options) {
+        this.form = form;
+        this.isDirty = false;
+        this.options = options;
+        this.history = [clean, clean]; //Keep track of last statuses
+        this.id = $(form).attr("id");
+        singleDs.push(this);
+    };
+
+    Dirty.prototype = {
+        init: function() {
+            this.saveInitialValues();
+            this.setEvents();
+        },
+
+        isRadioOrCheckbox: function(el){
+            return $(el).is(":radio, :checkbox");
+        },
+
+        isFileInput: function(el){
+            return $(el).is(":file")
+        },
+
+        saveInitialValues: function() {
+            var d = this;
+            this.form.find("input, select, textarea").each(function(_, e) {
+
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(e);
+                var isFile = d.isFileInput(e);
+
+                if (isRadioOrCheckbox) {
+                    var isChecked = $(e).is(":checked") ? "checked" : "unchecked";
+                    $(e).data(dataInitialValue, isChecked);
+                } else if(isFile){
+                    $(e).data(dataInitialValue, JSON.stringify(e.files))
+                } else {
+                    $(e).data(dataInitialValue, $(e).val() || '');
+                }
+            });
+        },
+
+        refreshEvents: function () {
+            var d = this;
+            clearNamespacedEvents(d);
+            setNamespacedEvents(d);
+        },
+
+        showDirtyFields: function() {
+            var d = this;
+
+            return d.form.find("input, select, textarea").filter(function(_, e){
+                return $(e).data("isDirty");
+            });
+        },
+
+        setEvents: function() {
+            var d = this;
+
+            setSubmitEvents(d);
+            setNamespacedEvents(d);
+            setNamespacedEventTriggers(d);
+        },
+
+        isFieldDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+             // Explicitly check for null/undefined here as value may be `false`, so ($field.data(dataInitialValue) || '') would not work
+            if (initialValue == null) { initialValue = ''; }
+            var currentValue = $field.val();
+            if (currentValue == null) { currentValue = ''; }
+
+            // Boolean values can be encoded as "true/false" or "True/False" depending on underlying frameworks so we need a case insensitive comparison
+            var boolRegex = /^(true|false)$/i;
+            var isBoolValue = boolRegex.test(initialValue) && boolRegex.test(currentValue);
+            if (isBoolValue) {
+                var regex = new RegExp("^" + initialValue + "$", "i");
+                return !regex.test(currentValue);
+            }
+
+            return currentValue !== initialValue;
+        },
+
+        isFileInputDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+
+            var plainField = $field[0];
+            var currentValue = JSON.stringify(plainField.files);
+
+            return currentValue !== initialValue;
+        },
+
+        isCheckboxDirty: function($field) {
+            var initialValue = $field.data(dataInitialValue);
+            var currentValue = $field.is(":checked") ? "checked" : "unchecked";
+
+            return initialValue !== currentValue;
+        },
+
+        checkValues: function(e) {
+            var d = this;
+            var formIsDirty = d.isDirty;
+
+            this.form.find("input, select, textarea").each(function(_, el) {
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(el);
+                var isFile = d.isFileInput(el);
+                var $el = $(el);
+
+                var thisIsDirty;
+                if (isRadioOrCheckbox) {
+                    thisIsDirty = d.isCheckboxDirty($el);
+                } else if (isFile) {
+                    thisIsDirty = d.isFileInputDirty($el);
+                } else {
+                    thisIsDirty = d.isFieldDirty($el);
+                }
+                
+                $el.data(dataIsDirty, thisIsDirty);
+
+                formIsDirty |= thisIsDirty;                
+            });
+
+            if (formIsDirty) {
+                d.setDirty();
+            } else {
+                d.setClean();
+            }
+                       
+            if (e) {
+                e.stopImmediatePropagation();
+            }
+        },
+
+        setDirty: function() {
+            this.isDirty = true;
+            this.history[0] = this.history[1];
+            this.history[1] = dirty;
+
+            if (this.options.fireEventsOnEachChange || this.wasJustClean()) {
+                this.form.trigger("dirty");
+            }
+        },
+
+        setClean: function() {
+            this.isDirty = false;
+            this.history[0] = this.history[1];
+            this.history[1] = clean;
+
+            if (this.options.fireEventsOnEachChange || this.wasJustDirty()) {
+                this.form.trigger("clean");
+            }
+        },
+
+        //Lets me know if the previous status of the form was dirty
+        wasJustDirty: function() {
+            return (this.history[0] === dirty);
+        },
+
+        //Lets me know if the previous status of the form was clean
+        wasJustClean: function() {
+            return (this.history[0] === clean);
+        },
+
+        setAsClean: function(){
+            this.saveInitialValues();
+            this.setClean();
+        },
+
+        setAsDirty: function(){
+            this.saveInitialValues();
+            this.setDirty();
+        },
+
+        resetForm: function(){
+            var d = this;
+            this.form.find("input, select, textarea").each(function(_, e) {
+
+                var $e = $(e);
+                var isRadioOrCheckbox = d.isRadioOrCheckbox(e);
+                var isFile = d.isFileInput(e);
+
+                if (isRadioOrCheckbox) {
+                    var initialCheckedState = $e.data(dataInitialValue);
+                    var isChecked = initialCheckedState === "checked";
+
+                    $e.prop("checked", isChecked);
+                } if(isFile) {
+                    e.value = "";
+                    $(e).data(dataInitialValue, JSON.stringify(e.files))
+
+                } else {
+                    var value = $e.data(dataInitialValue);
+                    $e.val(value);
+                }
+            });
+
+            this.checkValues();
+        }
+    };
+
+    $.fn.dirty = function(options) {
+
+        if (typeof options === "string" && /^(isDirty|isClean|refreshEvents|resetForm|setAsClean|setAsDirty|showDirtyFields)$/i.test(options)) {
+            //Check if we have an instance of dirty for this form
+            // TODO: check if this is DOM or jQuery object
+            var d = getSingleton($(this).attr("id"));
+
+            if (!d) {
+                d = new Dirty($(this), options);
+                d.init();
+            }
+            var optionsLowerCase = options.toLowerCase();
+
+            switch (optionsLowerCase) {
+            case "isclean":
+                return !d.isDirty;
+            case "isdirty":
+                return d.isDirty;
+            case "refreshevents":
+                d.refreshEvents();
+            case "resetform":
+                d.resetForm();
+            case "setasclean":
+                return d.setAsClean();
+            case "setasdirty":
+                return d.setAsDirty();
+            case "showdirtyfields":
+                return d.showDirtyFields();            
+            }
+
+        } else if (typeof options === "object" || !options) {
+
+            return this.each(function(_, e) {
+                options = $.extend({}, $.fn.dirty.defaults, options);
+                var dirty = new Dirty($(e), options);
+                dirty.init();
+            });
+
+        }
+    };
+
+    $.fn.dirty.defaults = {
+        preventLeaving: false,
+        leavingMessage: "There are unsaved changes on this page which will be discarded if you continue.",
+        onDirty: $.noop, //This function is fired when the form gets dirty
+        onClean: $.noop, //This funciton is fired when the form gets clean again
+        fireEventsOnEachChange: false, // Fire onDirty/onClean on each modification of the form
+    };
+
+})(jQuery);

--- a/noggin/templates/_form_macros.html
+++ b/noggin/templates/_form_macros.html
@@ -39,3 +39,8 @@
     </div>
   {% endif %}
 {% endmacro %}
+
+{% macro unsaved_changes() %}
+<script src="{{ url_for('static', filename='js/vendor/jquery.dirty-0.7.2/jquery.dirty.js') }}"></script>
+<script>$("form").dirty({preventLeaving: true})</script>
+{% endmacro %}

--- a/noggin/templates/user-settings-keys.html
+++ b/noggin/templates/user-settings-keys.html
@@ -15,3 +15,7 @@
               </form>
 {% endblock %}
 
+{% block scripts %}
+  {{ super () }}
+  {{ macros.unsaved_changes() }}
+{% endblock %}

--- a/noggin/templates/user-settings-profile.html
+++ b/noggin/templates/user-settings-profile.html
@@ -24,3 +24,8 @@
 </form>
 {% endblock %}
 
+{% block scripts %}
+  {{ super () }}
+  {{ macros.unsaved_changes() }}
+{% endblock %}
+


### PR DESCRIPTION
This adds dirty form checking to user profile settings,
and user keys settings. If a user makes a change to these
forms, then tries to leave the page, a dialog is presented
alerting them to the fact they have unsaved changes.

Resolves: #182

Signed-off-by: Ryan Lerch <rlerch@redhat.com>