### PR TITLE
make QR code modal show when document loads

### DIFF
--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -79,7 +79,7 @@
   {% if otp_uri %}
   <script src="{{ url_for('static', filename='js/vendor/jquery-qrcode-1.0/jquery.qrcode.min.js') }}"></script>
   <script>
-    $(window).on('load',function(){
+    $(document).ready(function() {
         $('#otp-modal').modal('show');
         $('#otp-qrcode').qrcode("{{ otp_uri|safe }}");
         $('#otp-toggle').click(function() {


### PR DESCRIPTION
Previoiusly, the method we were using for showing
the QR code otp modal was waiting for images and
other resources on the page to load before showing the
dialog. Now wer use the document.ready to show the modal
straight away

Resolves: #179

Signed-off-by: Ryan Lerch <rlerch@redhat.com>