### PR TITLE
Set the correct OpenID URL suffix for the openSUSE Accounts theme

### DIFF
--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -1,6 +1,8 @@
 {% extends "master.html" %}
 {% block website %}{{_("openSUSE Accounts")}}{% endblock %}
 
+{% set OPENID = '.sso.opensuse.org' %}
+
 {% block head %}
     <link href="{{ url_for('theme.static', filename='css/chameleon.css') }}" rel="stylesheet" type="text/css" />
     <link href="{{ url_for('theme.static', filename='css/accounts.css') }}" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
The openSUSE Ipsilon instance is sso.opensuse.org.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>