### PR TITLE
make loggedin change password form otp aware

### DIFF
--- a/noggin/controller/password.py
+++ b/noggin/controller/password.py
@@ -89,6 +89,12 @@ def user_settings_password(ipa, username):
     user = User(user_or_404(ipa, username))
     form = PasswordResetForm()
 
+    # check if an OTP token exists. If so, the user is using OTP.
+    using_otp = bool(ipa.otptoken_find(ipatokenowner=username))
+
+    if not using_otp:
+        form.current_password.description = ""
+
     if form.validate_on_submit():
         res = _validate_change_pw_form(form, username, ipa)
         if res and res.ok:
@@ -99,6 +105,7 @@ def user_settings_password(ipa, username):
         user=user,
         password_reset_form=form,
         activetab="password",
+        using_otp=using_otp,
     )
 
 

--- a/noggin/templates/user-settings-password.html
+++ b/noggin/templates/user-settings-password.html
@@ -6,10 +6,12 @@
   <div class="card-body">
     <h5 id="pageheading">{{ _("Change Password") }}</h5>
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    <div class="form-group">{{ macros.with_errors(password_reset_form.current_password, tabindex="2")}}</div>
+    <div class="form-group" id="currentpasswordinput">{{ macros.with_errors(password_reset_form.current_password, tabindex="2")}}</div>
     <div class="form-group">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
     <div class="form-group">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
