### PR TITLE
Add undo buttons to the flash messages for group edits

### DIFF
--- a/noggin/tests/unit/controller/test_group.py
+++ b/noggin/tests/unit/controller/test_group.py
@@ -107,10 +107,22 @@ def test_group_add_member(client, dummy_user_as_group_manager, make_user):
         result = client.post(
             '/group/dummy-group/members/', data={"new_member_username": "testuser"}
         )
+
+    expected_message = """You got it! testuser has been added to dummy-group.
+    <span class='ml-auto' id="flashed-undo-button">
+        <form action="/group/dummy-group/members/remove" method="post">
+            
+            <button type="submit" class="btn btn-outline-success btn-sm"
+             name="username" value="testuser">
+                Undo
+            </button>
+        </form>
+    </span>"""  # noqa
+
     assert_redirects_with_flash(
         result,
         expected_url="/group/dummy-group/",
-        expected_message="You got it! testuser has been added to dummy-group.",
+        expected_message=expected_message,
         expected_category="success",
     )
 
@@ -181,10 +193,20 @@ def test_group_remove_member(client, dummy_user_as_group_manager, make_user):
     result = client.post(
         '/group/dummy-group/members/remove', data={"username": "testuser"}
     )
+    expected_message = """You got it! testuser has been removed from dummy-group.
+    <span class='ml-auto' id="flashed-undo-button">
+        <form action="/group/dummy-group/members/" method="post">
+            <input id="username" name="username" required type="hidden" value="testuser">
+            <button type="submit" class="btn btn-outline-success btn-sm"
+             name="new_member_username" value="testuser">
+                Undo
+            </button>
+        </form>
+    </span>"""
     assert_redirects_with_flash(
         result,
         expected_url="/group/dummy-group/",
-        expected_message="You got it! testuser has been removed from dummy-group.",
+        expected_message=expected_message,
         expected_category="success",
     )
 
@@ -214,10 +236,22 @@ def test_group_remove_self(client, logged_in_dummy_user, dummy_group):
     result = client.post(
         '/group/dummy-group/members/remove', data={"username": "dummy"}
     )
+
+    expected_message = """You got it! dummy has been removed from dummy-group.
+    <span class='ml-auto' id="flashed-undo-button">
+        <form action="/group/dummy-group/members/" method="post">
+            <input id="username" name="username" required type="hidden" value="dummy">
+            <button type="submit" class="btn btn-outline-success btn-sm"
+             name="new_member_username" value="dummy">
+                Undo
+            </button>
+        </form>
+    </span>"""
+
     assert_redirects_with_flash(
         result,
         expected_url="/group/dummy-group/",
-        expected_message="You got it! dummy has been removed from dummy-group.",
+        expected_message=expected_message,
         expected_category="success",
     )
 

--- a/noggin/themes/default/templates/main.html
+++ b/noggin/themes/default/templates/main.html
@@ -34,7 +34,7 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
+            <div class="alert alert-{{ category }} alert-dismissible fade show d-flex align-items-center">
                 {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -36,7 +36,7 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
+            <div class="alert alert-{{ category }} alert-dismissible fade show d-flex align-items-center">
                 {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>

--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -46,7 +46,7 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
+            <div class="alert alert-{{ category }} alert-dismissible fade show d-flex align-items-center">
                 {{ flash }}
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span>

--- a/noggin/utility/__init__.py
+++ b/noggin/utility/__init__.py
@@ -2,7 +2,7 @@ import hashlib
 from functools import wraps
 from contextlib import contextmanager
 
-from flask import abort, flash, g, redirect, url_for, session
+from flask import abort, flash, g, redirect, url_for, session, Markup
 from flask_babel import lazy_gettext as _
 import python_freeipa
 
@@ -155,3 +155,21 @@ def handle_form_errors(form):
         yield
     except FormError as e:
         e.populate_form(form)
+
+
+def undo_button(form_action, submit_name, submit_value, hidden_tag):
+    """return an undo button html snippet as a string, to be used in flash messages"""
+
+    undo_text = _("Undo")
+
+    template = f"""
+    <span class='ml-auto' id="flashed-undo-button">
+        <form action="{form_action}" method="post">
+            {hidden_tag}
+            <button type="submit" class="btn btn-outline-success btn-sm"
+             name="{submit_name}" value="{submit_value}">
+                {undo_text}
+            </button>
+        </form>
+    </span>"""
+    return Markup(template)


### PR DESCRIPTION
This adds undo buttons to the flash messages for the actions:

* removing a user from a group
* adding a user to a group

Resolves: #211

Signed-off-by: Ryan Lerch <rlerch@redhat.com>