-    <div class="form-group">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+    {% if using_otp %}
+    <div class="form-group" id="otpinput">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+    {% endif %}
   </div>
   <div class="card-footer d-flex justify-content-between">
     <div>{{ macros.non_field_errors(password_reset_form) }}</div>

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_non_matching_passwords_user.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_non_matching_passwords_user.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:51 GMT
+      - Tue, 21 Apr 2020 04:14:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=GssXwH4dcWWgxcbFQyf7n1jmDNlpcfHHzWxvrqBty%2bZQFWWNyzZk%2fQ5CJOiLjth9mBcMzecPajfXd3Y%2flzNSDEIRPF3Ddmi6VPB8zKAPxyUkQvi%2f0tEr1JlgoB499QDzrLk8wNDiHkU1Map9lwS3F7ScPHzvphKqap7zXtIPP%2f9CeHOSAG1vYy7wLNQJfzdn;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=1m2QmWlvBP%2f371rxu3yBen18tPWeMShpZziV9Oesf25Kfex%2bmpyd9nYhTGE91yXE2w72TYCXhvIld87N5G3HqEpOMb9qXcRDmycbqWcr%2f2giETpPly3YzB1yxWywdT%2foP1eL34mLh3lCCOYNyB67hSX3qK%2f7YuiyqMa0ywXHxfpN7xPoYbkGR4JcIwgadqJU;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=GssXwH4dcWWgxcbFQyf7n1jmDNlpcfHHzWxvrqBty%2bZQFWWNyzZk%2fQ5CJOiLjth9mBcMzecPajfXd3Y%2flzNSDEIRPF3Ddmi6VPB8zKAPxyUkQvi%2f0tEr1JlgoB499QDzrLk8wNDiHkU1Map9lwS3F7ScPHzvphKqap7zXtIPP%2f9CeHOSAG1vYy7wLNQJfzdn
+      - ipa_session=MagBearerToken=1m2QmWlvBP%2f371rxu3yBen18tPWeMShpZziV9Oesf25Kfex%2bmpyd9nYhTGE91yXE2w72TYCXhvIld87N5G3HqEpOMb9qXcRDmycbqWcr%2f2giETpPly3YzB1yxWywdT%2foP1eL34mLh3lCCOYNyB67hSX3qK%2f7YuiyqMa0ywXHxfpN7xPoYbkGR4JcIwgadqJU
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -74,11 +74,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -91,11 +91,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:52 GMT
+      - Tue, 21 Apr 2020 04:14:26 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-14T13:19:51Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-21T04:14:26Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=GssXwH4dcWWgxcbFQyf7n1jmDNlpcfHHzWxvrqBty%2bZQFWWNyzZk%2fQ5CJOiLjth9mBcMzecPajfXd3Y%2flzNSDEIRPF3Ddmi6VPB8zKAPxyUkQvi%2f0tEr1JlgoB499QDzrLk8wNDiHkU1Map9lwS3F7ScPHzvphKqap7zXtIPP%2f9CeHOSAG1vYy7wLNQJfzdn
+      - ipa_session=MagBearerToken=1m2QmWlvBP%2f371rxu3yBen18tPWeMShpZziV9Oesf25Kfex%2bmpyd9nYhTGE91yXE2w72TYCXhvIld87N5G3HqEpOMb9qXcRDmycbqWcr%2f2giETpPly3YzB1yxWywdT%2foP1eL34mLh3lCCOYNyB67hSX3qK%2f7YuiyqMa0ywXHxfpN7xPoYbkGR4JcIwgadqJU
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227aQBD9FcsvfQGCAROoFKk0JVHT5lK1Sas0ERrvDmaLvevuhUuj/Hv3YkMj
-        pckT6zMzZ2bPnOUhlqhMoeO30cO/R8Ltz8/4gynLbXStUMb3rSimTFUFbDmU+FyYcaYZFCrErj2W
-        IxHquWSR/UKiSQEqhLWoYgtXKJXg7iRkDpz9Ac0Eh2KPM47axp4CxtG6cqHYBggRhmv3vZRZJRkn
-        rIICzKaGNCNL1JUoGNnWqE0IE9UfSi0azjmo5mgDX9XiVApTXc6vTPYJt8rhJVaXkuWMT7mW2yBG
-        BYaz3wYZ9fcbz+fpcJgO24eY9tpJgtAejYdZO+2lg24Xet1slPhCN7JtvxaS4qZi0gvgKXrdXrc7
-        SAZJPxmnyW2TbSXU1ZqSBfAcX0rEjZZAQYNLeohnswwUDgezmf2OJ5Ozvjm7QVKOV/R4vLg9Taps
-        +f7k+/Tk4nq6Ofm8vLj69mVyFD/ehwuXwCFHiv7GrivhR9TtuGUPuZNIuVO9DNWi5Ag3UFYFuiMR
-        pR/Liksk+jtqVv5/fBUk2NmnBFZ4xLd8VzN3GtqcrZA/9WmNU27KzJI4PDlMh7ZVPx3tlG/MsqsN
-        /NMfk/Orz9PO8eW5Ty2EXbZaYBGGOMgYP7BqLhoeAlxwRl7lMbU76G7ChSiRMmmdKGpdDxx0sM8w
-        L92hso8Y5Qod7dy+RXSUoGaNpSyspWnQJW41ZHusRMcr5jO/P8/vfGwZvc0XjNp9t8Nywz+CW4ub
-        aL96n/3K5h9t6QoK46Sp7+67K2UtpYI99bby4TVIznjuEmox4xvbwRrmnClVR+pSb+Srj1GdEAWd
-        ojWoiAsdKWvWVjQX0nLSyA5SWeNlrGB66+O5AQlcI9JONFHKlJY98nLKNypyxKtA3Ip6nV4/dZ2J
-        oK5t0u92EydIeF4PcSib1QVusFDy6N+P5S7B7zeeWE1p5FSL7oIWd7EXCKUUbsfcFIX7Q6H7886m
-        jgConfOJs5y6+76DzqgziB//AgAA//8DAPzjd8PrBQAA
+        H4sIAAAAAAAAA4RUW2/aMBT+K1Fe9gI0AYLopEpjHa2q9cK0dZu6VujEPiQeiZ3ZDpCh/vf5kpRW
+        qtanHJ/v3Pydz9mHElVd6PB9sH9uEm4+v8JPdVk2wa1CGT70gpAyVRXQcCjxNZhxphkUymO3zpch
+        Eeq1YJH+RqJJAcrDWlShcVcoleDWEjIDzv6CZoJDcfAzjtpgLx21LWvThWI7IETUXNvzWqaVZJyw
+        Cgqod61LM7JGXYmCkab1mgA/UXtQKu9qrkB1pgG+qvxcirq6WS3q9DM2yvpLrG4kyxifcy0bT0YF
+        NWd/amTU3e94shpBQrE/HU0n/ThG6AMd0X4yTMZRhBQRJi7Rjmzab4WkuKuYdAS4EsNoGEXjYRyN
+        4/EwueuiDYW62lKSA8/wf4G40xIoaLBB+3C5TEHhZLxcmnM4m13kJEmQlMcbenqc353HVbr+ePZj
+        fnZ9O9+dXa6vF9++zE7Cxwd/4RI4ZGZud2PblfATanfcM0ZmKVLWapehepSc4A7KqkBrElG6sUpg
+        hct2qR/aiEEHZ4zyukwN+zYmnoyTaRRFSeLAQhjGVY6Fr3CUMn5krpQ7sP5f5nNZPKnZTzD/Obta
+        XM4HpzdXXZ0D6jy5KJEyabQi2psfWdfRISJjG+QvX0nXlgAXnJE32xrREYlu95qVr6x14teqvDSe
+        nlVlHjHKDdqhV+Ytoh0Y1LKTlHFrWXfeNTYa0oOvRMuYWC3d/lxlq2NTUfkfgO1mKTls2oFvLPrR
+        pG6gqO01WiJdM6WMgpRXo24qB29BcsYzG9BSFH43HQwPV0ypFmlTnW4XF0EbEPiFB1tQARc6UEab
+        vWAlpKlJAzNIZfhMWcF04/CsBglcI9JBMFOqLk31wLEn36nAFt74wr1gOBiOJrYzEdS2jUdRFFtC
+        /Gvahz5t2SbYwXzKo3supnYJTizhjFKkgWUtuPdc3IeOIJRSWLHyuijs/4Me7Cet2gJAzZwv9GLZ
+        PfQdD6YD0/cfAAAA//8DAIEV5KLaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,11 +157,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:52 GMT
+      - Tue, 21 Apr 2020 04:14:26 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=GssXwH4dcWWgxcbFQyf7n1jmDNlpcfHHzWxvrqBty%2bZQFWWNyzZk%2fQ5CJOiLjth9mBcMzecPajfXd3Y%2flzNSDEIRPF3Ddmi6VPB8zKAPxyUkQvi%2f0tEr1JlgoB499QDzrLk8wNDiHkU1Map9lwS3F7ScPHzvphKqap7zXtIPP%2f9CeHOSAG1vYy7wLNQJfzdn
+      - ipa_session=MagBearerToken=1m2QmWlvBP%2f371rxu3yBen18tPWeMShpZziV9Oesf25Kfex%2bmpyd9nYhTGE91yXE2w72TYCXhvIld87N5G3HqEpOMb9qXcRDmycbqWcr%2f2giETpPly3YzB1yxWywdT%2foP1eL34mLh3lCCOYNyB67hSX3qK%2f7YuiyqMa0ywXHxfpN7xPoYbkGR4JcIwgadqJU
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -195,11 +195,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -212,11 +212,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:52 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -263,11 +263,11 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:52 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:52 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=54KCTLPT0V3l%2fJMNkW3GwQJCTbX24V5OeQ4rFBXXEOSvQgy%2bjsnwD4JccUxl1eAzkm2NnmctE59Huc0oQyTzuJ8JG10C%2fWLXVW5QtgeahPL4y1rrbqjzF1PeFXDDo%2f1RCHcbyxIdHU9QvDHDCTMmpc5jlOnUbt%2bF9hw15hXP566pAJrVakGX9ll2jTm4V%2f2g;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=54KCTLPT0V3l%2fJMNkW3GwQJCTbX24V5OeQ4rFBXXEOSvQgy%2bjsnwD4JccUxl1eAzkm2NnmctE59Huc0oQyTzuJ8JG10C%2fWLXVW5QtgeahPL4y1rrbqjzF1PeFXDDo%2f1RCHcbyxIdHU9QvDHDCTMmpc5jlOnUbt%2bF9hw15hXP566pAJrVakGX9ll2jTm4V%2f2g
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -354,11 +354,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -371,11 +371,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=54KCTLPT0V3l%2fJMNkW3GwQJCTbX24V5OeQ4rFBXXEOSvQgy%2bjsnwD4JccUxl1eAzkm2NnmctE59Huc0oQyTzuJ8JG10C%2fWLXVW5QtgeahPL4y1rrbqjzF1PeFXDDo%2f1RCHcbyxIdHU9QvDHDCTMmpc5jlOnUbt%2bF9hw15hXP566pAJrVakGX9ll2jTm4V%2f2g
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -410,19 +410,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUbWvbMBD+K8Jf9iVJbSdO00JhZStjbKWF0TE6RjlLF1urLHmS3CQt+e/TyU7S
-        bh37lPM99/rcozwlFl2nfHLKng7m96eEa/pN3ndNs2E3Dm3yY8QSIV2rYKOhwddgqaWXoFyP3URf
-        hdy414KX4LhF8NJoL4d6eZqn6SybZdPspMhuY5wpfyL3XIHry3jTJsHdonVGk2VsBVo+xkqgDn6p
-        0QfspaOj9pRunFwD56bTnr7vbdlaqblsQUG3Hlxe8nv0rVGSbwZvCOgnGj6cq3c1w0Y7MwBfXP3B
-        mq69Wl535SfcOPI32F5ZWUl9ob3d9KS10Gn5q0Mp4n4ny2Uxnxfz8TEW+TjLEMaLk3k5LvJilqaQ
-        p+Uii4k0cmi/MlbgupU2EnCg8TiQSDTmt7voQKFvV4LXoKtX+D4EctBGSw5qf2hBt3t78e388vrz
-        xeTd1WUMVSZs4mpUKgYdlVIfleDqCDYg1bNcXEPTKpxw00S4G9aNaK8U+YD6pbT2e+5O85+BatOg
-        kDZcxwR240zkOjo0cT1DexVWUuiuKcMXubPjYh4YmRaL3Yz/BrUb5KMMvw8ByyB8JGWFZ4T2AcUz
-        X4NUxSzvKlJErEZnD3FRFbUUAvU4gq5/aDQm9T+Lo4+4PovRZAxt3Ujws4FVMonYLeX2mj5lWbC9
-        7TQH/8cwzkGFrn/oftMSo8kKrJa6onEGkpOvoWGQ1KV0bkCGVALPrz+yIYD1JLEVOKaNZw61H7Gl
-        saGmYGGuNkizlEr6TcSrDixojygm7Ny5rgnVWeTMvnGMCj/0hUcsn+TTIolLCWqbTdOU9hLgIf5n
-        9Wl3QwIN1qdsIxWhdgNRCUnGiEDWgOd1oGMbULTW0Gl1pxQ9RHGw94Kj1L+1FiKedZxNFpNZsv0N
-        AAD//wMAAwBmq0wFAAA=
+        H4sIAAAAAAAAA4RU2W7UMBT9FSsvvMySzNahUiUqqBCCqpVQESpC1R37TmLq2MFLZ0LVf8fXySyF
+        Cp7GOeeux8fzmFl0QfnslD0ejt8eM67pN3sX6rplNw5t9n3AMiFdo6DVUONLtNTSS1Cu424SViI3
+        7qXgNThuEbw02su+3iSf5PlsUuSzYjZZ3KY4s/qB3HMFrivjTZNFuEHrjKaTsSVo+StVAnXApUYf
+        uedAoPaUbpzcAucmaE/f93bVWKm5bEBB2PaQl/wefWOU5G2PxoBuov7DuWpXM260O0bis6veWxOa
+        q/V1WH3E1hFeY3NlZSn1hfa27URrIGj5M6AUab/Xi/UU5gKHy+lyMSwKhCGIqRjOJ/NZnqNAhEVK
+        pJFj+42xAreNtEmAg4wnJGWU8eR2Fx0l9M1G8Ap0+YLefWCQQod6FfegiGIxmy/zPJ/PE1mZGoW0
+        cX0Tx6eAMUFjQXe7S0/4ATmWdu+cRL+5+Hp+ef3pYvT26rIzy796xzoctNGS/7eO63TYe60GqY7C
+        cQt1o3DETd23fUD93NQJVybelKtQdcnjldTjFbgqkdr19lGG30d+HY2P5Kz4jNA+oDjCaqSlzPqu
+        JEekYnTtMc5174rmJenO0oADrs8SSYe+ixsIftYPTkea/YlyOwufsiKevQ2ag/+jt3NQouvetW8b
+        2jLbgNVSl+TJfvHsS2wYHXQpneuZPpXI8+sPrA9g3RWxDTimjWcOtR+wtbGxpmBxriY6cSWV9G3i
+        ywAWtEcUI3buXKhjdZYksq8co8IPXeEBm4wm00WWlhLUtpjmOe0lwEP6i+rS7voEGqxLeUpSxNo1
+        JF9mBSMBWQ2eV1GOp8iitYaMpYNS9O7E4bz3J6X+bakYcdRxNlqOYsffAAAA//8DAIDAIQU7BQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,11 +434,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -463,7 +462,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=54KCTLPT0V3l%2fJMNkW3GwQJCTbX24V5OeQ4rFBXXEOSvQgy%2bjsnwD4JccUxl1eAzkm2NnmctE59Huc0oQyTzuJ8JG10C%2fWLXVW5QtgeahPL4y1rrbqjzF1PeFXDDo%2f1RCHcbyxIdHU9QvDHDCTMmpc5jlOnUbt%2bF9hw15hXP566pAJrVakGX9ll2jTm4V%2f2g
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -473,19 +472,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUa2vbMBT9K8Zf9iUP24nTdFBY2coYW2lhbIyNUa6lG0eLLGl6JPVK/vv0cB6F
-        spEPkc8996Fzj/2UazSO2/x19nR+JML//cjfua7rsy8Gdf5zlOWUGcWhF9DhS2EmmGXATYp9iViL
-        RJqXyLL5hcQSDiaFrVS5hxVqI0U4Sd2CYH/AMimAn3Am0PrYc8CFsiFdGvYIhEgnbHje6EZpJghT
-        wME9DpBlZINWSc5IP6CekCYaHoxZH2quwByOPvDZrN9r6dTd6t41H7E3Ae9Q3WnWMnEjrO6TGAqc
-        YL8dMhrvd7la1YtFvRhfYF2NyxJhvLxcNOO6qudFAVXRLMuYGEb27XdSU3xUTEcBYomqqIriopz5
-        32VdfT+wvYRW7ShZg2jxRJyX83OiY1S4rvH3CIzyol54zqxexqC/ItEYO1nWvVCkPBaJMRp2GZEO
-        GD9Bb/AROsVxQmR3GI+AkIIR4EfbJOrNt+vb+083k7d3t5Fq0iWPBlnLDinTfiXSSxpC0wBNT725
-        9IqbNfI0wbRhYtqAWSfjsS2K5049yntwxH8mav8lmTCDzbgkG09YeeNjGBvMw2F/HrbaHdAN9haa
-        E6b8+4Z6i/Qsu8PQT64e2uCx2DcYyfNMknuIM5GkOeOtGaUoxhFIZBoUDTu7ivcbEXEVK4XDMLwZ
-        UXI1LC0cw972PnUL3AVphk3HzsZAi/Flfcptr2J4B1ow0QbCIGb+1XfwPrplxgyRITUEr+8/ZAMh
-        S9pmOzCZkDYzKOwoW0nta9LMD6K8HxvGme1jvHWgQVhEOsmujXGdr55FAfUrk4XC21R4lFWTalaH
-        zkTS0LacFUUZBAEL8fOW0h6GhDBYStnvoxP9nSF6TjjOgxyotdTDc3i36el8NNNRrWc+Clqeuswn
-        y8k83/8FAAD//wMA8sCZYXYFAAA=
+        H4sIAAAAAAAAA4RU22obMRD9lWVf+uLLen2JWwg0tKGUNiRQUkpLCbPSeK1aK211sb0N+fdqtPIl
+        ENoHY2nOmduZ0T7mBq2XLn+TPZ4fmQp/P/L3vmm67N6iyX8OspwL20roFDT4EiyUcAKk7bH7aKuR
+        afsSWVe/kDkmwfaw020ezC0aqxWdtKlBiT/ghFYgT3ah0AXsucFTWHLXVuyBMe2Vo/vGVK0RiokW
+        JPh9MjnBNuhaLQXrkjUQ+orSxdr1IeYK7OEYgC92/cFo396u7nz1CTtL9gbbWyNqoa6VM10vRgte
+        id8eBY/9vV6spjDnOFxOl4vhZIIwBD7lw3k5nxUFckRYREcqOaTfacNx3woTBYghyqIsiovwm01m
+        5cX3AztI6NodZ2tQNZ6Is3JyTqwFV76pQh/EmCxm82VRFPN5BEOLzGDM5ETzQpDFMdtRzuMWcBrs
+        2+tvVzd3n69H725vInWtG+TCBEV1UIR4YzKNIzsy/L8qCpkYKK0E+2+mBoQ8g3EPTStxxHQTYanD
+        XOwaZU8aV0KNK7DrpMoW1fN9jnbbK37cVp+meKpe2bRmUrNNwFZh8ZH6BvtwmF8wO+MP1g12DqqT
+        rQ3vDc0W+Zl3gySIXj3UtGMxJS1S4Nn+BVJdVM1lrGTA1GUE6ZDqsQPOLpMIdCQdnoLrFqSnNlMP
+        MZm1UGN8f4+569oI78AooWoiJGHyryFDWI0bYW1CkiuBV3cfs0TI+nlmO7CZ0i6zqNwgW2kTYvIs
+        FNKGFauEFK6LeO3BgHKIfJRdWeubED2LmphXNqPA2z7wICtH5XRBmZnmlHYyLYoJCQIO4herd3tI
+        DlRY7/L0FOcZeoa4h8pLSXKgMdqkOz1XfjofV/yo1rOdIy1PWWaj5Shk+QsAAP//AwArrqdDSQUA
+        AA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -498,11 +497,67 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[], {"ipatokenowner": "dummy"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQTWsCMRD9K0Muvciyaimlp4p4KFT0UEqhlDJuRhu6SZaZRFnE/97JumBv7828
+        9+bjbJgkt8k8wfkGP78mYJqYQyG14sQ5NJjIKt9jK6Q1TyJ4ICn6s0l9R4rMCTm4cDAqCOiH0jux
+        uBjWTmTsjNbSXGxfYBRAyH5HDCcUCDGBUEgT2EfWTAtN9B0mt3OtS/3QP2RkDInIVrAQyV7T1cRH
+        4juBEny8Bk9gVs3mD2Y4ypax03ldT5VaTDicfrV9j4ay2NVyuZRXaLZH7ku5hs3bFlL8pSDgMTU/
+        +pSLaog5sipCblulzt5wxy40rsO2BFjN6p9XH4v19nVVLTfrsta/uffVY6Vz/wAAAP//AwAOf/OC
+        mQEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 21 Apr 2020 04:14:27 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -526,7 +581,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=54KCTLPT0V3l%2fJMNkW3GwQJCTbX24V5OeQ4rFBXXEOSvQgy%2bjsnwD4JccUxl1eAzkm2NnmctE59Huc0oQyTzuJ8JG10C%2fWLXVW5QtgeahPL4y1rrbqjzF1PeFXDDo%2f1RCHcbyxIdHU9QvDHDCTMmpc5jlOnUbt%2bF9hw15hXP566pAJrVakGX9ll2jTm4V%2f2g
+      - ipa_session=MagBearerToken=HYYI1kzU82lf6d%2fqdjHaiEqbNgdLHOXCUSuBwcEAIZOhTNCWOd%2fqv7l8yL708LyvtlkVfDUXLWWZqRRlvNuW9ZRcuuaV9XAzQgpuXJg0RUsQrT%2bFr9dIR08OJNAz75u1VdJUA8Rx2O2j9ai0ronugnLBACJIVIZ1GXl8vCIZ1LidQ7SaB1apz4%2bBtwBDu33%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -536,11 +591,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
-        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
-        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
-        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
-        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
+        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
+        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
+        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
+        5aPM0D8AAAD//wMA5lpmj1gBAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -553,11 +608,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -606,13 +661,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=ZY92C29stXon9c2t9zw843j1tB1VsWgINLT0EHN1jwk38TDpavxalpPD9mlaKPIIhoWqgr%2ff%2bmWGZOINALz8KjSrxM6QXHvvwOVQLRxik7DWwX%2bageRkzX%2buGVVmEmPRUW6J9vuGNDawS9b22L89hOI6cjQq01efkgAWNSZzBu7YhujSXHOFUrkYtQDuiFIW;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=p10g2TAmHqZLh8otFqnr%2f1uEh2Po33UFn%2f4ODkrtNOeGvhVUaZ2Nujnhv2jaT9ZiRX4q9zwqWzaDZxNIRasoaK1MeKx2Ua%2bALXqBbXpGGQto50L5Rimvm1Qzpo03NE1tVbsb59mqQfbxprT%2bpKEDYOOhPCgAsvhwwT%2blCNbisTimGH781ndtLhsSAn5fbW6O;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -634,7 +689,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ZY92C29stXon9c2t9zw843j1tB1VsWgINLT0EHN1jwk38TDpavxalpPD9mlaKPIIhoWqgr%2ff%2bmWGZOINALz8KjSrxM6QXHvvwOVQLRxik7DWwX%2bageRkzX%2buGVVmEmPRUW6J9vuGNDawS9b22L89hOI6cjQq01efkgAWNSZzBu7YhujSXHOFUrkYtQDuiFIW
+      - ipa_session=MagBearerToken=p10g2TAmHqZLh8otFqnr%2f1uEh2Po33UFn%2f4ODkrtNOeGvhVUaZ2Nujnhv2jaT9ZiRX4q9zwqWzaDZxNIRasoaK1MeKx2Ua%2bALXqBbXpGGQto50L5Rimvm1Qzpo03NE1tVbsb59mqQfbxprT%2bpKEDYOOhPCgAsvhwwT%2blCNbisTimGH781ndtLhsSAn5fbW6O
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -644,11 +699,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -661,11 +716,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -690,7 +745,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ZY92C29stXon9c2t9zw843j1tB1VsWgINLT0EHN1jwk38TDpavxalpPD9mlaKPIIhoWqgr%2ff%2bmWGZOINALz8KjSrxM6QXHvvwOVQLRxik7DWwX%2bageRkzX%2buGVVmEmPRUW6J9vuGNDawS9b22L89hOI6cjQq01efkgAWNSZzBu7YhujSXHOFUrkYtQDuiFIW
+      - ipa_session=MagBearerToken=p10g2TAmHqZLh8otFqnr%2f1uEh2Po33UFn%2f4ODkrtNOeGvhVUaZ2Nujnhv2jaT9ZiRX4q9zwqWzaDZxNIRasoaK1MeKx2Ua%2bALXqBbXpGGQto50L5Rimvm1Qzpo03NE1tVbsb59mqQfbxprT%2bpKEDYOOhPCgAsvhwwT%2blCNbisTimGH781ndtLhsSAn5fbW6O
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -700,11 +755,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
-        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
-        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
-        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
-        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroY4yx00rXw2BlPY3BWoZaq8VgO0G2U0LJf5/UBNab9Ol7
+        SLoaplR8Ni9wvS9P6DxZKX/2/QRMi76QdsaWEDqzFyxQSnimpPDV5K5RgrkgRxfPRggRww36Ik6u
+        jhuX0jgZpTpcbt9hJEAs4UAMF0wQ6wyJYp7AqWbxtHCsQ4PZHZx3ubvNzwUZYyayFSxTKkHcRcQt
+        8UMCNW4H4wnMq/niSZOPtdXY2WI6nUlrMePt3kH2Owp0sUHS93qqeAfkTuE38pTJQhEF7IZ37IzR
+        JxFzzcKJxXtpnf2vG3bx6Br0aoFWNn1dfy832491tfrc6GJ3yY/VcyXJfwAAAP//AwC881l1mwEA
         AA==
     headers:
       Cache-Control:
@@ -718,11 +773,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -746,7 +801,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ZY92C29stXon9c2t9zw843j1tB1VsWgINLT0EHN1jwk38TDpavxalpPD9mlaKPIIhoWqgr%2ff%2bmWGZOINALz8KjSrxM6QXHvvwOVQLRxik7DWwX%2bageRkzX%2buGVVmEmPRUW6J9vuGNDawS9b22L89hOI6cjQq01efkgAWNSZzBu7YhujSXHOFUrkYtQDuiFIW
+      - ipa_session=MagBearerToken=p10g2TAmHqZLh8otFqnr%2f1uEh2Po33UFn%2f4ODkrtNOeGvhVUaZ2Nujnhv2jaT9ZiRX4q9zwqWzaDZxNIRasoaK1MeKx2Ua%2bALXqBbXpGGQto50L5Rimvm1Qzpo03NE1tVbsb59mqQfbxprT%2bpKEDYOOhPCgAsvhwwT%2blCNbisTimGH781ndtLhsSAn5fbW6O
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -756,11 +811,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -773,11 +828,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:27 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_changes_user.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_changes_user.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2020 12:59:46 GMT
+      - Tue, 21 Apr 2020 04:49:32 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=UWtFl6cJHp9y%2bDLrYWvS7U8QfgD%2feWY39VH70hyIqMvL4HCiZJF3K5c1%2b7AJAEBMR5J3NK9q9rW0YLX0dvih2GciBhc70UNxI8IKtoG02EjfiCNjz%2b%2fWJKq3j%2f4uZpu2JTA5sCJuhZozQWRCm%2fXqTyvPi0%2fXNHNLjg8WmfYK39e6ZxnEACHLXVPEsCoILbur;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=bwNB4JOERwXaVWyse4QuoeJm4CZApk9RZ3mdMSUEO0h4gkWxKg3tTszdb1vOAcfvTNJ9axIDr4CK8b1duG%2fNOmlbZLU0Xqu1GgS86B0jOJbBw2UPc54EaQyDldzUKUJO%2f4MZ%2bdI0sThUkdq4G56TyL68cY4T6DIXHQxH34BBn51f8LHhmm6TP%2b1L5r1c33Nj;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UWtFl6cJHp9y%2bDLrYWvS7U8QfgD%2feWY39VH70hyIqMvL4HCiZJF3K5c1%2b7AJAEBMR5J3NK9q9rW0YLX0dvih2GciBhc70UNxI8IKtoG02EjfiCNjz%2b%2fWJKq3j%2f4uZpu2JTA5sCJuhZozQWRCm%2fXqTyvPi0%2fXNHNLjg8WmfYK39e6ZxnEACHLXVPEsCoILbur
+      - ipa_session=MagBearerToken=bwNB4JOERwXaVWyse4QuoeJm4CZApk9RZ3mdMSUEO0h4gkWxKg3tTszdb1vOAcfvTNJ9axIDr4CK8b1duG%2fNOmlbZLU0Xqu1GgS86B0jOJbBw2UPc54EaQyDldzUKUJO%2f4MZ%2bdI0sThUkdq4G56TyL68cY4T6DIXHQxH34BBn51f8LHhmm6TP%2b1L5r1c33Nj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-15T12:59:46Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-21T04:49:32Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UWtFl6cJHp9y%2bDLrYWvS7U8QfgD%2feWY39VH70hyIqMvL4HCiZJF3K5c1%2b7AJAEBMR5J3NK9q9rW0YLX0dvih2GciBhc70UNxI8IKtoG02EjfiCNjz%2b%2fWJKq3j%2f4uZpu2JTA5sCJuhZozQWRCm%2fXqTyvPi0%2fXNHNLjg8WmfYK39e6ZxnEACHLXVPEsCoILbur
+      - ipa_session=MagBearerToken=bwNB4JOERwXaVWyse4QuoeJm4CZApk9RZ3mdMSUEO0h4gkWxKg3tTszdb1vOAcfvTNJ9axIDr4CK8b1duG%2fNOmlbZLU0Xqu1GgS86B0jOJbBw2UPc54EaQyDldzUKUJO%2f4MZ%2bdI0sThUkdq4G56TyL68cY4T6DIXHQxH34BBn51f8LHhmm6TP%2b1L5r1c33Nj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227bMAz9FcMve8nFzm3JgAJLu7TY1kuGrdvQtQhoiXa02JInyUm8oP8+XZym
-        Bbr2KfQheUgdktmFElWV6/BdsHtsEm5+foUfqqKog2uFMrxrBSFlqsyh5lDgc27GmWaQK++7dliG
-        RKjngkXyG4kmOSjv1qIMDVyiVIJbS8gMOPsLmgkO+QFnHLXxPQUqS2vThWJbIERUXNvvlUxKyThh
-        JeRQbRtIM7JCXYqckbpBTYDvqPlQarnnTEHtTeP4qpZnUlTlVTqvks9YK4sXWF5JljE+41rWXowS
-        Ks7+VMioe1+apINxfwztt2k8bscxQntCx6P2sDccRNEkGvew7xJty6b8RkiK25JJJ4Cj6EW9KBrE
-        w7g3nAxGN/toI6EuN5QsgWf4UiButQQKGmzQLlwsElA4GiwW5jucTj+dHN9QJMVkTU8my5uzuExW
-        x6c/ZqeX17Pt6fnqcv7ty/QovL/zDy6AQ4YU3YttVcKPqJ1xyxiZlUhZqxmGalFyhFsoyhytSUTh
-        2sqFUU0tMc8dRzdhvGvaWjpnAczDjvd9k97Z51aM8qpIzGhsTDwY9kdRFI29jEtRIGXSTFQ0/XUt
-        1HVU+/QDuV/WlwiNgAS44IxA/nABvrHZz+nF/HzWObm6aHjWyJ9eicPNJhGJbqCaFf+flfLzfriV
-        x1v8SunSHDHKNdqnpeYW0UoBarFfKQNrWe3RFdYakgNWoH29SBdufq6M3WPDqPwfgG3MCneYtHO+
-        Muh7k7qGvLKNN3K7YkqZDVJ+G3VdOvcGJGc8swHNU8PvpoKR7IIp1XiaVLe3849BExD44QUbUAEX
-        OlBmN1tBKqThpIFppDTSJyxnunb+rAIJXCPSTjBVqioMe+DUk29UYInXnrgV9Dq9/shWJoLasnE/
-        imIriL+mXejTFk2Cbcyn3LtzMdwFuDUMp5QiDaxqwa3X4jZ0AqGUwi4er/Lc/n/Qg/0wfEsA1PT5
-        ZO5W3UPdQWfcMXX/AQAA//8DAG5xnynaBQAA
+        H4sIAAAAAAAAA4RUWW/TQBD+K5ZfeMnhHA4JUiVCSSugRxAUUGkVjXcnzhJ7d9kjB1H/O7trJ2ml
+        qn3y7Df3NzPexQq1LUz8Lto9Fgl3n9/xR1uW2+hGo4rvG1FMmZYFbDmU+JyacWYYFLrS3QQsRyL0
+        c8Yi+4PEkAJ0pTZCxg6WqLTgXhIqB87+gWGCQ3HEGUfjdE8B68N6d6HZBggRlhv/XqpMKsYJk1CA
+        3dSQYWSJRoqCkW2NOoOqovqh9WIfcw56LzrFN704V8LK6/nUZl9wqz1eorxWLGd8wo3aVmRIsJz9
+        tcho6O8tpsNBkibNYW+YNTsdhOYoHZBm2k37SYIUEQbB0Zfs0q+ForiRTAUCQohu0k2SfreT9Puj
+        Xvd2b+0oNHJNyQJ4ji8Z4sYooGDAG+3i2SwDjYP+bObe8Xj8mWCaIilHK3o6Wtyed2S2/HD2c3J2
+        dTPZnF0sr6bfv45P4of7quESOOSu7tCxz0r4CfUzbjgh9xRpL9XD0A1KTnADpSzQi0SUoSzLKLdl
+        5uj1ITqDfjpMkiQdBeVClEiZclMRdY62h9ohzd494EfETYsoDKQZVr7Ix2EzDgsdwryf/BpfTi8m
+        rdPry2BaAiseqesuWvsWcrZC/vQmAl4ItxB6gUXl3M4YbzvGF0Gpq5EeziF/iQdXKwEuOCOv1ird
+        EaNaoadl7m4RPY2gZ/uVcrBRdo8ucWsgO2Il+hLEfBbmF9L4PXYRdfUD8FV70o+TDspXBv3gXFdQ
+        WF94PaqQTGu3QbraRrOVQb0GxRnPvUHdavzDZXDjvGRa15raNezt9FNUG0QVg9EadMSFibTbzUY0
+        F8rFpJErRLq1yFjBzDbocwsKuEGkrWistS1d9Ciwp97oyAdeVYEbUbfV7Q18ZiKoT9vpJUnHE1Jd
+        0y6u3Ga1gy+scnkI5+JilxBWOB5TijTyrEV3FRd3cSAIlRJ++twWhf9/0KN8WFQfAKir88ncPbvH
+        vP3WsOXy/gcAAP//AwApJzbL2gUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UWtFl6cJHp9y%2bDLrYWvS7U8QfgD%2feWY39VH70hyIqMvL4HCiZJF3K5c1%2b7AJAEBMR5J3NK9q9rW0YLX0dvih2GciBhc70UNxI8IKtoG02EjfiCNjz%2b%2fWJKq3j%2f4uZpu2JTA5sCJuhZozQWRCm%2fXqTyvPi0%2fXNHNLjg8WmfYK39e6ZxnEACHLXVPEsCoILbur
+      - ipa_session=MagBearerToken=bwNB4JOERwXaVWyse4QuoeJm4CZApk9RZ3mdMSUEO0h4gkWxKg3tTszdb1vOAcfvTNJ9axIDr4CK8b1duG%2fNOmlbZLU0Xqu1GgS86B0jOJbBw2UPc54EaQyDldzUKUJO%2f4MZ%2bdI0sThUkdq4G56TyL68cY4T6DIXHQxH34BBn51f8LHhmm6TP%2b1L5r1c33Nj
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -410,19 +410,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU72/TMBD9V6x84UvbJf21bNIkJpgQgmmT0BAaQuhiO6mZYwefvbZM+9/xOena
-        wQSferl79+78/NyHzEkM2men7GEffn3IuKHf7G1o2y27QemybyOWCYWdhq2BVr5UVkZ5BRr72k3K
-        NZJbfAlcA3InwStrvBr4pvk0z+fFopguTubL24Sz1Q/JPdeAPY23XRbTnXRoDUXWNWDUr8QEep9X
-        RvpYe54INJ7aLaoNcG6D8fR956rOKcNVBxrCZkh5xe+k76xWfDtkI6DfaPhAXO0444l2YSx8wtU7
-        Z0N3VV+H6oPcIuVb2V051ShzYbzb9qJ1EIz6GaQS6Xx1Vc/LWQnj47oox0UhYXwiyuV4MV3M8/wk
-        L6dylhpp5Th+bZ2Qm065JMBexuNinmQ8vt2ho4S+Wwu+AtO8oPcA1DauhyupdYIcVcocVYCrHQsH
-        Y43ioJ9cIOhiX198Ob+8/ngxeXN1maAtKH1QlhtoOy0n3LapjP2qT3Y4vID/MAclTGir2EiYYr6Y
-        LfM8L3tVGnUvzXOD7pr2lAPyHzQr20qhXLxnG+8pCUGpo327wcE+2vK7iKij8SU5Kz4j6e6lOMi1
-        kubY+ntDjkh0dO0Rh/27IjFoxbPEP+LmLBUpGKbgSPCzQUQKScdH6u0tfMqKGHsXDAf/x2xEaCT2
-        79pvO1ImW4MzyjTkyUGs7HMcGB10qRCHytBKxfPr92wAsF41tgZkxnqG0vgRq62LnILFvbroxEpp
-        5bep3gRwYLyUYsLOEUMb2VmSyL1CRsT3PfGITSfT2TJLhxI0tpjlOZ1LgIf0F9W3fR8aaLG+5TFJ
-        EblbSNeVFYwEZC14vopyPMaqdM7SXZugNb07sY+fnEetf5suIg4mziflJE78DQAA//8DAC4J04I7
-        BQAA
+        H4sIAAAAAAAAA4RUbU/bMBD+K1a+7Etf0rQpBQlpaEPTtCGQJqaJaUKOfU09HDvz2bQF8d/nc9IW
+        NrR96uXuubfnHvcxc4BB++yEPR7M74+ZMPSbvQ9Ns2XXCC77MWCZVNhqvjW8gdfCyiivuMYudp18
+        NQiLr4GXHIUD7pU1XvX1irzI81kxyWez42lxk3C2+gnCC82xK+Ntm0V3Cw6tIcu6mhv1kCpxffAr
+        Az7GXjoCtad0i2rDhbDBePq+c1XrlBGq5ZqHTe/yStyBb61WYtt7I6CbqP9AXO1qxo12Zgx8wdUH
+        Z0N7ubwK1SfYIvkbaC+dqpU5N95tO9JaHoz6FUDJtN8RlIt5XubDxXRRDScT4MPjci6GZVHO8hwk
+        AJ+nRBo5tl9bJ2HTKpcIONB4RFRGGqc3O3Sk0LdrKVbc1K/w3QNrJU1oqrgHISbzWbnI87w83vfc
+        0bRXgaTDvj3/dnZx9fl89O7yIkGxm2V/74Yr/QwOG960GkbCNim8sg1I5SKxNhJDuDG5xgmdEOFf
+        g2kbScUV6K7HuFJmXHFc9Svdg3kp2l3Fw0S7/QQ31ijx3/0M9vLRVtxF3DIKH0hZ8RmBuwf5zNcA
+        zW2XtzUpIhWls0ccdu+KuKJxTlOvgTCnKUhG3wUHUpz2pJFJvD1RbifhEzaJtnfBCO7/6I3Ia8Du
+        XfttS0tla+6MMjVpst8z+xobRgVdKMQ+0qdS8OzqI+sBrLsCW3NkxnqGYPyALa2LNSWLc7VRiZXS
+        ym9TvA7cceMB5IidIYYmVmeJIvcGGRW+7woPWDEqpvMsLSWp7WSa57SX5J6nv6gu7bZPoMG6lKdE
+        Razd8KSebMKIQNZwL1aRjqcYBecsaccErendyYO91zSl/n3uiHjWcTZajGLH3wAAAP//AwBHzRjc
+        OwUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,7 +435,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -473,19 +473,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU22rcMBD9FeOXvuxu7L1lUwg0tKGUNiRQWkpLCWN57FVXllRdduOG/Hs1svYS
-        CO3TyufMzJk5Gu1jbtB64fLX2ePpkcnw8yN/57uuz75YNPnPUZbX3GoBvYQOX6K55I6DsAP3JWIt
-        MmVfClbVL2SOCbAD7ZTOA6zRWCXppEwLkv8Bx5UEccS5RBe454CnspSuLH8AxpSXjr43ptKGS8Y1
-        CPAPCXKcbdBpJTjrExoCho7Sh7Xrfc0G7P4YiM92/d4or2+bO199xN4S3qG+Nbzl8lo60w9maPCS
-        //bI6zhfUzXz1WwF4/OmXI3LEmF8Ua+W48V0MS+Ki2I1xVlMpJaD/E6ZGh80N9GAWGJaTIvivJyX
-        08XF/Pz7PjpY6PSuZmuQLR4D5+XiNLDltfRdFeagiHK+mC2LolgNmmvVYc1NGF+F9ingjKCzmu5s
-        r8NAKskZiMP9R/rN9berm7tP15O3tzdJaYvy+Y5EXKhgkF2jEINCxeVZBXYdSZ9sOiraYejDwpxe
-        5X868P+aNVwnMxhddbx7wbDlYFgHXJxo4AN0WuCEqS7S0qY1E4ptQlwTFh/JSrD3+/sLsDN+j26w
-        d1AdMR3eG5ot1ifZHVLbqrlvaceiPC1SiLPDCyRTaL7L2NWIyctI0iH1Y0c1u0zd0pEafgqpWxCe
-        pk0WRzFrocX4/h5z1+tI78BILlsKSDbnX4NCsOuGW5uYlErk1d2HLAVkg+vZDmwmlcssSjfKGmVC
-        zToLjehge8UFd33kWw8GpEOsJ9mVtb4L1bPoiXllMyq8HQqPsulkOluSMlM1yZazoijJEHAQ/7GG
-        tPuUQI0NKU9PcZnCzBBXW3ohyA40Rpn0Tc+1Pp4Pa3Zw69mGkZdHlflkNQkqfwEAAP//AwCFdou/
-        SQUAAA==
+        H4sIAAAAAAAAA4RU22obMRD9lWVf+mI76/UlTiHQ0IZS2pBASSktJcxqx2vVWknVxfYm5N+r0cqX
+        QGgfjKVz5npmtE+5QeuFy99mT6dHJsPfz/yDb9suu7do8l+DLK+51QI6CS2+RnPJHQdhe+4+Yg0y
+        ZV8zVtVvZI4JsD3tlM4DrNFYJemkTAOSP4LjSoI44lyiC9xLwFNYcleW74Ax5aWj+9pU2nDJuAYB
+        fpcgx9kanVaCsy6hwaCvKF2sXe1jLsHuj4H4alcfjfL6dnnnq8/YWcJb1LeGN1xeS2e6XgwNXvI/
+        Hnkd+zvH2WJezIrhYrKohuMxwvBiNmfDWTmbFgXWiDCPjlRySL9Vpsad5iYKEEOURVkU5+E3nV5M
+        Jj/21kFCp7c1W4Fs8Gg4Lcenhg3foHw5uYTX0rdV6I/w8Xw6WxRFMbuIpE/F1wfzU0EP0SL97vr7
+        1c3dl+vR+9ubaLpSLdbcBE1V0ITszgg6OwYTKkhmVyhET1dcnlVgV/tMDKSSnP03k/9XDy1wceKL
+        O2i1wBFTbaRtr+1hL8O0mcEouuPtK3qWvZ7SpjUTiq2D1TIsPlLXYB/28wuwM36PrrFzUB0xHd4b
+        mg3WJ94tUhtq+dDQjsXktEjBzvYvkKqlfi9jNwMmLyNJh1SPHdTsMnVJR2r0ObhuQHhqJw0zJrMW
+        Gozv7yl3nY70FozksiGDJHv+LWQIetxwaxOTXIm8uvuUJYOsn0K2BZtJ5TKL0g2ypTIhZp2FQnTQ
+        teKCuy7yjQcD0iHWo+zKWt+G6FnUxLyxGQXe9IEHWTkqJ3PKzFRNaceTohiTIOAgfrF6t4fkQIX1
+        Ls/PccqhZ4hbKL0QJAcao0y603Otj+fDgh/UerFxpOUxy3S0GIUsfwEAAP//AwApIOUYSQUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -498,9 +497,65 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[], {"ipatokenowner": "dummy"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQTWsCMRD9K0Muvciyaimlp4p4KFT0UEqhlDJuRhu6SZaZRFnE/97JumBv7828
+        9+bjbJgkt8k8wfkGP78mYJqYQyG14sQ5NJjIKt9jK6Q1TyJ4ICn6s0l9R4rMCTm4cDAqCOiH0jux
+        uBjWTmTsjNbSXGxfYBRAyH5HDCcUCDGBUEgT2EfWTAtN9B0mt3OtS/3QP2RkDInIVrAQyV7T1cRH
+        4juBEny8Bk9gVs3mD2Y4ypax03ldT5VaTDicfrV9j4ay2NVyuZRXaLZH7ku5hs3bFlL8pSDgMTU/
+        +pSLaog5sipCblulzt5wxy40rsO2BFjN6p9XH4v19nVVLTfrsta/uffVY6Vz/wAAAP//AwAOf/OC
+        mQEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 21 Apr 2020 04:49:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
@@ -526,7 +581,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
       User-Agent:
       - python-requests/2.23.0
     method: POST
@@ -549,9 +604,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:47 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
-      - timeout=30, max=97
+      - timeout=30, max=96
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
@@ -579,7 +634,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8tTySC3wkNdz0A265RiT6Exf%2f38I1m4pHS3EBwxhr1qzuifthxpiU0fz77PUWHUfKKvixohTiOu4UUkx7yBzlQLVplc7wEabvNFeIEVmpEpRIE26ikVFlJMGQ%2bgtvau6vk%2f9TYAxoJeAZlWuZxAZO%2f81lOLKWEgZAvoDZpQpRGcumaGPOKHQP%2fr6CvEWAJhD
+      - ipa_session=MagBearerToken=hPfiHY7J3KekUTiwaZ7uPVY1mdRbrRZY2xw28VcIb%2fJTC17S2mOJrNhExAixlKysQFtmKtKrnXzyHvz1MLwHXcJ7G6D6Zfm2Sy71JNISXu37pci4AEX70ggZmLgITwYG5%2fhfnuHBVErSnf7pX5ByGFJnAxNrg%2bX3kqwZy%2bdd1ay%2bwy8K2A%2b7%2bw7J26eBokTv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -606,7 +661,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:48 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -657,13 +712,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 15 Apr 2020 12:59:48 GMT
+      - Tue, 21 Apr 2020 04:49:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=AeS7zY%2bRtJPDfCjMWnr4nP7mbD4tEgf%2bWK1THYUa6VpnAWN2xRSgbTCJ1WL6ODUqZ4%2bS540xsGCboyKrsNro5t6diyLGizGC3T9JW5Bqng2PtHlS86uqEfr3wCtznhmeR8JlC6TfXz%2b88GL7JqYi3aXFn11JGzpXssGFKtXfVDaTFfVRWpkRCbNlbsLwTDyT;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=M2SDhl%2fcy7zwiPCXGsiz3cGusmrJ7HT04PtQBtN%2b5sFXj44jEtbsDdyETuUT3Ux5MVsNaoSpNFWx%2fsq932b0lBRIIPGPVWOUBWSRBuIs6Ffz5jvGMPVOUxVB%2fQxsycQZXUtB5amZyelBreXso6OkeF6oRaA%2b9unG9021CJJWLpwDYw4vZafXwiscIZlIRwEo;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -687,7 +742,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AeS7zY%2bRtJPDfCjMWnr4nP7mbD4tEgf%2bWK1THYUa6VpnAWN2xRSgbTCJ1WL6ODUqZ4%2bS540xsGCboyKrsNro5t6diyLGizGC3T9JW5Bqng2PtHlS86uqEfr3wCtznhmeR8JlC6TfXz%2b88GL7JqYi3aXFn11JGzpXssGFKtXfVDaTFfVRWpkRCbNlbsLwTDyT
+      - ipa_session=MagBearerToken=M2SDhl%2fcy7zwiPCXGsiz3cGusmrJ7HT04PtQBtN%2b5sFXj44jEtbsDdyETuUT3Ux5MVsNaoSpNFWx%2fsq932b0lBRIIPGPVWOUBWSRBuIs6Ffz5jvGMPVOUxVB%2fQxsycQZXUtB5amZyelBreXso6OkeF6oRaA%2b9unG9021CJJWLpwDYw4vZafXwiscIZlIRwEo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -714,7 +769,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:48 GMT
+      - Tue, 21 Apr 2020 04:49:34 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -743,7 +798,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AeS7zY%2bRtJPDfCjMWnr4nP7mbD4tEgf%2bWK1THYUa6VpnAWN2xRSgbTCJ1WL6ODUqZ4%2bS540xsGCboyKrsNro5t6diyLGizGC3T9JW5Bqng2PtHlS86uqEfr3wCtznhmeR8JlC6TfXz%2b88GL7JqYi3aXFn11JGzpXssGFKtXfVDaTFfVRWpkRCbNlbsLwTDyT
+      - ipa_session=MagBearerToken=M2SDhl%2fcy7zwiPCXGsiz3cGusmrJ7HT04PtQBtN%2b5sFXj44jEtbsDdyETuUT3Ux5MVsNaoSpNFWx%2fsq932b0lBRIIPGPVWOUBWSRBuIs6Ffz5jvGMPVOUxVB%2fQxsycQZXUtB5amZyelBreXso6OkeF6oRaA%2b9unG9021CJJWLpwDYw4vZafXwiscIZlIRwEo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -771,7 +826,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:48 GMT
+      - Tue, 21 Apr 2020 04:49:34 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -799,7 +854,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AeS7zY%2bRtJPDfCjMWnr4nP7mbD4tEgf%2bWK1THYUa6VpnAWN2xRSgbTCJ1WL6ODUqZ4%2bS540xsGCboyKrsNro5t6diyLGizGC3T9JW5Bqng2PtHlS86uqEfr3wCtznhmeR8JlC6TfXz%2b88GL7JqYi3aXFn11JGzpXssGFKtXfVDaTFfVRWpkRCbNlbsLwTDyT
+      - ipa_session=MagBearerToken=M2SDhl%2fcy7zwiPCXGsiz3cGusmrJ7HT04PtQBtN%2b5sFXj44jEtbsDdyETuUT3Ux5MVsNaoSpNFWx%2fsq932b0lBRIIPGPVWOUBWSRBuIs6Ffz5jvGMPVOUxVB%2fQxsycQZXUtB5amZyelBreXso6OkeF6oRaA%2b9unG9021CJJWLpwDYw4vZafXwiscIZlIRwEo
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -826,7 +881,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 15 Apr 2020 12:59:48 GMT
+      - Tue, 21 Apr 2020 04:49:34 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_form_with_otp.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_form_with_otp.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:22 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=Fi%2frXmqbUGS2JSeoVccacZHseT0ihNpqOWxIBPri3pwYBHD7LN4VbutVBeHSQwA90uY79M0OAIc5qOYa2eXgPMZo2XhubzKSvo2snRY7vCtqCWhEE3t%2fdBaqTcx1WpQKejQnhlQaceF7IYzWcEgVn2OQweGYsRqMctAomytjk2GZf%2bFNFXY4aJSsFj7EDPMn;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=Fi%2frXmqbUGS2JSeoVccacZHseT0ihNpqOWxIBPri3pwYBHD7LN4VbutVBeHSQwA90uY79M0OAIc5qOYa2eXgPMZo2XhubzKSvo2snRY7vCtqCWhEE3t%2fdBaqTcx1WpQKejQnhlQaceF7IYzWcEgVn2OQweGYsRqMctAomytjk2GZf%2bFNFXY4aJSsFj7EDPMn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -107,8 +107,8 @@ interactions:
       message: Success
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
-      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-21T04:14:22Z"}]}'
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-04-20T10:55:45Z"}]}'
     headers:
       Accept:
       - application/json
@@ -117,11 +117,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '249'
+      - '220'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=Fi%2frXmqbUGS2JSeoVccacZHseT0ihNpqOWxIBPri3pwYBHD7LN4VbutVBeHSQwA90uY79M0OAIc5qOYa2eXgPMZo2XhubzKSvo2snRY7vCtqCWhEE3t%2fdBaqTcx1WpQKejQnhlQaceF7IYzWcEgVn2OQweGYsRqMctAomytjk2GZf%2bFNFXY4aJSsFj7EDPMn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227aQBD9FcsvfQFiG0NJpUilKYmi5kLVpq3SRGi8O5gt9q67F8BF+ffurg0k
-        Uto8MT5zP3OWbShRmUKH74LtU5Nw+/Mz/GjKsg5uFcrwoROElKmqgJpDiS+5GWeaQaEa363HciRC
-        vRQssl9INClANW4tqtDCFUoluLOEzIGzP6CZ4FAccMZRW99zwLiyLl0otgFChOHafS9lVknGCaug
-        ALNpIc3IEnUlCkbqFrUBzUTth1KLXc05qJ1pHV/U4lwKU93Mpyb7hLVyeInVjWQ54xOuZd2QUYHh
-        7LdBRv1+x2kW0f7bUXfUHw27cYzQzRCS7iAZpFGEFBGGPtGNbNuvhaS4qZj0BPgSSZREUZrEURqn
-        SXK3i7YU6mpNyQJ4jv8LxI2WQEGDC9qGs1kGCofpbGa/w/H4AslggKQ8XtHT48XdeVxlyw9n3ydn
-        17eTzdnl8nr69fP4JHx8aBYugUNu5/Ybu66En1B34441ckeRclZ7DNWh5AQ3UFYFOpOIstEHWyF/
-        LqgWp9yUmaXd4fEwHYyiKBr0vdO0nNJ9+NM776t59/vJj/HV9HLSO7258qELUSJl0p5atIMfOejo
-        UKwQ9pJqgUXRuDPGjyxVi10nAlxwRl7tZP63QwmseJLbUtPb8aKak++fixUhkei1oFn57zNX9hGj
-        XKEjaG7fIrqNQc12krKwlmaHLrHWkB2wEt24Yj7z9/NNnI5tRdX8Abip3F6HS3vnK4d+tKkrKIwb
-        uz2ab6aUVZBq1KjryrvXIDnjuQto6Q2/2Q527yumVOtpU71upxdBGxA0bAdrUAEXOlBWm51gLqSt
-        SQM7SGX5y1jBdO39uQEJXCPSXjBWypS2euDZk29U4AqvmsKdIOkl/aHrTAR1beN+FMWOkOY1bcMm
-        bdYmuMGalEf/XGztErzawjGlSAPHWnDfcHEfeoJQSuGUwk1RuP8PerD30nYFgNo5n2nNsXvom/ZG
-        Pdv3LwAAAP//AwCr2hP42gUAAA==
+        H4sIAAAAAAAAA4RUbW/aMBD+K1G+7AsvSQoMJlUa62g19Y1p6zZ1rdDFPoKHY2e2A2So/322E6BI
+        3dovvdzLc3fPPWYbKtQlN+G7YPvcJML++xl+LPO8Cu40qvCxFYSU6YJDJSDHl8JMMMOA6zp2530Z
+        EqlfSpbpLySGcNB12MgitO4ClZbCWVJlINgfMEwK4Ac/E2hs7NhROlhXLjXbACGyFMZ9L1VaKCYI
+        K4BDuWlchpElmkJyRqrGaxPqiZoPrRc7zDnonWkDX/TiQsmyuJ1Py/QSK+38ORa3imVMTIRRVU1G
+        AaVgv0tk1O/3lgxHGMXYHibzfjuOEdqjJO21+0m/F0XDUTKMBr7QjWzbr6WiuCmY8gR4iCRKoqiX
+        RHHU7/d697tsS6Ep1pQsQGT4v0TcGAUUDLikbTibpaBx0JvN7Hc4Hl+u5/0YST5a0bPR4v4iLtLl
+        h/Pvk/Obu8nm/Gp5M/36eXwaPj3WC+cgIEOKfmPXlYhT6m7cskbmKNLOao6hW5Sc4gbygqMzicx3
+        YxEQUjACfK8rD/N+8mN8Pb2adM5ur31qDow/CzdgnR1Sxqgo89QeyuXEg5PI/g1OmtgKxbFsvZ9L
+        ezO9QF4Dd1MmupaUhQ8uZI6UKasJ2WzYda4u3ZeXzW2PPP8c4rkWX1lV1wffPxYrQaLQK8Gw/IUj
+        9+sjF/YJo1qhG2tuXyK6NUDPdoKybqPKnXeJlYH04MvRTS7nM38938Sp2CLq+vm7qdyKhzv74Ctn
+        frKlK+ClG7uhyjfT2upH11o0VeHDa1CCicwlNBSF32wHu/c107qJNKVetdNPQZMQ1MQHa9CBkCbQ
+        VpmtYC6VxaSBHaSw/KWMM1P5eFaCAmEQaScYa13mFj3w7Kk3OnDAqxq4FSSd5GTgOhNJXdvYnjV2
+        hNRvaRvWZbOmwA1Wlzz5x2Kxc/ASCseUIg0ca8FDzcVD6AlCpaQTjSg5d78e9GDvReMAgNo5j/Ti
+        2D307XWGHdv3LwAAAP//AwAzPIfT2AUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=Fi%2frXmqbUGS2JSeoVccacZHseT0ihNpqOWxIBPri3pwYBHD7LN4VbutVBeHSQwA90uY79M0OAIc5qOYa2eXgPMZo2XhubzKSvo2snRY7vCtqCWhEE3t%2fdBaqTcx1WpQKejQnhlQaceF7IYzWcEgVn2OQweGYsRqMctAomytjk2GZf%2bFNFXY4aJSsFj7EDPMn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:45 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -331,7 +331,8 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "ping", "params": [[], {}]}'
+    body: '{"method": "otptoken_add", "params": [[], {"ipatokenowner": "dummy", "ipatokenotpalgorithm":
+      "sha512", "description": "dummy''s token"}]}'
     headers:
       Accept:
       - application/json
@@ -340,11 +341,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '38'
+      - '136'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -354,11 +355,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
+        H4sIAAAAAAAAA4xT72/aMBD9V6xIY1/4ERJIOqRoYxu0XcnIVmDr1qky8RWsJU5mOzCE+N93NqiF
+        8aVfIjt37927d+etI0FVmXZ6ZHt8ZKBSyUvNC4H3nw6r8nzzWhFd/Abh/KoTh5fUXoq1APmccxrT
+        Jc0WheR6mdsUtaTdtneSozFJ8xyUhtLm+O5JvBL8TwWc2Vg39Do0dLuNEIKw0aEuNKiHn0ePvQGf
+        ddwLz/9fAeMLrpWFBzZWSY43x4ir9LLXahkJLav+3eB7P05Gg+aHcdx7SbG3XKkKZGTRrzruEb6m
+        IJWgozgJRzfT+PPd4MfdbDBMkuk4+eZ7V0Gn+9Gfvg++XPreKJwlw6/BZDocXXVv4sth//ZTbS88
+        CmpPHka3V330r1aC5AWL0ClsR29KMP1MxpPE3HMq6ALYfPNQqbPJMDPOM2+jl7RaT0WERtVZGsFf
+        mpcZmGNa5M4OiVc0q4wMUWWZEQFKoQpr+/ZJ4ppKwcXCqBQ0t79mIBUuWYw+HiIHqAn2k2tySEDi
+        fA6SrKkiOFWicHPq5LGQyMkIqsCW+JxnXG9sfFFRSYUGYE3SxxnlyI4guQKJa2yIV3viOvGanh+Y
+        ymnBTNm277pt4xXV1D6GPezhADDC9pDdzliK3DmVG6uXMWAE57B/J+TeuXesOyBlIZ/dsdt8OJeS
+        ixQHkhmCsyU0so7qdpoXTaz7DwAA//8DAA969O+2AwAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -371,9 +377,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
-      - timeout=30, max=100
+      - timeout=30, max=99
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
@@ -399,7 +405,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -426,62 +432,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -510,7 +461,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -520,19 +471,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU224TMRD9FWtfeMlld3NpqFSJCiqEoGolVISKUDVrTzamXnvxpUmo8u94vJuk
-        hQqeMjtz5nbmOI+ZRReUz07Z49H89phxTb/Zu9A0W3bj0GbfBywT0rUKthoafCkstfQSlOtiN8lX
-        IzfuJfASHLcIXhrtZV+vzMs8n5ZFPi2mZXmbcKb6gdxzBa4r402bRXeL1hlNlrE1aPkrVQJ19EuN
-        PsaeOwK1p3Tj5AY4N0F7+r63VWul5rIFBWHTu7zk9+hboyTf9t4I6CbqP5xb7WvGjfZmDHx2q/fW
-        hPZqeR2qj7h15G+wvbKylvpCe7vtSGshaPkzoBRpv9fTKheTk8VwMVnMh0WBMKwQyuGsnE3zHAUi
-        zFMijRzbr40VuGmlTQQcaTwhKiONk9s9OlLo27XgK9D1C3z3wFoKHZoq7kGIYj6dLfI8n00OPfc0
-        HVQg6LBvLr6eX15/uhi9vbpMUNfNcrh3A1I9geMGmlbhiJsmhVemQSFtJNZEYgg3Jtc4oRMi/Gsw
-        ZSKpboWq6zGupB5X4Fb9Sg+on4t2X/E40X4/Dtpoyf+7n3a9fJTh9xG3jMJHUlZ8RmgfUDzxNUhz
-        m+VdTYpIRensEee6d0Vc0ThnqdeA67MUJKPv4gaCn/WkkUm87Si3k/ApK6LtbdAc/B+9nYMaXfeu
-        /balpbI1WC11TZrs98y+xIZRQZfSuT7Sp1Lw/PoD6wGsuwJbg2PaeOZQ+wFbGhtrChbnaqMSK6mk
-        36Z4HcCC9ohixM6dC02szhJF9pVjVPihKzxg5aiczLO0lKC2xSTPaS8BHtJfVJd21yfQYF3KLlER
-        azeQ1JMVjAhkDXi+inTsYhStNaQdHZSidyeO9kHTlPr3uSPiScfpaDGKHX8DAAD//wMADC0CrzsF
-        AAA=
+        H4sIAAAAAAAAA4RUbW/TMBD+K1a+8KXtkqwt7aRJTDAhBNMmoSEEQpPjXFMzxzZ+WRum/XfunKzt
+        YBP7sss99/rc495nDnxUITth93vz+30mNP3P3sW27di1B5f9GLGslt4q3mnewnOw1DJIrnyPXSdf
+        A8L454JX3AsHPEijgxzqlXmZ59MyL/LZbDr7luJM9RNEEIr7vkwwNkO3BeeNJsu4hmv5O1Xiau+X
+        GgJiTx2R2lO68XLLhTBRB/q+dZV1UgtpueJxO7iCFLcQrFFSdIMXA/qJhg/v1481caNHE4HPfv3e
+        mWgvV1ex+gidJ38L9tLJRupzHVzXk2Z51PJXBFmn/V6LxRLyAsaLcjUbFwXw8bKspuNZOZvm+WJZ
+        LvJ5SqSRsf3GuBq2VrpEwJ7G18XykEaMRgqD3dRizXXzMt9xmKOmc/UnlHegn948+ZXBRfwalErA
+        USX1UcX9OoFr00ItHRJlcNGEk+toXxYnElwbLQVXu+oJfnP+9ezi6tP55O3lRQr1/V477eCMOrYV
+        fpG7mB/n+Dc/HqZ9GWu5VAdtYMtbq2AiTLtj9FEE/5lI+0E8yohbjFuh7IF0hY8I3B3UB74WaByz
+        umlID6koHR3jfP+qaDva6TT1Ggl9mkAyhi5+VIvTYVwyaeIHyu0FfMIKtIOLWvDwV2/veQO+f9Wh
+        s7RUtuFOS92QIoc9sy/YEPVzIb0fkCGVwLOrD2wIYD25bMM90yYwDzqM2Mo4rFkznMuiDiupZOgS
+        3kTuuA4A9YSdeR9brM4SRe6VZ1T4ri88YuWkPJ5naama2hZ4Otqr5oGnH6g+7WZIoMH6lIdEBdZu
+        edJaVjAikLU8iDXS8YAoOGdIEjoqRa+u3tu7m1Pqv+fGiIOO08ligh3/AAAA//8DAP+Zevo5BQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -545,7 +495,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -573,7 +523,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -583,18 +533,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUW2vbMBT+K8Yve0lS23HSbFBY2coYW2lhdIyNUY6lE0eLLGm6JPFK/vskWbkU
-        yvYQIn3fuX7nyE+5RuO4zd9kT+dHIvzfj/y967o+ezCo85+jLKfMKA69gA5foplglgE3A/cQsRaJ
-        NC8Zy+YXEks4mIG2UuUeVqiNFOEkdQuC/QHLpAB+wplA67nngAthg7s0bAeESCdsuK91ozQThCng
-        4HYJsoys0SrJGekT6g2GitLFmNUh5hLM4eiJL2b1QUun7pb3rvmEvQl4h+pOs5aJG2F1P4ihwAn2
-        2yGjsb/XdVPQ6eVivJgu5uOyRBg3CNV4Vs3qokCKCPPoGEr26bdSU9wppqMAMURVVEVx6X91WVfT
-        7wdrL6FVW0pWIFo8GdZVeW7Ysg2K55NLOBWua3x/AS/n9WxRFMVsGkmXiqdH83NBj9Ei/fbm2/Xt
-        /eebybu722i6kh1Spr2m0msS7C4CdHEKxqWXzKyQ84FumLhowKwOmQgIKRj5byb3rx46YPzMF3fQ
-        KY4TIrtIm0Hb4176aRONUXTLuhf0rAY9hUlrxiVZe6ulX3wMXYN5PMzPw1a7A7rG3kJzwpR/b6g3
-        SM+8OwxtyOVjG3YsJg+L5O3M8AJDtaHfq9jNiIirSIZDqseMKLlKXYZjaHTvXTfAXWgnDTMmMwZa
-        jO/vKbe9ivQWtGCiDQZJ9vyrz+D1uGXGJCa5BvL6/mOWDLJhCtkWTCakzQwKO8qWUvuYNPOFKK9r
-        wzizfeRbBxqERaST7NoY1/noWdREvzJZCLwZAo+yalJN5yEzkTSkLadFUQZBwEL8Yg1uj8khFDa4
-        7Pdxyr5niFsoHOdBDtRa6nQPz5WezscFP6r1bOOClqcs9WQx8Vn+AgAA//8DAFsH6xFJBQAA
+        H4sIAAAAAAAAA4RUW2/TMBT+K1FeeGm7JGu7FmkSE0wIwbRJaAiB0HTinKamjm187F6Y9t+xHfcy
+        aUBfan/n/p3PecwNkhM2f509nh6Z9H/f83eu63bZPaHJfwyyvOGkBewkdPiSmUtuOQjqbfcRa5Ep
+        eslZ1T+RWSaAerNVOvewRkNKhpMyLUj+GyxXEsQR5xKttz0HXEgbwhXxLTCmnLThvjK1NlwyrkGA
+        2ybIcrZCq5XgbJdQ79B3lC5Ey33OBdD+6A2fafneKKdvF3eu/og7CniH+tbwlstrac2uJ0ODk/yX
+        Q97E+S7YbI5FicNZtZgMyxJhOK/q8XBSTcZFMZtXs2IaA0PLvvxGmQa3mptIQExRFVVRXJTzsphM
+        xpNve29PodWbhi1Btnh0HFfFqWPLG+m62s8RPMrpeeF/0/No8xMyg7GQ5d3fc/hiDKSSnIE4iKAJ
+        e31z/fXq5u7T9ejt7U10FcqzQUsUIjqd1Vye1UDLaOyAi5NY3EKnBY6Y6lKra5TPRRZxl6hsDsjp
+        ev/TkPvH/NTze9DmUnXYcOPVoPw2Y/8BOjsWlpREJhRbeY+Flz2GSKCH/fY8bI3boyvcWaiPmPav
+        Dc0am5PoDkODavHQBoXFwkFG3o/69xf6DJNcxk4GTF5GYzikfmjQsMtEaDgGTp986BqEC/Qk8mIx
+        Imgxvr7H3O50NG/ASC7b4JAIzb/4Cl4ZN5woWVJoMF7dfciSQ9bzm22AMqlsRijtIFso43M2mW9E
+        e4XVXHC7i/bWgQFpEZtRdkXkOp89i5yYV5SFxOs+8SCrRtX5NFRmqgllS7+9MhACFuL3qg97SAGh
+        sT7k6Snu188McZPSCRHoQGOUSffwWJvj+SCoA1vPtBS4PFYZj2YjX+UPAAAA//8DAGv6shJHBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -607,7 +557,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -635,7 +585,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -645,12 +595,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xQTWsCMRD9K0Muvciyaimlp4p4KFT0UEqhlDJuRhu6SZaZRFnE/97JumBv7828
-        9+bjbJgkt8k8wfkGP78mYJqYQyG14sQ5NJjIKt9jK6Q1TyJ4ICn6s0l9R4rMCTm4cDAqCOiH0jux
-        uBjWTmTsjNbSXGxfYBRAyH5HDCcUCDGBUEgT2EfWTAtN9B0mt3OtS/3QP2RkDInIVrAQyV7T1cRH
-        4juBEny8Bk9gVs3mD2Y4ypax03ldT5VaTDicfrV9j4ay2NVyuZRXaLZH7ku5hs3bFlL8pSDgMTU/
-        +pSLaog5sipCblulzt5wxy40rsO2BFjN6p9XH4v19nVVLTfrsta/uffVY6Vz/wAAAP//AwAOf/OC
-        mQEAAA==
+        H4sIAAAAAAAAA4xSTUsDQQz9K8NcvGyX7bZaFQoW8SBY7EFEEJG4k9bBnZl1Pqyl9L+bzFaqePGy
+        ZJK8l5e83UqPIbVRnovtIXzcSoWh8bqL2llOSJWM2RwFEd0bWvlUCKk7yA+3tugPPb9qyer3hFrl
+        8vGkHsOkOh5M8GQyGEOFA6jps6zVGY7UuDqtRxkdNx0SQt7d3i0kvRVL+MM5/Q9f0dipi12hmil+
+        gula5LBxRu54UuOS5YWHPNUn20BEFruENiDlDIYAKwz9Tb51rcFbbVcszYLJqXv0gU411yHsK3so
+        F2eLa7FvEDaZF/RiDUFYF0VAGwuxdJ44lSBdtKR+0a2Om1xfJfBgI6IqxSyEZIidQP4DPZnBxB89
+        cSHqsh6dyLyU4rHDUVXxXgoiZHt72PMewMJ6yC6fgrgN+A2nh4IO3zstDMTmlW6yoxb03rHTNrUt
+        m6wOcee1bcihlvH5P7i4epjNFzdX5eXtnFX9GDsuT0sa+wUAAP//AwDDkyzDfAIAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -663,9 +614,171 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
       - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 20 Apr 2020 10:55:46 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=BJbocA0sV184I%2fPY3G2x4z5tAd5fhJXUD5i3359GJFr5fZksUPzciWVMP4jtmOWMW7chZem3mV1Mm4oO9cJlVU%2bSMG26nK32gTN%2furYJFHY5cMXHdbne%2bj7d6ZbksaqIcDhxSF%2bre8kfz%2bOvgTjs1wqoGkou%2btHtTblj8sgx9Nfs7KbeskEe3l5%2fsip3bis8;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BJbocA0sV184I%2fPY3G2x4z5tAd5fhJXUD5i3359GJFr5fZksUPzciWVMP4jtmOWMW7chZem3mV1Mm4oO9cJlVU%2bSMG26nK32gTN%2furYJFHY5cMXHdbne%2bj7d6ZbksaqIcDhxSF%2bre8kfz%2bOvgTjs1wqoGkou%2btHtTblj8sgx9Nfs7KbeskEe3l5%2fsip3bis8
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Apr 2020 10:55:46 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [[], {"ipatokenuniqueid": "5724a705-7e67-4a0e-a20e-f2d9e3d40823"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BJbocA0sV184I%2fPY3G2x4z5tAd5fhJXUD5i3359GJFr5fZksUPzciWVMP4jtmOWMW7chZem3mV1Mm4oO9cJlVU%2bSMG26nK32gTN%2furYJFHY5cMXHdbne%2bj7d6ZbksaqIcDhxSF%2bre8kfz%2bOvgTjs1wqoGkou%2btHtTblj8sgx9Nfs7KbeskEe3l5%2fsip3bis8
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4yQTWsCMRCG/8qQSy/rsu6uru2pS+uhUNFDKYUqZTSjhGaTJckqIv73TnRBj72E
+        +cjzzjtzEo58p4N4gtN9uEWlSXL4vTonIPaoO4qZGFV5iVU2GlQ0rgYlZjTAnJ9tLh+pkGU2yQux
+        YqQh73FHPlInEY5t5MUBnVFmJ/iDweZS+iTnlTUz5X3f6dHYrBdv0H8A0zVrcnBAD8YG8GRCAlvr
+        WFPCxjYtBrVWWoXjpb/r0KEJRDKF2vuuYXWG3J7cg4covL8KJ5CneTGOkzdWxrHDIsuGnEoMeDnH
+        FfvpgWjsipzPcVXWbtAdY/mVNAWSMP9YQLC/ZGD5r5MthYh3JuesYx3Tac2pkre4dcpsVIs6jkHJ
+        2zxPv+rZ4n2avsxn0fyduzKdpOzuDwAA//8DAF2Dle3eAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Apr 2020 10:55:46 GMT
+      Keep-Alive:
+      - timeout=30, max=98
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
@@ -691,7 +804,64 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=BJbocA0sV184I%2fPY3G2x4z5tAd5fhJXUD5i3359GJFr5fZksUPzciWVMP4jtmOWMW7chZem3mV1Mm4oO9cJlVU%2bSMG26nK32gTN%2furYJFHY5cMXHdbne%2bj7d6ZbksaqIcDhxSF%2bre8kfz%2bOvgTjs1wqoGkou%2btHtTblj8sgx9Nfs7KbeskEe3l5%2fsip3bis8
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Apr 2020 10:55:46 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oze1q95WCeZWLwItI8CzDpeMEdAqnXyimKCGgkA1XRcuLbRbuz6dAlwXiUk%2f9tyjasPZsvdPq2bhBTsOL%2bnh3BRpz3is2BQDxLZDGJxzv0nXpZscz%2frFTyPTxfOUetITtJQWoy9q%2fXfPyoQlshTXwdZpKMYsaciSqM8vxR3JYA1WyHgUzZBfEcGvO8i7IDwl
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -718,9 +888,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
-      - timeout=30, max=99
+      - timeout=30, max=98
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
@@ -756,7 +926,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -764,20 +934,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 10:55:46 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=UsscqqYaKeZ48JPf29LP9lcZ2NuTOc%2f390OuONQ9z4G5xGno%2fK79gs4mw4kAbNSnIwjZrBaBMWib6QhkHeEVZAfHoIXy8APs%2faCnpk9wYQS8MzxzCpEeigB5W0ncSuw1szQTx2f2gDLrpQP9QpFbaseUT4w85VILgsBRQWyi7zzcRclYPakaren6vduD%2bMbA;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -799,7 +969,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=UsscqqYaKeZ48JPf29LP9lcZ2NuTOc%2f390OuONQ9z4G5xGno%2fK79gs4mw4kAbNSnIwjZrBaBMWib6QhkHeEVZAfHoIXy8APs%2faCnpk9wYQS8MzxzCpEeigB5W0ncSuw1szQTx2f2gDLrpQP9QpFbaseUT4w85VILgsBRQWyi7zzcRclYPakaren6vduD%2bMbA
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -826,7 +996,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 10:55:47 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -855,7 +1025,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=UsscqqYaKeZ48JPf29LP9lcZ2NuTOc%2f390OuONQ9z4G5xGno%2fK79gs4mw4kAbNSnIwjZrBaBMWib6QhkHeEVZAfHoIXy8APs%2faCnpk9wYQS8MzxzCpEeigB5W0ncSuw1szQTx2f2gDLrpQP9QpFbaseUT4w85VILgsBRQWyi7zzcRclYPakaren6vduD%2bMbA
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -883,7 +1053,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 10:55:47 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -911,7 +1081,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=UsscqqYaKeZ48JPf29LP9lcZ2NuTOc%2f390OuONQ9z4G5xGno%2fK79gs4mw4kAbNSnIwjZrBaBMWib6QhkHeEVZAfHoIXy8APs%2faCnpk9wYQS8MzxzCpEeigB5W0ncSuw1szQTx2f2gDLrpQP9QpFbaseUT4w85VILgsBRQWyi7zzcRclYPakaren6vduD%2bMbA
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -938,7 +1108,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 10:55:47 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_form_without_otp.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_form_without_otp.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:22 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=FrRDqGuRQ9EN6aFOYW5%2b3gFDsgP%2b7akqT%2bDu6CjQXMdTWn%2becIHStTrswJCPyPuq5Fl6UEH8iSQWNezaVI8etBxWi6A%2fVQFNEhMsy%2bR915CpwG7dr8CF7aY2iY6J%2fURPgf11jIQJIfBvV4NO7kjLpaReXtk5aK4As7muWpwmSRy3x5RSpFpFn%2fqIX3LzSAX0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=FrRDqGuRQ9EN6aFOYW5%2b3gFDsgP%2b7akqT%2bDu6CjQXMdTWn%2becIHStTrswJCPyPuq5Fl6UEH8iSQWNezaVI8etBxWi6A%2fVQFNEhMsy%2bR915CpwG7dr8CF7aY2iY6J%2fURPgf11jIQJIfBvV4NO7kjLpaReXtk5aK4As7muWpwmSRy3x5RSpFpFn%2fqIX3LzSAX0
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -107,8 +107,8 @@ interactions:
       message: Success
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
-      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-21T04:14:22Z"}]}'
+      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
+      "dummy_password", "fascreationtime": "2020-04-20T11:20:25Z"}]}'
     headers:
       Accept:
       - application/json
@@ -117,11 +117,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '249'
+      - '220'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=FrRDqGuRQ9EN6aFOYW5%2b3gFDsgP%2b7akqT%2bDu6CjQXMdTWn%2becIHStTrswJCPyPuq5Fl6UEH8iSQWNezaVI8etBxWi6A%2fVQFNEhMsy%2bR915CpwG7dr8CF7aY2iY6J%2fURPgf11jIQJIfBvV4NO7kjLpaReXtk5aK4As7muWpwmSRy3x5RSpFpFn%2fqIX3LzSAX0
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227aQBD9FcsvfQFiG0NJpUilKYmi5kLVpq3SRGi8O5gt9q67F8BF+ffurg0k
-        Uto8MT5zP3OWbShRmUKH74LtU5Nw+/Mz/GjKsg5uFcrwoROElKmqgJpDiS+5GWeaQaEa363HciRC
-        vRQssl9INClANW4tqtDCFUoluLOEzIGzP6CZ4FAccMZRW99zwLiyLl0otgFChOHafS9lVknGCaug
-        ALNpIc3IEnUlCkbqFrUBzUTth1KLXc05qJ1pHV/U4lwKU93Mpyb7hLVyeInVjWQ54xOuZd2QUYHh
-        7LdBRv1+x2kW0f7bUXfUHw27cYzQzRCS7iAZpFGEFBGGPtGNbNuvhaS4qZj0BPgSSZREUZrEURqn
-        SXK3i7YU6mpNyQJ4jv8LxI2WQEGDC9qGs1kGCofpbGa/w/H4AslggKQ8XtHT48XdeVxlyw9n3ydn
-        17eTzdnl8nr69fP4JHx8aBYugUNu5/Ybu66En1B34441ckeRclZ7DNWh5AQ3UFYFOpOIstEHWyF/
-        LqgWp9yUmaXd4fEwHYyiKBr0vdO0nNJ9+NM776t59/vJj/HV9HLSO7258qELUSJl0p5atIMfOejo
-        UKwQ9pJqgUXRuDPGjyxVi10nAlxwRl7tZP63QwmseJLbUtPb8aKak++fixUhkei1oFn57zNX9hGj
-        XKEjaG7fIrqNQc12krKwlmaHLrHWkB2wEt24Yj7z9/NNnI5tRdX8Abip3F6HS3vnK4d+tKkrKIwb
-        uz2ab6aUVZBq1KjryrvXIDnjuQto6Q2/2Q527yumVOtpU71upxdBGxA0bAdrUAEXOlBWm51gLqSt
-        SQM7SGX5y1jBdO39uQEJXCPSXjBWypS2euDZk29U4AqvmsKdIOkl/aHrTAR1beN+FMWOkOY1bcMm
-        bdYmuMGalEf/XGztErzawjGlSAPHWnDfcHEfeoJQSuGUwk1RuP8PerD30nYFgNo5n2nNsXvom/ZG
-        Pdv3LwAAAP//AwCr2hP42gUAAA==
+        H4sIAAAAAAAAA4RU227TQBD9FcsvvORmNwkpUiVCSSuglyAooNIqGu9O7CX2rtldpwlR/53ZtZM0
+        UqF96XguZ2bOnM0m1Giq3IZvgs1Tk0n69zN8XxXFOrgxqMP7VhByYcoc1hIKfC4spLACclPHbrwv
+        RabMc8kq+YXMshxMHbaqDMldojZKOkvpFKT4A1YoCfneLyRaih06KgfrypURK2BMVdK674VOSi0k
+        EyXkUK0alxVsgbZUuWDrxksJ9UTNhzHZFnMOZmtS4IvJzrWqyuv5tEo+4do4f4HltRapkBNp9bom
+        o4RKit8VCu73QwQ2iHu99iiej9pRhNAevYZ+exAP+r3e6Dge9Ya+0I1M7R+U5rgqhfYEeIi4R/X9
+        uBdFZPVvt9lEoS0fOMtApvi/RFxZDRwsuKRNOJslYHDYn83oOxyPP/az2whZcbzkp8fZ7XlUJot3
+        Z98nZ1c3k9XZxeJq+vXz+CR8vK8XLkBCihz9xq4rkyfc3bhFRuooMs5qjmFanJ3gCooyR2cyVWzH
+        YiCVFAzyna48zNvJj/Hl9GLSOb2+9KkFiPxJuAHrbJFSwWVVJHQolxMNj3r0Nxw0sSXKQ9l6f67o
+        ZibDvAbuJkJ2iZTMBzNVIBeaNKGaDbvO1eW78qq57YHnn0M81eILq5r64LvHQhJkGr0SrCieOfKg
+        PnJJTxj1Et1Yc3qJ6NYAM9sKitxWV1vvAtcWkr2vQDe5ms/89XwTp2JCNPXzd1O5Ffd39sEXzvxI
+        pUvIKzd2Q5VvZgzpx9RatOvShx9ASyFTl9BQFH6jDrT3pTCmiTSlXrXTD0GTENTEBw9gAqlsYEiZ
+        rWCuNGHygAYpib9E5MKufTytQIO0iLwTjI2pCkIPPHv6lQkc8LIGbgVxJz4aus5Mcdc2orNGjpD6
+        LW3CumzWFLjB6pJH/1gIuwAvoXDMOfLAsRbc1VzchZ4g1Fo50cgqz92vB9/bO9E4AOA054FeHLv7
+        vv3OqEN9/wIAAP//AwDGkLCi2AUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=k%2fbHwFjZHNqK43zmOz7TULpjLwUbW1gecinYu1msyyZheRVZ1hpvpecLkLMR6ydAPcAR8MvV9sYByCHg5gyrDuMAiscjwSYN9rMM1LVWjtJ7vsDWmC%2f8GAILCb9H0NqPUUJ2ggMrtNAEK5v2MLu7v6WPggkfAOcbrQggQNymyLLhNpeY2o17cLIWMwahFaSM
+      - ipa_session=MagBearerToken=FrRDqGuRQ9EN6aFOYW5%2b3gFDsgP%2b7akqT%2bDu6CjQXMdTWn%2becIHStTrswJCPyPuq5Fl6UEH8iSQWNezaVI8etBxWi6A%2fVQFNEhMsy%2bR915CpwG7dr8CF7aY2iY6J%2fURPgf11jIQJIfBvV4NO7kjLpaReXtk5aK4As7muWpwmSRy3x5RSpFpFn%2fqIX3LzSAX0
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:25 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -371,117 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -510,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -520,19 +410,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU224TMRD9FWtfeMlld3NpqFSJCiqEoGolVISKUDVrTzamXnvxpUmo8u94vJuk
-        hQqeMjtz5nbmOI+ZRReUz07Z49H89phxTb/Zu9A0W3bj0GbfBywT0rUKthoafCkstfQSlOtiN8lX
-        IzfuJfASHLcIXhrtZV+vzMs8n5ZFPi2mZXmbcKb6gdxzBa4r402bRXeL1hlNlrE1aPkrVQJ19EuN
-        PsaeOwK1p3Tj5AY4N0F7+r63VWul5rIFBWHTu7zk9+hboyTf9t4I6CbqP5xb7WvGjfZmDHx2q/fW
-        hPZqeR2qj7h15G+wvbKylvpCe7vtSGshaPkzoBRpv9fTKheTk8VwMVnMh0WBMKwQyuGsnE3zHAUi
-        zFMijRzbr40VuGmlTQQcaTwhKiONk9s9OlLo27XgK9D1C3z3wFoKHZoq7kGIYj6dLfI8n00OPfc0
-        HVQg6LBvLr6eX15/uhi9vbpMUNfNcrh3A1I9geMGmlbhiJsmhVemQSFtJNZEYgg3Jtc4oRMi/Gsw
-        ZSKpboWq6zGupB5X4Fb9Sg+on4t2X/E40X4/Dtpoyf+7n3a9fJTh9xG3jMJHUlZ8RmgfUDzxNUhz
-        m+VdTYpIRensEee6d0Vc0ThnqdeA67MUJKPv4gaCn/WkkUm87Si3k/ApK6LtbdAc/B+9nYMaXfeu
-        /balpbI1WC11TZrs98y+xIZRQZfSuT7Sp1Lw/PoD6wGsuwJbg2PaeOZQ+wFbGhtrChbnaqMSK6mk
-        36Z4HcCC9ohixM6dC02szhJF9pVjVPihKzxg5aiczLO0lKC2xSTPaS8BHtJfVJd21yfQYF3KLlER
-        azeQ1JMVjAhkDXi+inTsYhStNaQdHZSidyeO9kHTlPr3uSPiScfpaDGKHX8DAAD//wMADC0CrzsF
-        AAA=
+        H4sIAAAAAAAAA4RUbU/bMBD+K1a+7EtbktCWgoQ0tKFp2hBIE9O0aUJX+5p6OHZmO7QF8d9354S2
+        bKDlSy738tz5ucd5yDyG1sTsRDzszB8PmbT8zt63db0R1wF99nMgMqVDY2BjocaXwtrqqMGELnad
+        fBVKF15KXkCQHiFqZ6Pu8cq8zPNxmRcFWZPvKc/Nf6GM0kDoYKJrMnI36IOzbDlfgdX3CQnMzq8t
+        Roo9d7Tcnstd0GuQ0rU28vetnzdeW6kbMNCue1fU8hZj44yWm95LCd1E/UcIyydMOtGTSYEvYfnB
+        u7a5XFy180+4Ceyvsbn0utL23Ea/6UhroLX6d4tapfMhgpwQDcNZuZgNiwJhODuC8XBSTsZ5Pjsu
+        Z/k0FfLI1H7lvMJ1o30iYEfjUXG8TyNlE4WxWSm5BFu9znfoMLZ7Mo7GDUs0JvkP5toezCEsu+1q
+        Zdt6TqkcK6aHOT3TyVNHCdZZLcFsFaNYBG/Pv51dXH0+H727vOhh7tA+V1Xytz0nauvZ39N/QJeu
+        RqU9rcoR1Wl2dh2offhXp69Bmz1wXEPdGBxJV6ewDb14jJO3lLcg2SPrii4R+jtUe74auYdb3FSs
+        hwTKS6e80N0qZpyHOU29BtKepiAbfZcwUPK0n4FNHuORazsBn4iC7OhbKyH+1TsEqDB0tzpuGmYs
+        W4G32lasyJ7E7Cs1JP1c6BD6SF/KwbOrj6JPEB1jYgVBWBdFQBsHYuE8YSpBczWkw7k2Om5SvGrB
+        g42IaiTOQmhrQheJIv8mCAa+64AHohyVh9MsHUpx24L2wedSECH9oLqym76AB+tKHhMVhF1D2nRW
+        CCZQ1BDlkuh4pCh673jPtjWGb53a2VtBcem/WqKMvY7j0WxEHf8AAAD//wMAlNw+2jkFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -545,7 +434,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -573,7 +462,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -583,18 +472,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUW2vbMBT+K8Yve0lS23HSbFBY2coYW2lhdIyNUY6lE0eLLGm6JPFK/vskWbkU
-        yvYQIn3fuX7nyE+5RuO4zd9kT+dHIvzfj/y967o+ezCo85+jLKfMKA69gA5foplglgE3A/cQsRaJ
-        NC8Zy+YXEks4mIG2UuUeVqiNFOEkdQuC/QHLpAB+wplA67nngAthg7s0bAeESCdsuK91ozQThCng
-        4HYJsoys0SrJGekT6g2GitLFmNUh5hLM4eiJL2b1QUun7pb3rvmEvQl4h+pOs5aJG2F1P4ihwAn2
-        2yGjsb/XdVPQ6eVivJgu5uOyRBg3CNV4Vs3qokCKCPPoGEr26bdSU9wppqMAMURVVEVx6X91WVfT
-        7wdrL6FVW0pWIFo8GdZVeW7Ysg2K55NLOBWua3x/AS/n9WxRFMVsGkmXiqdH83NBj9Ei/fbm2/Xt
-        /eebybu722i6kh1Spr2m0msS7C4CdHEKxqWXzKyQ84FumLhowKwOmQgIKRj5byb3rx46YPzMF3fQ
-        KY4TIrtIm0Hb4176aRONUXTLuhf0rAY9hUlrxiVZe6ulX3wMXYN5PMzPw1a7A7rG3kJzwpR/b6g3
-        SM+8OwxtyOVjG3YsJg+L5O3M8AJDtaHfq9jNiIirSIZDqseMKLlKXYZjaHTvXTfAXWgnDTMmMwZa
-        jO/vKbe9ivQWtGCiDQZJ9vyrz+D1uGXGJCa5BvL6/mOWDLJhCtkWTCakzQwKO8qWUvuYNPOFKK9r
-        wzizfeRbBxqERaST7NoY1/noWdREvzJZCLwZAo+yalJN5yEzkTSkLadFUQZBwEL8Yg1uj8khFDa4
-        7Pdxyr5niFsoHOdBDtRa6nQPz5WezscFP6r1bOOClqcs9WQx8Vn+AgAA//8DAFsH6xFJBQAA
+        H4sIAAAAAAAAA4RUbW/TMBD+K1G+8KXtkqztOqRJTDAhBNMmoSEEQtPFuaamjm380jZM/e+cnaTt
+        pAH90vNzb4+fO+cpNWi9cOnr5OnUZJL+vqfvfNO0yYNFk/4YJWnFrRbQSmjwJTeX3HEQtvM9RKxG
+        puxLwar8icwxAbZzO6VTgjUaq2SwlKlB8t/guJIgjjiX6Mj3HPChbEhXlu+AMeWlC+e1KbXhknEN
+        Avyuhxxna3RaCc7aHqWAjlF/sHY11FyCHUxyfLar90Z5fbe89+VHbG3AG9R3htdc3khn2k4MDV7y
+        Xx55Fe+HCGxWZNl4USwX4zxHGC8uYDqeFbNpli0ui0U2j4mBMrXfKlPhTnMTBYgliozyL/LLPCdr
+        9m2IJgmd3lZsBbLGY+C0yE4DhSJ6doVCxJCzksuzEuwqOn1PsgozishKNVhxQ4IoulDMCNDZMaLm
+        G5TPV2GoJX1TkmABz+fnGf3ms+gjKZnBeCPHm7+TPR3boUVs/ebm6/Xt/aebydu72yGUgVSSs/+G
+        2k7GwwrW/2DaABcnpXAHjRY4YaqJbmn7JROKrSluSWuPQTawj8P0CHbGD+gaWwflEdP02tBssDrJ
+        bjCwUcvHOmxYbB/WiOJs9/7CBYLAV5HViMmr6AxGz8eOKnbVsw1mILyn1A0IH7TpRxybWQs1xtf3
+        lLpWR/cWjOSyDgG9mukX6kADu+XW9p4+NTiv7z8kfUDSiZlswSZSucSidKNkqQzVrBIiomnwJRfc
+        tdFfezAgHWI1Sa6t9Q1VT6Im5pVNQuFNV3iUFJPifB46M1WFtjmNKg+CgIP4verSHvuEQKxL2e/j
+        4OnOENdYeiGCHGiMMv05PNbqaB8W76DWs0UKWh67TCeLCXX5AwAA//8DAHVxFkNHBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -607,7 +496,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -635,7 +524,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -663,7 +552,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -691,7 +580,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PguLk036d%2b1SunaYovrxnBVXbk%2bf6bSKi0F1jz73ZCEyROIyxc3JqTnVHKlvPil%2fYsmqsnb4sIA40N5et4Z6r0qExzMzxVsM%2bd7FX7pKVAx2m37aHD6Kf9QnWp4g2sgQBT9Fs8z4thAFPU6t5ltzuHjjCS1iEm%2fqBsmzA5PpRm3BcEe%2b%2bIl7kR3yla8NUZl7
+      - ipa_session=MagBearerToken=V%2bcNklocQRfCoSeOJG3B4qzLQ0SktGfsSynO%2bz%2bpHuselES0t9fQPTNH3okqawYAeFexCPXTIyNsFqg7yqgMdrU%2b8hR5kHGCgpMHplFEIF1jTvf4YTgf2tyYYEa6SR5%2b8EcsBF%2bgBGbmA7HnG7PmyyjDmHwskw9wxSvrhTJ4hVJvyrPX1bZFEXzh4RLLMBk%2b
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -718,7 +607,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -769,13 +658,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 21 Apr 2020 04:14:23 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=Vw8ihvMhQgD8e2qlOkB0sd6ILabwUFoK6xhjqcOdIUnOcQFLijNkVAOxTjiHfl1i7uc8IVBDruG7mS3Enxc5TLLigxOKVK9Ct2T7PulAht4dI%2b9e9YAKenn8wPQg9bW3BnpO3dM4NfbdrvZrzlYWZHyEwfwNSxWVfnFHsG4GGwgU%2bKVVO%2boYs7B6Ni1%2f00SX;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -799,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=Vw8ihvMhQgD8e2qlOkB0sd6ILabwUFoK6xhjqcOdIUnOcQFLijNkVAOxTjiHfl1i7uc8IVBDruG7mS3Enxc5TLLigxOKVK9Ct2T7PulAht4dI%2b9e9YAKenn8wPQg9bW3BnpO3dM4NfbdrvZrzlYWZHyEwfwNSxWVfnFHsG4GGwgU%2bKVVO%2boYs7B6Ni1%2f00SX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -826,7 +715,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -855,7 +744,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=Vw8ihvMhQgD8e2qlOkB0sd6ILabwUFoK6xhjqcOdIUnOcQFLijNkVAOxTjiHfl1i7uc8IVBDruG7mS3Enxc5TLLigxOKVK9Ct2T7PulAht4dI%2b9e9YAKenn8wPQg9bW3BnpO3dM4NfbdrvZrzlYWZHyEwfwNSxWVfnFHsG4GGwgU%2bKVVO%2boYs7B6Ni1%2f00SX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -883,7 +772,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -911,7 +800,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=uud2Hu7ZV1J6x8Hs6XLd1H3X5eJObmFIyQxWedqYeaIqx5TFiUrrZj%2fLbuyhJ9jErK6lmgIdCXDxRU7x%2bmn%2bavJSLcylSgyygF0oQTkM2dJVUgYm6M2hV3yhBO3Ylxk6XDk%2bp2aZntdgrPhZMlhfUYepc1rXnNddgkcPtFf8Uj2cO%2bTUhHWkVmHYkd2PsAPH
+      - ipa_session=MagBearerToken=Vw8ihvMhQgD8e2qlOkB0sd6ILabwUFoK6xhjqcOdIUnOcQFLijNkVAOxTjiHfl1i7uc8IVBDruG7mS3Enxc5TLLigxOKVK9Ct2T7PulAht4dI%2b9e9YAKenn8wPQg9bW3BnpO3dM4NfbdrvZrzlYWZHyEwfwNSxWVfnFHsG4GGwgU%2bKVVO%2boYs7B6Ni1%2f00SX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -938,7 +827,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 21 Apr 2020 04:14:24 GMT
+      - Mon, 20 Apr 2020 11:20:26 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_user.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_password_user.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:53 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=sI8M6wkHSicuq5Xy4x5u6klqlZvqhxCfGAbbMQMA8GcSOGZRGa3nWuwxZasDy%2fE%2f4eqiWkhG%2bMr5m3hiV6Z4N5vZ5cMGWLnyfuc%2bG0k35s1LlnvzPhLJNrDUIgvigA5zhAmArFLXJMWncoSdHXwZc%2fJOP1ZgcoIWvZN%2f3NkSnBqAQzhb%2fp%2f5G973kQDfipkV;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=diwNccpDlBi72sbtzxrLO6JxFAbgtc8DD9N9AK7dfp87ox6EFbhuQon5MvTB2fieVIP7%2fLHt9e9883ksQowKdx%2bV641R4D%2fNG93XbJq%2bbVjArzkZayffafgXFLgJttw1jzfIVste6wDsspBSu1WXDLIcERbFZZbhW4gY48JB7jvBVz4EDPwV0vF8rzfBuNKH;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sI8M6wkHSicuq5Xy4x5u6klqlZvqhxCfGAbbMQMA8GcSOGZRGa3nWuwxZasDy%2fE%2f4eqiWkhG%2bMr5m3hiV6Z4N5vZ5cMGWLnyfuc%2bG0k35s1LlnvzPhLJNrDUIgvigA5zhAmArFLXJMWncoSdHXwZc%2fJOP1ZgcoIWvZN%2f3NkSnBqAQzhb%2fp%2f5G973kQDfipkV
+      - ipa_session=MagBearerToken=diwNccpDlBi72sbtzxrLO6JxFAbgtc8DD9N9AK7dfp87ox6EFbhuQon5MvTB2fieVIP7%2fLHt9e9883ksQowKdx%2bV641R4D%2fNG93XbJq%2bbVjArzkZayffafgXFLgJttw1jzfIVste6wDsspBSu1WXDLIcERbFZZbhW4gY48JB7jvBVz4EDPwV0vF8rzfBuNKH
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -74,11 +74,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -91,11 +91,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-14T13:19:53Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-04-21T04:14:28Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sI8M6wkHSicuq5Xy4x5u6klqlZvqhxCfGAbbMQMA8GcSOGZRGa3nWuwxZasDy%2fE%2f4eqiWkhG%2bMr5m3hiV6Z4N5vZ5cMGWLnyfuc%2bG0k35s1LlnvzPhLJNrDUIgvigA5zhAmArFLXJMWncoSdHXwZc%2fJOP1ZgcoIWvZN%2f3NkSnBqAQzhb%2fp%2f5G973kQDfipkV
+      - ipa_session=MagBearerToken=diwNccpDlBi72sbtzxrLO6JxFAbgtc8DD9N9AK7dfp87ox6EFbhuQon5MvTB2fieVIP7%2fLHt9e9883ksQowKdx%2bV641R4D%2fNG93XbJq%2bbVjArzkZayffafgXFLgJttw1jzfIVste6wDsspBSu1WXDLIcERbFZZbhW4gY48JB7jvBVz4EDPwV0vF8rzfBuNKH
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUJ2VyAVEJqSgMqLZeqhVYUFM3ak42bXXvrS0iK+PeO7Q0p
-        EoWnHZ+5+szx3qcajStt+ja5/9dkkj4/0w+uqtbJpUGd3raSlAtTl7CWUOFzbiGFFVCa6LsMWIFM
-        meeCVf4LmWUlmOi2qk4JrlEbJb2ldAFS/AErlIRyiwuJlnxPAefL+nRlxAoYU05af17ovNZCMlFD
-        CW7VQFawBdpalYKtG5QC4kTNwZj5puYMzMYkx1czP9bK1eezC5d/wrXxeIX1uRaFkBNp9TqSUYOT
-        4rdDwcP9IMsYZnu77T0c9tpZhtDORyxrD3vDQbcLvW6+n4VEPzK1v1Oa46oWOhAQSvS6vW53kA2y
-        fjYa9q830UShre84m4Ms8KVAXFkNHCz4oPt0Os3B4O5gOqVzOh6fDN3JFbJqtOSHo/n1cVbni/dH
-        3ydHZ5eT1dHnxdnFty/jg/ThNl64AgkFcgw39l2ZPOB+xy0yCk+R8VazDNPi7ABXUNUlepOpKozl
-        BJeuyoleXyLbG+7S6P3hKDiJeaYxEGBF9f+7uYbj0D4gFYhyC71rGnc2XYkMBlJJwaB8VHMMnfwY
-        n158nnQOz09DqIncP+p2rirkQpNSVHPvHQ/tbHuXioRg5ljGCXZyIXeI6Xl8D2KJ8ukDetz6Rqiv
-        TFS8RFlNjxj1Ej0hM3qL6EcGM91IimCr3QZd4NpCvsUq9HXVbBr2F+p7HVPFIPO54LTvdlxu/CN4
-        djz/29WH6Fc2/0CpSyidv2aztdDdGJKUifK06zq470BLIQsf0BCTXlEH0sSpMKbxNKlByBcfkyYg
-        iTwld2ASqWxiSKytZKY01eQJDVKTtnJRCrsO/sKBBmkReScZG+Mqqp4EOvUbk/jCy1i4lfQ6vf7Q
-        d2aK+7ZZv9vNPCHxed2nMW3aJPjBYspDeD9Uu4Kgn3RMnPLEs5bcRC5u0kAQaq38jqUrS/9D4Vv7
-        USq+AHCa84lKPLvbvoPOfmeQPvwFAAD//wMAOqVxyOsFAAA=
+        H4sIAAAAAAAAA4RU227aQBD9FcsvfQFiE0NIpUilKYmi5kLVpq3SRGi8O8AGe9fdC+Ci/Hv3YiCR
+        ouSJ8Zn7mbNsYonKFDr+GG2em4Tbnz/xF1OWdXSrUMYPrSimTFUF1BxKfM3NONMMChV8tx6bIRHq
+        tWCRPyLRpAAV3FpUsYUrlEpwZwk5A87+gWaCQ7HHGUdtfS8B48q6dKHYGggRhmv3vZB5JRknrIIC
+        zLqBNCML1JUoGKkb1AaEiZoPpebbmlNQW9M6vqv5uRSmupmOTf4Va+XwEqsbyWaMj7iWdSCjAsPZ
+        X4OM+v2Oj2jWJ9OsPTgc9NtpitDOUzxq97q9LEmQIkLfJ7qRbfuVkBTXFZOeAF+im3STJOumSZZm
+        3aO7bbSlUFcrSubAZ/hWIK61BAoaXNAmnkxyUNjPJhP7HQ+HF4+k10NSHi/p6fH87jyt8sXns1+j
+        s+vb0frscnE9/vFteBI/PYSFS+Aws3P7jV1Xwk+ou3HLGjNHkXJWcwzVouQE11BWBTqTiDLogy2R
+        vxRUg1NuytzS7vC0n/UGSZL0AkWm4ZTuwp/feVfNuz+Nfg+vxpejzunNlQ+dixIpk/bUohn8wEEH
+        +2KFsJdUcyyK4M4ZP7BUzbedCHDBGXm3k3lrhxJY8Sy3oaaz5UWFk++eixUhkei1oFn5ypkH4cyV
+        fcQol+gImtq3iG5jUJOtpCyspdmiC6w15HusRDeumE78/XwTp2NbUYU/ADeV22t/ae9859BPNnUJ
+        hXFjN0fzzZSyClJBjbquvHsFkjM+cwENvfFP28HufcWUajxNqtft+CJqAqLAdrQCFXGhI2W12Yqm
+        QtqaNLKDVJa/nBVM194/MyCBa0TaiYZKmdJWjzx78oOKXOFlKNyKup3uYd91JoK6tulhkqSOkPCa
+        NnFImzQJbrCQ8uSfi61dgldbPKQUaeRYi+4DF/exJwilFE4p3BSF+/+ge3snbVcAqJ3zhdYcu/u+
+        WWfQsX3/AwAA//8DAJw+DLDaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,11 +157,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sI8M6wkHSicuq5Xy4x5u6klqlZvqhxCfGAbbMQMA8GcSOGZRGa3nWuwxZasDy%2fE%2f4eqiWkhG%2bMr5m3hiV6Z4N5vZ5cMGWLnyfuc%2bG0k35s1LlnvzPhLJNrDUIgvigA5zhAmArFLXJMWncoSdHXwZc%2fJOP1ZgcoIWvZN%2f3NkSnBqAQzhb%2fp%2f5G973kQDfipkV
+      - ipa_session=MagBearerToken=diwNccpDlBi72sbtzxrLO6JxFAbgtc8DD9N9AK7dfp87ox6EFbhuQon5MvTB2fieVIP7%2fLHt9e9883ksQowKdx%2bV641R4D%2fNG93XbJq%2bbVjArzkZayffafgXFLgJttw1jzfIVste6wDsspBSu1WXDLIcERbFZZbhW4gY48JB7jvBVz4EDPwV0vF8rzfBuNKH
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -195,11 +195,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -212,11 +212,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -263,11 +263,11 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -354,11 +354,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AlSfM3x5fhZ1c3bsXx9r9PMO9HlnnL+AwAA//8DAG2Fr3yCAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -371,11 +371,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:54 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -410,19 +410,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUXW/TMBT9K1ZeeGm7JG3pNmkSE0wIwbRJaAgNoenGvk3MHDv4Y22Z+t/xddJ2
-        gwme6tyPc889Pu5jZtEF5bNT9ng4fnvMuKbf7F1o2w27cWiz7yOWCek6BRsNLb6Ullp6Ccr1uZsU
-        q5Eb91LxEhy3CF4a7eWAV+Zlns+KWTEtTubT21Rnqh/IPVfgehhvuiyGO7TOaDoZW4OWvxISqENc
-        avQx9zwQaDy1GyfXwLkJ2tP3va06KzWXHSgI6yHkJb9H3xkl+WaIxoKe0fDhXLPDjBvtjjHx2TXv
-        rQnd1fI6VB9x4yjeYndlZS31hfZ204vWQdDyZ0Ap0n5QFByLxevxAufluCgQxtUJL8bzcj7Lcyjz
-        6rhIjUQ5jl8ZK3DdSZsEOMi4iCKSjLPbXXWU0HcrwRvQ9Qt6D4WNaVFIGzc0kSFVHVHoSND17Qfv
-        tNpbIaXfXHw9v7z+dDF5e3XZ3758QP3cLinueqJ7M4Rh+cMQZaJKrkGleg6V1EcVuCYlW5DqyVRc
-        Q9spnHDTDlOFDm0VsammWMxfxzWn85Mdew7aaMn/yz78C0e7wT7K8PtYsIzGR3JWfEZoH1A8ibVI
-        KGZ5V5MjEhpde6xLrmikEKjHKen6h0b60PyzxGzE9VmqpsMw1o0EPxs2pyMtv6Xe3tOnrIhnb4Pm
-        4P8g4xzU6PqH7jcdSZCtwGqpa6IzqJJ9iQOjpS6lc0NmaKXk+fUHNhSwXiS2Ase08cyh9iO2NDZi
-        ChZ5ddGalVTSb1K+DmBBe0QxYefOhTais6SZfeUYAT/0wCNWTsrpPEtLCRpbTPOc9hLgIf1n9W13
-        QwMR61u2SYqI3UJycVYwEpC14HkT5djGLFpr6Gp1UIoeojic9/6m1r/NESueTJxNjiezbPsbAAD/
-        /wMAfSAkVEwFAAA=
+        H4sIAAAAAAAAA4RUa2/TMBT9K1a+8KWPJEu7MmkSE0wIwbRJaAiB0OTYt4mZYwc/1oZp/x1fO203
+        GPCpzrnnvo6Pe58ZsF667ITcH45f7zOm8Dd747tuINcWTPZtQjIubC/poGgHz4WFEk5QaVPsOmIN
+        MG2fI6+pZQaoE1o5MdYr8zLPq7LIq6IqV18iT9ffgTkmqU1lnO6zAPdgrFZ40qahSvyMlag84EKB
+        C7GngMf2mK6t2FLGtFcOv29N3RuhmOippH47Qk6wW3C9loINIxoIaaLxw9p2VzNstDuGwEfbvjXa
+        95frK1+/h8Ei3kF/aUQj1LlyZkii9dQr8cOD4HG/l8e8WrJ1NV0drZbTogA6rQs4ni7KRZXnwAHo
+        MibiyKH9RhsO216YKMBBxmOU8iBjYAcJXb/hrKWq+bveXnDluzrsgYxiWS1WeZ4vUs9Wd8CFCevr
+        MD4S5gjNOd5tum9xB+qpQSLeUSEjFKmvYEu7XsKM6W6/zE7/fXainn8+u7j6cD57fXmxozKqtBLs
+        v9TmX7vYJNbekFKHe7EtyDTnvBZqXlPb7lQ59ImIsqN9pGa3IbYOxgd0VnhGYO6AP8I6wCH0+qZB
+        R8RCeO2BZ9O7wlGwx2msP2HqNAbxMHaxE85OR9XwiMI9YG6y8AkpwtkZrxh1v/W2ljZg07t2Q4+C
+        ZRtqlFANenLUMPsUGgYHXQhrx8iYisGzq3dkJJAkKdlQS5R2xIJyE7LWJtTkJMzVByfWQgo3xHjj
+        qaHKAfAZObPWd6E6iRKZF5Zg4btUeELKWXm0zOJSHNsWR3mOe3HqaPyLSmk3YwIOllIeohShdkej
+        L7OCoICko461QY6HEAVjNBpBeSnx3fHDeW89TP3TSoHxqGM1W81Cx18AAAD//wMAsR7tMDsFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,11 +434,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -463,7 +462,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -473,19 +472,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU2WobMRT9lWFe+mI7M17ipBBoaEMpbUigpJSWEu5I12PVGknVYnsS/O/V5iUQ
-        Wvxg6dxzz101z6VG47gt3xbPp0ci/N/P8oPrur54MKjLX4OipMwoDr2ADl8zM8EsA26S7SFiLRJp
-        XiPL5jcSSziYZLZSlR5WqI0U4SR1C4I9gWVSAD/iTKD1tpeAC7LBXRq2BUKkEzbcV7pRmgnCFHBw
-        2wxZRlZoleSM9Bn1hJRRvhiz3GsuwOyP3vDVLD9q6dTd4t41n7E3Ae9Q3WnWMnEjrO5TMxQ4wf44
-        ZDTWB3VNsJ6fD+c4Gw/rGmHYXJJ6OBvPplUF46q5qKNjSNmH30hNcauYjg2IEuNqXFXzeuJ/l7Pp
-        jz3bt9CqDSVLEC0eidN6ekr0VRCNUcyy7hXeJPFMinWYUweMR4SG+b3DLXSK44jILs2XrVG8XIiM
-        U+G6xosEvJ7Pzn2oyezyUOJ+KgffpH/z/fr2/svN6P3dbaRy6btqlshTEmcNE2cNmOVeh4CQgpH/
-        6rg8BnrIcCk7pEz7kUs/sigeoLMjw/2rBmHymnFJVp6w8IuPQRbM435+Hrba7dEV9haaI6b8e0O9
-        Rnri3WGIJxePbdixGDcskueZNI1sZyKlfsJbMkpRDCOQyDSMMlRxFWsaEHEVlcIhJ28GlFzlmYZj
-        GOvOu66Bu9DO3K8Y2RhoMT7W59L2Kpo3oAUTbSDkAZTffAS/ZLfMmGzJrsF4ff+pyIQi9bbYgCmE
-        tIVBYQfFQmqvSQufiPLL2jDObB/trQMNwiLSUXFtjOu8ehEbqN+YIgivk/CgGI/Gk1mITCQNYetJ
-        VdWhIWAhft6S22N2CIkll90uPgFfM8SdEI7z0A7UWup8D2+bHs+HRT5068XuhV4eo0xHF6NpufsL
-        AAD//wMAy57+T3YFAAA=
+        H4sIAAAAAAAAA4RUW2vbMBT+K8Yve8nFTp00GxRWtjLGVloYHWNjlGPpxNEiS5ouSb3S/z4d2bkU
+        dnkIkb5z/84nP+YWXZA+f5U9nh6Zin/f8rehbbvszqHNv4+ynAtnJHQKWvyTWSjhBUjX2+4S1iDT
+        7k/Ouv6BzDMJrjd7bfIIG7ROKzpp24ASv8ALrUAecaHQR9tzIFBaCtdOPABjOihP942tjRWKCQMS
+        wsMAecE26I2WgnUDGh36joaLc+t9zhW4/TEaPrn1O6uDuVndhvoDdo7wFs2NFY1QV8rbrifDQFDi
+        Z0DB03wvz3m1YKtqvDxbLsZliTCuSzwfz2fzqiiQI8IiBVLLsfxOW44PRthEQEoxK2ZFcR5/VVnN
+        ll/33pFCb3acrUE1eHSsZuWpYxBchbaOc5BHuajmy6Io5n3NtW6RCxvH17F9cpgSNOW0s314wo9I
+        pIVZTN150f698OkKDspJaV5ffbm8vv14NXlzc51cWxDyxIwP0BqJE6bbXktii+q5+BIudWTerVH2
+        wdNaqGkNbp2MrufuoLvmXzzEXhkorQT7b6/KDTKTmm2i3yoKH4lKcPf7/UXY27BHN9h5qI+Yie8N
+        7Rb5SXSL1Jpe3TeksVSehBT9XP8CaRpaxkXqasTURTLSYejHjTi7GKijI7H3FEO3IAMNNKwwFXMO
+        Gkzv7zH3nUnmHVglVEMOAwX551ghrvlaODdYhlAyXt6+zwaHrGc224HLlPaZQ+VH2UrbmJNnsRET
+        5VILKXyX7E0AC8oj8kl26VxoY/YscWJfuIwSb/vEo2w2mZ0tqDLTnMqWZ0VREiHgIX2x+rD7IYAa
+        60OenpIK4syQpK2ClEQHWqvtcKfnyo/ng1wPbD3bPnF5rFJNlpNY5TcAAAD//wMAwAURzkkFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -498,11 +496,67 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[], {"ipatokenowner": "dummy"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQTWsCMRD9K0Muvciyaimlp4p4KFT0UEqhlDJuRhu6SZaZRFnE/97JumBv7828
+        9+bjbJgkt8k8wfkGP78mYJqYQyG14sQ5NJjIKt9jK6Q1TyJ4ICn6s0l9R4rMCTm4cDAqCOiH0jux
+        uBjWTmTsjNbSXGxfYBRAyH5HDCcUCDGBUEgT2EfWTAtN9B0mt3OtS/3QP2RkDInIVrAQyV7T1cRH
+        4juBEny8Bk9gVs3mD2Y4ypax03ldT5VaTDicfrV9j4ay2NVyuZRXaLZH7ku5hs3bFlL8pSDgMTU/
+        +pSLaog5sipCblulzt5wxy40rsO2BFjN6p9XH4v19nVVLTfrsta/uffVY6Vz/wAAAP//AwAOf/OC
+        mQEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 21 Apr 2020 04:14:28 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -526,7 +580,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
       User-Agent:
       - python-requests/2.23.0
     method: POST
@@ -549,11 +603,11 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:28 GMT
       Keep-Alive:
-      - timeout=30, max=97
+      - timeout=30, max=96
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -579,7 +633,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=cTKSYsUjnuWlC%2flHIAf567JvrzhR0pd2RYtrMTBTCzA18Y27I%2fIoajc7ocsDrnx0vvI3pgiERbaepkUZaF7M%2bVXsS0mKfmLmxqSr6eynvln0mvUxVrGrgObQwOWJ8oxXG7iETXLcuwkzoO5pFKrynbGybzc19yEyStggIuvqSSetbhl8fT5%2bYsAFm8TEzxFH
+      - ipa_session=MagBearerToken=otZtgzAY2Vg6mojpyl%2f7n1ufuQYf0gjwwKgtkwdflkQ6GkYMkx0vdOMRM0DoDY%2bInktjb9Ux3%2fGMQ4GIGoJH2T%2fP0Zv1deX5UvYw93KH2LJFQX9M3jH4r7FXkaj97GLSA1lW7g6GUG3JopDodDAFSvFqcj6smGUrUZazHZG1jhOHneNLibVGBzo9wifqgYY3
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -589,11 +643,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yPS2vDMBCE/8qiSy9G5FUoPdWUHAoxyakUSimKtTECPcyunGCM/3sl2+DeRjsz
-        32oHQcidjeIVhlX6ztoChENm1SCnyfcgYt9iUuKhyBvfiBTwyk2jTyQ2wVeGeXGWajbLywcsgQR2
-        VyR4KAYfIjD6WMAtUGJqqINrVTRXY03sJ7/pFCkfEbWEkrlziZ5KdEd6Ysjg+wwuYCd3++e8uQ46
-        r93uN5ttemoV1XTcXPtdCvljc2Ucf8aUQ6JA6+lGr7ol42vTKptLunOufzt+ldXldJTv5yrv/Ac9
-        yBd5EOMfAAAA//8DAJwAjXpYAQAA
+        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
+        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
+        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
+        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
+        5aPM0D8AAAD//wMA5lpmj1gBAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -606,11 +660,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:29 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -657,13 +711,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=aSkjaFiRqv9qAnfyXSNjhoMdHF%2fITR8TSx9CfjLpRJTR1xqbSYuzEFCkD4FceDfFrHgbNxpU9%2fS%2fQOPVpnxUqmmhoiRmhGRCnJ0CoEYSXsyix%2fZj9gmHURxIRXa8YJfBnbfxYf6YHU%2bD8TtfirQObMQPCXfNIFB8FreL7pgCj%2be0ZPR3T0HV2m6nHx2BuMhu;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=NABUVPc0n3YJkEvuBUAt3PDtWhr8BYXMDViy%2b%2f7LMZ0BNQkgN3p1TZTlsmxKjgkAjlurpT5StuLVD2fH49iYygvoXT%2bdE6tudDoGiiPfPVLYvCqsnp8aM6H7E2nrkWnkwCypX6%2b7gydtpzxAU0mqDMLUXh1YiAjqFvOVuXypaCvjPObegnp2wNH9H74iXsbn;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -687,7 +741,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=aSkjaFiRqv9qAnfyXSNjhoMdHF%2fITR8TSx9CfjLpRJTR1xqbSYuzEFCkD4FceDfFrHgbNxpU9%2fS%2fQOPVpnxUqmmhoiRmhGRCnJ0CoEYSXsyix%2fZj9gmHURxIRXa8YJfBnbfxYf6YHU%2bD8TtfirQObMQPCXfNIFB8FreL7pgCj%2be0ZPR3T0HV2m6nHx2BuMhu
+      - ipa_session=MagBearerToken=NABUVPc0n3YJkEvuBUAt3PDtWhr8BYXMDViy%2b%2f7LMZ0BNQkgN3p1TZTlsmxKjgkAjlurpT5StuLVD2fH49iYygvoXT%2bdE6tudDoGiiPfPVLYvCqsnp8aM6H7E2nrkWnkwCypX6%2b7gydtpzxAU0mqDMLUXh1YiAjqFvOVuXypaCvjPObegnp2wNH9H74iXsbn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -697,11 +751,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jUYOy2MHgoLy2kMxhhq7AZDbAfJXgkh/31yYtYeDLKk
-        59UrTRI1xT7IZzFJitYCjhzLU1MJ0virUfAj4504lE/loRRVc/pP7crd/lEWQlpNBJ0mRr8mGcZB
-        J5EroDOuSw0O7JL6WMnaEOVKRlMxSecG4aI98/ArkHA+sBcXCnHxyJpKtN4OEMzZ9CaMS72LgOCC
-        1oodEi/C6nmBB7r3XNxMt16lsdv9ZrPlr4IA6xkW7CcDydiKzPP3zH0a0SNnXex7/hp1iwc0rjUD
-        9AkCxSZejp9V3bwdy9f3Os28E13uKec/AAAA//8DAMnZqp+CAQAA
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -714,11 +768,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:29 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -743,7 +797,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=aSkjaFiRqv9qAnfyXSNjhoMdHF%2fITR8TSx9CfjLpRJTR1xqbSYuzEFCkD4FceDfFrHgbNxpU9%2fS%2fQOPVpnxUqmmhoiRmhGRCnJ0CoEYSXsyix%2fZj9gmHURxIRXa8YJfBnbfxYf6YHU%2bD8TtfirQObMQPCXfNIFB8FreL7pgCj%2be0ZPR3T0HV2m6nHx2BuMhu
+      - ipa_session=MagBearerToken=NABUVPc0n3YJkEvuBUAt3PDtWhr8BYXMDViy%2b%2f7LMZ0BNQkgN3p1TZTlsmxKjgkAjlurpT5StuLVD2fH49iYygvoXT%2bdE6tudDoGiiPfPVLYvCqsnp8aM6H7E2nrkWnkwCypX6%2b7gydtpzxAU0mqDMLUXh1YiAjqFvOVuXypaCvjPObegnp2wNH9H74iXsbn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -753,11 +807,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXULoazB2Wtl6GKyspzFYy1BjNRj8CLLdEkr++6wmsN6kT99D
-        0lUxxWyTeobrfXlCY0mX8ucwVKDOaDNJp3R2rleHgjmKEVuKAl9V6jshqAuyN75VheDR3aAv4miC
-        35oYp8kkleF69w4TAXx2R2K4YAQfEkTyqYJT4OKpoQmuw2SOxprU3+ZtRkafiHQN6xizK+5FxGfi
-        hwhifB6NK1jUi+WjJDdBS+x8OZvNS6sx4e3eUfY7CWSxUTIMcmrxdsi9wG9kKZGGXBSwH9+xV0qe
-        RMyBC8dna0tr9H/dsfGN6dCKBeqy6cvme73dfWzq18+tLHaXvKqf6pUa/gAAAP//AwAnUrPDmwEA
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroY4yx00rXw2BlPY3BWoZaq8VgO0G2U0LJf5/UBNab9Ol7
+        SLoaplR8Ni9wvS9P6DxZKX/2/QRMi76QdsaWEDqzFyxQSnimpPDV5K5RgrkgRxfPRggRww36Ik6u
+        jhuX0jgZpTpcbt9hJEAs4UAMF0wQ6wyJYp7AqWbxtHCsQ4PZHZx3ubvNzwUZYyayFSxTKkHcRcQt
+        8UMCNW4H4wnMq/niSZOPtdXY2WI6nUlrMePt3kH2Owp0sUHS93qqeAfkTuE38pTJQhEF7IZ37IzR
+        JxFzzcKJxXtpnf2vG3bx6Br0aoFWNn1dfy832491tfrc6GJ3yY/VcyXJfwAAAP//AwC881l1mwEA
         AA==
     headers:
       Cache-Control:
@@ -771,11 +825,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:29 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -799,7 +853,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=aSkjaFiRqv9qAnfyXSNjhoMdHF%2fITR8TSx9CfjLpRJTR1xqbSYuzEFCkD4FceDfFrHgbNxpU9%2fS%2fQOPVpnxUqmmhoiRmhGRCnJ0CoEYSXsyix%2fZj9gmHURxIRXa8YJfBnbfxYf6YHU%2bD8TtfirQObMQPCXfNIFB8FreL7pgCj%2be0ZPR3T0HV2m6nHx2BuMhu
+      - ipa_session=MagBearerToken=NABUVPc0n3YJkEvuBUAt3PDtWhr8BYXMDViy%2b%2f7LMZ0BNQkgN3p1TZTlsmxKjgkAjlurpT5StuLVD2fH49iYygvoXT%2bdE6tudDoGiiPfPVLYvCqsnp8aM6H7E2nrkWnkwCypX6%2b7gydtpzxAU0mqDMLUXh1YiAjqFvOVuXypaCvjPObegnp2wNH9H74iXsbn
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -809,11 +863,11 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xPS2vDMAz+K8KXXYLpazB2Whg9DBbW0xiMMdRYDQbHDpLTUkL+++wkkN0+6XtJ
-        g2KS3kX1DMMKfe9cAaolEWxI0uZ7UPHeUULqhuytb1QSeGyn1Sex2OArK7IwizWT5ekNFkEKbs/E
-        cEMBHyII+VjAJXDKNFCHtsNoz9bZeJ/4pkdGH4mMhlKkb1N6MvGV+EEgB1/n4AJ2erd/zM11MLl2
-        u99stmk0GHF6brb9LoZ82GwZx58x6Yg58Pq6NSvu2PraduiyCU064uX4VVan96N+/ahy57/Qg37S
-        BzX+AQAA//8DADhciJlYAQAA
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -826,11 +880,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 14 Apr 2020 13:19:55 GMT
+      - Tue, 21 Apr 2020 04:14:29 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:

--- a/noggin/tests/unit/controller/test_password_reset.py
+++ b/noggin/tests/unit/controller/test_password_reset.py
@@ -77,6 +77,38 @@ def test_password_changes_user(client, logged_in_dummy_user):
 
 
 @pytest.mark.vcr()
+def test_password_form_with_otp(client, logged_in_dummy_user, dummy_user_with_otp):
+    """Verify that the password change form shows OTP form elements
+       when a user has OTP enabled"""
+    result = client.get("/user/dummy/settings/password")
+
+    page = BeautifulSoup(result.data, "html.parser")
+
+    currentpasswordinput = page.select_one("#currentpasswordinput .form-text")
+    assert currentpasswordinput is not None
+    expected = "Just the password, don't add the OTP token if you have one"
+    assert expected in currentpasswordinput.get_text(strip=True)
+
+    otpinput = page.select("#otpinput")
+    assert len(otpinput) == 1
+
+
+@pytest.mark.vcr()
+def test_password_form_without_otp(client, logged_in_dummy_user):
+    """Verify that the password change form shows OTP form elements
+       when a user has OTP disabled"""
+    result = client.get("/user/dummy/settings/password")
+
+    page = BeautifulSoup(result.data, "html.parser")
+
+    currentpasswordinput = page.select("#currentpasswordinput .form-text")
+    assert len(currentpasswordinput) == 0
+
+    otpinput = page.select("#otpinput")
+    assert len(otpinput) == 0
+
+
+@pytest.mark.vcr()
 def test_non_matching_passwords_user(client, logged_in_dummy_user):
     """Verify that passwords that dont match are caught"""
     result = client.post(


### PR DESCRIPTION
previously, the form a logged in user used to change their
password presented fields and descriptions for OTP stuff
when a user hadnt enrolled an OTP token.

This hides those descriptions and fields if a user has not
enabled a OTP token.

Note that the descriptions are still shown on the expired password
reset page as this is not a logged in page, and we cannot know if the
user has an OTP setup there (nor would we want to expose that fact to
the world if not logged in)

Resolves: #206

Signed-off-by: Ryan Lerch <rlerch@redhat.com>