### PR TITLE
escape the OTP token description in the URI

### DIFF
--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlparse
+from urllib.parse import urlparse, quote
 
 from flask import flash, redirect, render_template, session, url_for, Markup
 from flask_babel import _
@@ -154,7 +154,7 @@ def user_settings_otp(ipa, username):
             # the token's UUID
             principal = uri.path.split(":", 1)[0]
             new_uri = uri._replace(
-                path=f"{principal.lower()}:{addotpform.description.data}"
+                path=f"{principal.lower()}:{quote(addotpform.description.data)}"
             )
             session['otp_uri'] = new_uri.geturl()
         except python_freeipa.exceptions.InvalidSessionPassword:

--- a/noggin/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_check_description_escaping.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_check_description_escaping.yaml
@@ -1,0 +1,2024 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:40 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=ysF5YOpRl2UI1oBNJ%2bwFk2TLOPIC%2fLzh5lK7ChpzuCBVAfGHAO73hDuBFGI%2f6jR0PYIXJMFlkCUS0%2bHe4CXaKfIysQR1GKD1AQpT50%2furXFyeH02r27QIAB9%2b1U6CixPNwPfTu4ekpoqyFW5iPCmCOm4sUQIBuviITZIwUftHxcLf1j%2buAMZ4Z0EiTGRsxvV;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ysF5YOpRl2UI1oBNJ%2bwFk2TLOPIC%2fLzh5lK7ChpzuCBVAfGHAO73hDuBFGI%2f6jR0PYIXJMFlkCUS0%2bHe4CXaKfIysQR1GKD1AQpT50%2furXFyeH02r27QIAB9%2b1U6CixPNwPfTu4ekpoqyFW5iPCmCOm4sUQIBuviITZIwUftHxcLf1j%2buAMZ4Z0EiTGRsxvV
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:40 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-05-06T03:39:40Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ysF5YOpRl2UI1oBNJ%2bwFk2TLOPIC%2fLzh5lK7ChpzuCBVAfGHAO73hDuBFGI%2f6jR0PYIXJMFlkCUS0%2bHe4CXaKfIysQR1GKD1AQpT50%2furXFyeH02r27QIAB9%2b1U6CixPNwPfTu4ekpoqyFW5iPCmCOm4sUQIBuviITZIwUftHxcLf1j%2buAMZ4Z0EiTGRsxvV
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU2W7TQBT9FcsvvCSpszQLUiVCSSsKaYOggEqr6Hrmxhliz5hZkpio/84sTtOK
+        qn3ynbvPOWe8iyUqk+v4bbR7bBJuP7/iD6YoquhaoYzvGlFMmSpzqDgU+FyYcaYZ5CrErr0vQyLU
+        c8ki/Y1EkxxUCGtRxtZdolSCO0vIDDj7C5oJDvnBzzhqG3vqMK6tKxeKbYEQYbh255VMS8k4YSXk
+        YLa1SzOyQl2KnJGq9tqEsFF9UGq577kAtTdt4KtankthyqvFzKSfsFLOX2B5JVnG+IRrWQUwSjCc
+        /THIqL9fd0BoikCaw0UvbbbbCM2U0qR53DnuJckg7QzbxBe6le34jZAUtyWTHgDfopN0kuQ46Sfd
+        7qg7utlnWwh1uaFkCTzDlxJxqyVQ0OCSdvF8noLCfm8+t+d4PL4YTNMLJMVoTU9Hy5vzdpmu3p/9
+        mJxdXk+2Z59Xl7NvX8Yn8f1duHABHDKk6G/sphJ+Qh3HDWtkDiLlrJoM1aDkBLdQlDk6k4jCr2Vq
+        eHxlUAxbI38qsX0mN0VqiXD+dmcw6if2lkMfLIDlhz7v6kGt/RQVAHwQnwWDABecEcgfRoXSyc/x
+        dPZ50jq9mvpUyz6R6EnQrPgf315yU6/9wnq5sNpQS8zDkkcp40cW/KUPLkWBlEmrPVEjeeRcRwdI
+        Hqv4lXVL+4hRrtGhurBvEd0AUPO9pKxbS7P3rrDSkB58BbobiMXc8+fHOB3bjir8AByOjokD0z74
+        CtH3tnQNuXGL10z7YUpZBamgRl2VPrwByRnPXEJ91fi7nWDhnzKl6khd6nU7+xjVCVEgINqAirjQ
+        kbLabEQLIW1PGtlFSktjynKmKx/PDEjgGpG2orFSprDdI4+efKMi13gdGjeiTqvT7bvJRFA3tt1N
+        krYDJLymXRzK5nWBWyyU3PvnYnsX4MmNx5QijRxq0W3A4jb2AKGUwomHmzx3/w96sB/Idw2A2j2f
+        8O7QPczttYYtO/cfAAAA//8DACr3KEzaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:40 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ysF5YOpRl2UI1oBNJ%2bwFk2TLOPIC%2fLzh5lK7ChpzuCBVAfGHAO73hDuBFGI%2f6jR0PYIXJMFlkCUS0%2bHe4CXaKfIysQR1GKD1AQpT50%2furXFyeH02r27QIAB9%2b1U6CixPNwPfTu4ekpoqyFW5iPCmCOm4sUQIBuviITZIwUftHxcLf1j%2buAMZ4Z0EiTGRsxvV
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_add", "params": [[], {"ipatokenowner": "dummy", "ipatokenotpalgorithm":
+      "sha512", "description": "dummy''s token"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '136'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTa2/aMBT9K1aksS88A6GAFG3peJbxaKFs2jpVJr4Fa4mT2Q4MIf77rg0qdHzp
+        NyfnnnPPPdfeOxJUFmmnRfaXR55SnfwGkWwFSPzz02FZHO+cX3lyxnRKo1UiuV7HtkStqVdx39Rk
+        gv/JgDOLl72GV2m6jcINc1mh1mTNAvUay8ILhKHHaCO8qXpv2BpbaB6D0pBahWr5fweMr7hWFqxb
+        jIEKJUdaIs6+PypiCbYikxwRx9jP9LpVKpk2JVv3ufM9GE2/dopfJqPWe+x+4kplIH3L/lArX/Bz
+        CkIJ2p9O6rMfj8GsU3v03HG3+21Rbw8X7YfJ7e3jtDu8r7bvhrXefDwcjGdBr7/o3Y8H/Zr7kDuO
+        5tdzryn7s36ACedSkDxhPqaB4+hdCmae+WQ+Nd8xFXQFbLl7ztTV7pgJ5Wo7/ntGzYfCx6DyLPTh
+        L43TCMwxTGLngMIbGmXGhsiiyJgApdCFXcz+1eKWSsHFyrgUNLa/FiAVrmqEOZ6QE9WAwXRATgUo
+        HC9Bki1VBPdOFN6OPHlJJGoygi5wJL7kEdc7i68yKqnQAKxIAtxRjOpIkhuQeBmM8OYonCdu0a3W
+        TecwYaZtpVouV0xWVFP7GI605xPBGDtSDgcTKWrHVO6sX8aAEdzD8baRJ+fJsemAlIk8p2Pfw+mc
+        Si5CXEhkBK4uobF10bdWbBSx7z8AAAD//wMApkJKDrYDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbU8bMQz+K9F92Ze23LUFChLS0IamaUMgTUwT04R8SXrNyCW3OKEtiP++OJe+
+        sDHtU33248f2Y6dPhZMYtC9O2dPO/P5UcEO/xfvQtmt2g9IVPwasEAo7DWsDrXwtrIzyCjT2sZvk
+        ayS3+Bp4DsidBK+s8SrzjctxWR6WR+VkcjItbxPO1j8l91wD9jTedkV0d9KhNWRZ14BRj4kJ9M6v
+        jPQx9tIRqDylW1Qr4NwG4+n73tWdU4arDjSEVXZ5xe+l76xWfJ29EdB3lD8QFxvOONHGjIEvuPjg
+        bOiu5teh/iTXSP5WdldONcpcGO/WvWgdBKN+BalEmm9yzEUtgQ9n82k9rCoJw1qIcng4PpyW5XE9
+        nlU8JVLLsfzSOiFXnXJJgJ2Ms3KaZKxuN+gooe+Wgi/ANK/onYGNepDm5YazX5jQ1nE+8lfj45Oj
+        MibPUjDk5sUWrm2cEhdS6xQ4qJU5qAEXG/i/ufZXse0jEb+9+HZ+ef35YvTu6jJBsZ93e1MxlYOx
+        RvH/pi5sK4VycZE2LiK1SK6D3QQtKL1HIFfQdlqOuG1T2GA+H235fcTN4+FLuqz4jKR7kGLP10oa
+        1s7vGrqIREprjzjs3xXNQaqcpVoDbs5SkIxcBQeCn+UeyKQ2nim3P+FTVkXbu2A4+D9qI0IjsX/X
+        ft2RKsUSnFGmoZvMQhVfY8F4QZcKMUdyKgXPrz+yDGD96tgSkBnrGUrjB2xuXeQULPbVxUuslVZ+
+        neJNAAfGSylG7BwxtJGdJYncG2RE/NATD9h4NJ4cFWkoQWWrSVnSXAI8pL+oPu0uJ1BjfcpzkiJy
+        t5C2WVSMBGQteL6IcjzHqHTO0sGZoDW9O7Gzt/dGqX/fS0TsVZyOZqNY8TcAAAD//wMANswu5TsF
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU22obMRD9lWVf+mI760sSpxBoaEMpbUigpJSWEmal8Vq1VlI1ku1NyL9X0sqX
+        QGifPHvmzJzR0chPpUXy0pVvi6fjkKnw87P84Nu2K+4JbflrUJRckJHQKWjxtbRQwgmQ1OfuE9Yg
+        0/QaWde/kTkmgfq006YMsEFLWsVI2waUeAQntAJ5wIVCF3IvAR/bxnJNYguMaa9c/F7Z2lihmDAg
+        wW8z5ARboTNaCtZlNBD6ifIH0XLXcwG0C0PiKy0/Wu3N7eLO15+xo4i3aG6taIS6Vs52vRkGvBJ/
+        PAqezjc9Z7xGYMP5YlYPx2OEYc15NTydnM6q6ryezMcsFcaRg/xGW45bI2wyILWYVJOqmlezajq9
+        mI1/7NjBQmc2nC1BNXggnlZnx0Spw3i0RCkT5aQW6qQGWqbkUrfIhQ3H12H8lI/QCY93lhg+H+OA
+        BFuYxTSdE+0rwlUv3AiufFsHAyNjPDm/OKsCab4bn4HSSjCQ+7VKGu+uv1/d3H25Hr2/vUnUFoQ8
+        SuMWWiNxxHSbZdaoXm5mwqn3br93xxvxH0X/r8kV5TWTmq0CYREWH6OVQA+7+wuws36HrrBzUB8w
+        E94b2jXyo+oWo55ePDRxx5JuXKTAo/4FxtPEwS7TyAOmLlMyBnkeGnB2md2JYTToOZSuQfp42nyF
+        SYwIGkzv76l0nUnpDVglVBMJ2Z/yW1AI13wjiHIml8bk1d2nIhOK3q5iA1Qo7QpC5QbFQtvQkxdh
+        EBPWpRZSuC7lGw8WlEPko+KKyLehe5E8sW+oiI3XfeNBMRlNpmdRmWkeZcfTqhpHQ8BB+sfqyx5y
+        QRysL3l+TlsQzgxptZWXMtqB1mqbv+Nz5Yd4vx97t16sRvTyoDIbzUdB5S8AAAD//wMAKCLKLEkF
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password231860
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:41 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=5tL4PsFmZKQIh8ZmOIagMnT2IWxZ9bFqmmrq%2fL3%2byEkWXMkeTJigIsyU48NnwkJ3VkWQ%2bQycngGXLuMzAHwbBiJO83wm%2fUU6g73yj5J1zcGu%2f3Psxx7AcrO2x0knulXCMKHfziBuLmNkLqtZnt5910cNTNiDJ3F%2bh9MQyIkskbZ2SRXNqHL2AwFs3xuHbOIy;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_add", "params": [[], {"ipatokenowner": "dummy", "ipatokenotpalgorithm":
+      "sha512", "description": "pants token"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTXW/aMBT9K1aksRc+AgnhQ4o2StvBKCMdbJ26TpWJ78Ba4mS2A0OI/75rB7Ug
+        Xvpm5/ice+65N3tHgioS7fTJ/vTIc6qzPyAyndNklUmu1ykCPx21pu1my/lVJa9vtgKkBVmRprsz
+        TKOA5ikoDbl94rlneCH43wI4s1iwXLp+14da3Gu1av6y06n1vKBda/aaXb/rdoK417VsBiqWHIUz
+        YYk5FVoRK3juTOeMr7hWpbzFCsnx5pjGCr3uNxrGYsM6/3jzYzCN7m7qw9m0/xYzH7hSBcjQst/5
+        7gm/oiCWoMM7P7oO8PvV1efr+XAwmQfTx/uHhf91HnnR1Lt/CEbtzrfReHI7/NIZe7efJvPR43A4
+        q5TGw6Dykn84Hw0w+0oOkmcsxCSxHb3LwfSzmC0ic0+poCtgy91zoS6mwkxcF9mHb2m1GosQg6qy
+        OIR/NM0TMMc4S50DCm9oUhgbokgSYwKUQhc29v2LxS2VgouVcSloaj99B6lwiFPM8YgcqQYcRGNy
+        fIDC6RIk2VJFcKpE4WZVye9MoiYj6AJb4kuecL2z+KqgEncCgNXJAGeUojqS5Abke0WM8KYUrpJW
+        veUFpnKcMVO26blu02RFNbW/Qkl7PhKMsZJyOJhIUTulcmf9MgaM4BzKTSRPzpNj0wEpM/majt32
+        4zmXXMQ4kMQIXCyhsXVS169361j3PwAAAP//AwBmRHZmtAMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=5tL4PsFmZKQIh8ZmOIagMnT2IWxZ9bFqmmrq%2fL3%2byEkWXMkeTJigIsyU48NnwkJ3VkWQ%2bQycngGXLuMzAHwbBiJO83wm%2fUU6g73yj5J1zcGu%2f3Psxx7AcrO2x0knulXCMKHfziBuLmNkLqtZnt5910cNTNiDJ3F%2bh9MQyIkskbZ2SRXNqHL2AwFs3xuHbOIy
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=5tL4PsFmZKQIh8ZmOIagMnT2IWxZ9bFqmmrq%2fL3%2byEkWXMkeTJigIsyU48NnwkJ3VkWQ%2bQycngGXLuMzAHwbBiJO83wm%2fUU6g73yj5J1zcGu%2f3Psxx7AcrO2x0knulXCMKHfziBuLmNkLqtZnt5910cNTNiDJ3F%2bh9MQyIkskbZ2SRXNqHL2AwFs3xuHbOIy
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUYW/TMBD9K1a+8KXtkrbbukmTmGBCCKZNQkNoCKGL7SZmjh189toy7b/jc9x2
+        gwk+1bl3957v3bkPhZMYtC9O2cP++PWh4IZ+i7eh6zbsBqUrvo1YIRT2GjYGOvkSrIzyCjQO2E2K
+        NZJbfCl5CcidBK+s8SrzTctpWR6WR+VsdjIvb1OerX9I7rkGHGi87YsY7qVDa+hkXQNG/UpMoPdx
+        ZaSP2PNAIHkqt6jWwLkNxtP3nat7pwxXPWgI6xzyit9J31ut+CZHY8Jwo/yB2G45Y0fbYwQ+YfvO
+        2dBfLa9D/UFukOKd7K+capS5MN5tBtN6CEb9DFKJ1N/smItaAh8vlvN6XFUSxrUQ5fhwejgvy+N6
+        uqh4KqQrR/mVdUKue+WSAXsbF+U82VjdbrOjhb5fCd6CaV7wOyc26l6a5xNOcW3jtbGVWifgoFbm
+        oAZsE4iD8G64UY2DsUZx0DsuQVyvL76cX15/vJi8ubrMesKEro6FlFNNj0+Oynipxa7H7Vj+w9OB
+        0k9guYau13LCbZfg8C+Z1nZSKBenauNUUnsUOhC77kOezj5iMK+PtvwuYsu4+JI2Kz4j6e6leBLr
+        JCnb5feGNiIR0dhjHg7viuwjjbPEP+LmLIF0yCo4EvwsN0VH6uuRaocVPmVVPHsXDAf/hzYiNBKH
+        d+03PZlYrMAZZRrayexr8TkKxg26VIgZyaUEnl+/ZzmBDT6yFSAz1jOUxo/Y0rrIKVi8Vx83sVZa
+        +U3CmwAOjJdSTNg5YugiO0sWuVfIiPh+IB6x6WQ6OypSU4Jkq1lZUl8CPKS/qKHsey6giw0lj8mK
+        yN1BGmBRMTKQdeB5G+14jKh0ztL0TdCa3p3Yn3c7RqV/r1fMeKI4nywmUfE3AAAA//8DACssFhE7
+        BQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=5tL4PsFmZKQIh8ZmOIagMnT2IWxZ9bFqmmrq%2fL3%2byEkWXMkeTJigIsyU48NnwkJ3VkWQ%2bQycngGXLuMzAHwbBiJO83wm%2fUU6g73yj5J1zcGu%2f3Psxx7AcrO2x0knulXCMKHfziBuLmNkLqtZnt5910cNTNiDJ3F%2bh9MQyIkskbZ2SRXNqHL2AwFs3xuHbOIy
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU22obMRD9lWVf+mI760sSpxBoaEMpbUigpJSUEmal8Vq1VlI1ku1tyL9X0sqX
+        QGifPDtnLmfmjPxUWiQvXfm2eDo2mQo/P8oPvm274p7Qlj8HRckFGQmdghZfg4USToCkHrtPvgaZ
+        pteCdf0LmWMSqIedNmVwG7SkVbS0bUCJP+CEViAPfqHQBeylw8eyMV2T2AJj2isXv1e2NlYoJgxI
+        8NvscoKt0BktBeuyNwT0jPIH0XJXcwG0MwPwlZYfrfbmdnHn68/YUfS3aG6taIS6Vs52/TIMeCV+
+        exQ8zTc9Z7xGYMP5YlYPx2OEYc15NTydnM6q6ryezMcsJUbKof1GW45bI2xaQCoxqSZVNa9m1XR6
+        MRs/7KLDCp3ZcLYE1eAh8LQ6Ow70mQePMvTSiDWql1ruIpVv6zBx9I8n5xdnVSg3T2ALQh7qvMMt
+        tEbiiOk2wdQz3asc6DFQWgkGct+qT73+fnVz9+V69P72JoWGNTOLaVon2lcGqR4y7X/QkzqIQEuU
+        PcmTWqiTGmiZwKVukQsbRNZBpIRH18lhJcfn8h+6ivKZSc1WIW4RDh9jE6DHnX7B7azfeVfYOagP
+        PhPeG9o18qPsFuNkevHYxBtL7eMhhTjqX2Dcb1ToMrEaMHWZwGhkPjTg7DLrEs0ozXNIXYP0caB8
+        AakZETSY3t9T6TqT4A1YJVQTA/IKym+hQ5DlRhBlJKdG8OruU5EDil6YYgNUKO0KQuUGxULbUJMX
+        gYgJ8tZCCtclvPFgQTlEPiquiHwbqhdpJ/YNFbHwui88KCajyfQsdmaax7bjaVWN40LAQfrH6tMe
+        c0Ik1qc8P6e7DDNDEl15KeM60Fpt83d8rvxg709gv60X6sddHrrMRvNR6PIXAAD//wMAkC5FGUkF
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[], {"ipatokenowner": "dummy"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=5tL4PsFmZKQIh8ZmOIagMnT2IWxZ9bFqmmrq%2fL3%2byEkWXMkeTJigIsyU48NnwkJ3VkWQ%2bQycngGXLuMzAHwbBiJO83wm%2fUU6g73yj5J1zcGu%2f3Psxx7AcrO2x0knulXCMKHfziBuLmNkLqtZnt5910cNTNiDJ3F%2bh9MQyIkskbZ2SRXNqHL2AwFs3xuHbOIy
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5xSTYvbMBD9K0KXXmxjO3ZsFwINZQ+Fhs1hKYVSiixNUlFLcvWxaQj736uR06bQ
+        Upa9DTPz3ps3MxdqwYXJ09fkcgs/XaicmTffQJuTBospKoJSZ/o5I79rQcvvAaRI5bLt22qo+7wT
+        tcibQQw5a/sxPwDnrWA971ZtQgtw3MrZS6NvvK8cSZSpw59niCX6cP+wp4jAxr9UN89RzLjeGD9n
+        gm/gB1PzBBhyo+hTRl7gcj2OZdM3kPOhrvNm7Lp8WK3bvBqqvunLbs2H/p8uZ6b9Czw+R+8/HlGJ
+        m6DxqDWq2qA584BmDmxyEHMKnGNHcMvdf811YlZLfcTRNFMp9QGsi3Z20rlr5QrF4nb/jlwbiA5q
+        BEtOzBFtPHGgfUYOxkZOQeJc0aQc5ST9OdWPgdm4HQBRkK1zQUX2CLKPYONbIPHjQpyRuqhXa5pM
+        CZStVmVZ4faYZ+mFF9iXKwAHWyBPaRWRWzF7TmkSF7/cwxHFPP8alxJ/goK1Bl9Bh2nCLxC3eLZS
+        83iiCQnSo7y5+7jd7d/fFW/vdzjWH7pN0RdR9ycAAAD//wMAl8v0cWEDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=bLzPVXPFDiamrOI2tMnrRCaOprNimvroBa8%2frlIhzU1vwxbqULlRmWl31GeburMyl7ytZ8XpB2KEYzFZBIlNl%2bfvu4rbkv0Zo4LXes%2fzCNlK96aPbQxf%2bltV%2bdLfop1CaU3dXdPRMNbqu1lnZOA%2fcckDRd4gJHZh%2flBAbJuEyOxoKkAwK67pi%2ffHSlPzSthR;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=bLzPVXPFDiamrOI2tMnrRCaOprNimvroBa8%2frlIhzU1vwxbqULlRmWl31GeburMyl7ytZ8XpB2KEYzFZBIlNl%2bfvu4rbkv0Zo4LXes%2fzCNlK96aPbQxf%2bltV%2bdLfop1CaU3dXdPRMNbqu1lnZOA%2fcckDRd4gJHZh%2flBAbJuEyOxoKkAwK67pi%2ffHSlPzSthR
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[], {"ipatokenowner": "dummy"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '71'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=bLzPVXPFDiamrOI2tMnrRCaOprNimvroBa8%2frlIhzU1vwxbqULlRmWl31GeburMyl7ytZ8XpB2KEYzFZBIlNl%2bfvu4rbkv0Zo4LXes%2fzCNlK96aPbQxf%2bltV%2bdLfop1CaU3dXdPRMNbqu1lnZOA%2fcckDRd4gJHZh%2flBAbJuEyOxoKkAwK67pi%2ffHSlPzSthR
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5xSTYvbMBD9K0KXXmxjO3ZsFwINZQ+Fhs1hKYVSiixNUlFLcvWxaQj736uR06bQ
+        Upa9DTPz3ps3MxdqwYXJ09fkcgs/XaicmTffQJuTBospKoJSZ/o5I79rQcvvAaRI5bLt22qo+7wT
+        tcibQQw5a/sxPwDnrWA971ZtQgtw3MrZS6NvvK8cSZSpw59niCX6cP+wp4jAxr9UN89RzLjeGD9n
+        gm/gB1PzBBhyo+hTRl7gcj2OZdM3kPOhrvNm7Lp8WK3bvBqqvunLbs2H/p8uZ6b9Czw+R+8/HlGJ
+        m6DxqDWq2qA584BmDmxyEHMKnGNHcMvdf811YlZLfcTRNFMp9QGsi3Z20rlr5QrF4nb/jlwbiA5q
+        BEtOzBFtPHGgfUYOxkZOQeJc0aQc5ST9OdWPgdm4HQBRkK1zQUX2CLKPYONbIPHjQpyRuqhXa5pM
+        CZStVmVZ4faYZ+mFF9iXKwAHWyBPaRWRWzF7TmkSF7/cwxHFPP8alxJ/goK1Bl9Bh2nCLxC3eLZS
+        83iiCQmYiHO+ufu43e3f3xVv73c41h+6TdEXUfcnAAAA//8DADOX8ZJhAwAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=bLzPVXPFDiamrOI2tMnrRCaOprNimvroBa8%2frlIhzU1vwxbqULlRmWl31GeburMyl7ytZ8XpB2KEYzFZBIlNl%2bfvu4rbkv0Zo4LXes%2fzCNlK96aPbQxf%2bltV%2bdLfop1CaU3dXdPRMNbqu1lnZOA%2fcckDRd4gJHZh%2flBAbJuEyOxoKkAwK67pi%2ffHSlPzSthR
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:42 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Hm0vzbogdYEjLT4dYFl5fkZ6Wl51WFzJHux%2fvZavjLFUDXJNN8JJsZ2Fouo1MTC6qvtGMGufvlw0R%2bpMPZsEAoljTJqzBC%2bq%2b%2fKKu63ubStOoejyfcglTmTAPFy4Ny%2bXjUiF1ZQLRVChJU85bkCXoKqlz7s44UbuhP86LXWMS6q8m2ubL649BuOsEHo32N%2f%2f;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hm0vzbogdYEjLT4dYFl5fkZ6Wl51WFzJHux%2fvZavjLFUDXJNN8JJsZ2Fouo1MTC6qvtGMGufvlw0R%2bpMPZsEAoljTJqzBC%2bq%2b%2fKKu63ubStOoejyfcglTmTAPFy4Ny%2bXjUiF1ZQLRVChJU85bkCXoKqlz7s44UbuhP86LXWMS6q8m2ubL649BuOsEHo32N%2f%2f
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [[], {"ipatokenuniqueid": "05851928-7d2d-49d9-a58b-fecc5da8c735"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hm0vzbogdYEjLT4dYFl5fkZ6Wl51WFzJHux%2fvZavjLFUDXJNN8JJsZ2Fouo1MTC6qvtGMGufvlw0R%2bpMPZsEAoljTJqzBC%2bq%2b%2fKKu63ubStOoejyfcglTmTAPFy4Ny%2bXjUiF1ZQLRVChJU85bkCXoKqlz7s44UbuhP86LXWMS6q8m2ubL649BuOsEHo32N%2f%2f
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4yQTWvCQBCG/8qwl16SoNHU2FOl9VCo6KGUQpUyZieydLMbdjeKiP+9OxrQY2/z
+        9bzzzpyEI9/pIJ7gdB/WqDTJGH5vzgmIPeqOOBODoiyG07xMJzKX6XgqpykW5TatqaoKiWU1GRVi
+        E5GGvMcdeaZOIhxb5sUBnVFmJ+KAweZS+iTnlTUL5X3f6VFuzlZv0A+A6ZotOTigB2MDeDIhgdq6
+        qCmhsk2LQW2VVuF46e86dGgCkcxg5n3XRPUIuT25Bw8svL8KJ5Bn+eiRN1dW8trhaDAYxlRiwMs7
+        rthPD7CxK3I+86lRu0F35PIraQokYfmxgmB/ycD6Xy9bC8F/Juesizqm0zqmSt7i1ilTqRY1r0EZ
+        r3mef80Wq/d59rJcsPk7d+OszKK7PwAAAP//AwDaJpSG3gEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hm0vzbogdYEjLT4dYFl5fkZ6Wl51WFzJHux%2fvZavjLFUDXJNN8JJsZ2Fouo1MTC6qvtGMGufvlw0R%2bpMPZsEAoljTJqzBC%2bq%2b%2fKKu63ubStOoejyfcglTmTAPFy4Ny%2bXjUiF1ZQLRVChJU85bkCXoKqlz7s44UbuhP86LXWMS6q8m2ubL649BuOsEHo32N%2f%2f
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=FgSobxRQ2N3f7dxF2H%2fbqlamWo2LLMxV0byqFNnTlGUk6%2ferXXqxEVbGB3w7z0UEHGDjUYLVFpG%2ffCaJMZz7eFJviEMQHDjKCdsFT5dvb%2bLscX%2fNAGdAHAyjP3ZRUtiV6FtgDJeDggj2BsVgtR1hN%2f61nbUqDtGReWkoHZssAmLUrQ2g%2b1DyiH8hDDLrU6zt;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=FgSobxRQ2N3f7dxF2H%2fbqlamWo2LLMxV0byqFNnTlGUk6%2ferXXqxEVbGB3w7z0UEHGDjUYLVFpG%2ffCaJMZz7eFJviEMQHDjKCdsFT5dvb%2bLscX%2fNAGdAHAyjP3ZRUtiV6FtgDJeDggj2BsVgtR1hN%2f61nbUqDtGReWkoHZssAmLUrQ2g%2b1DyiH8hDDLrU6zt
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [[], {"ipatokenuniqueid": "6bb0484e-c922-4b77-9365-191848076c98"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=FgSobxRQ2N3f7dxF2H%2fbqlamWo2LLMxV0byqFNnTlGUk6%2ferXXqxEVbGB3w7z0UEHGDjUYLVFpG%2ffCaJMZz7eFJviEMQHDjKCdsFT5dvb%2bLscX%2fNAGdAHAyjP3ZRUtiV6FtgDJeDggj2BsVgtR1hN%2f61nbUqDtGReWkoHZssAmLUrQ2g%2b1DyiH8hDDLrU6zt
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4yQTWvCQBCG/8qwl15MSGIak54aWg+Fih5KKVQpk+woSze7YXejiPjfu6sBPfY2
+        X88778yJGbKDdOwJTvfhFoUk7sPvzXkCbI9yoJCxommSvMwpaqssi/JmNouqafEYpVVa5mUyK9qq
+        ZBuPdGQt7sgG6sTcsQ88O6BRQu2YH1DYXUqfZKzQaiGsHTsjGpr16g3GAVBD15CBA1pQ2oEl5Saw
+        1cZrcmh116MTjZDCHS/93YAGlSPiMdTWDp1X95DZk3mwEIT3V+EJZHE2LcLmVvOwNp0mSepTjg4v
+        77hiPyMQjF2R8zmc6rU7NMdQfiVJjjgsP1bg9C8pWP/rZWvGwp/JGG28jhqk9Kngt7g3QrWiRxnW
+        IPfXPM+/6sXqfR6/LBfB/J27PC5j7+4PAAD//wMA4ugzo94BAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=FgSobxRQ2N3f7dxF2H%2fbqlamWo2LLMxV0byqFNnTlGUk6%2ferXXqxEVbGB3w7z0UEHGDjUYLVFpG%2ffCaJMZz7eFJviEMQHDjKCdsFT5dvb%2bLscX%2fNAGdAHAyjP3ZRUtiV6FtgDJeDggj2BsVgtR1hN%2f61nbUqDtGReWkoHZssAmLUrQ2g%2b1DyiH8hDDLrU6zt
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:43 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=FMpubdUbSThaXmvwcSReyXpoIF4hqses%2bNBMwuQbT2Hd3S9Nb9VdTSCsvR66heayuamuF%2b4XPPIqfHZmlsh7V3AzdW4Mhkpax34elbcHcg3OI0nDd%2b6yh30XfY1nYy3E1WzsIkq8UcCt7xbM53AGkQvVcz9oHdG6ZsOXe4enVVGhFMNuW7sqZzHmQw7AfH8w;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=FMpubdUbSThaXmvwcSReyXpoIF4hqses%2bNBMwuQbT2Hd3S9Nb9VdTSCsvR66heayuamuF%2b4XPPIqfHZmlsh7V3AzdW4Mhkpax34elbcHcg3OI0nDd%2b6yh30XfY1nYy3E1WzsIkq8UcCt7xbM53AGkQvVcz9oHdG6ZsOXe4enVVGhFMNuW7sqZzHmQw7AfH8w
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [[], {"ipatokenuniqueid": "05851928-7d2d-49d9-a58b-fecc5da8c735"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=FMpubdUbSThaXmvwcSReyXpoIF4hqses%2bNBMwuQbT2Hd3S9Nb9VdTSCsvR66heayuamuF%2b4XPPIqfHZmlsh7V3AzdW4Mhkpax34elbcHcg3OI0nDd%2b6yh30XfY1nYy3E1WzsIkq8UcCt7xbM53AGkQvVcz9oHdG6ZsOXe4enVVGhFMNuW7sqZzHmQw7AfH8w
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6SPsQ6CMBBAf6XpLASRamHSGJxEHBxcz14xjdCStrgQ/t2iiX6A293L5eXdSK10
+        Q+tpQfTQtgtCpbXGhnWkwqAMQ5Yky8A76RzcZ0ATxtkyT3m0wRSjLMc8AsZvUSOFYAhcbFasIPXl
+        TLx5SE208aQxg0YaPAge3norwRn9n28KQg3du+pk/OELFf4+6q3SQvXQzleAndLb8rqrzscy3tfV
+        3PSU1qlPSxbzeE2nFwAAAP//AwAUQMEGGAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XiLahdFHrRprvzy2FhihsJYPlLvMHuy9OtshRcFFHWiTrA9SXLr45hFbxoEUz514NBDzLWZKlU3YVT2E%2bwE1dIpvbQ9V9FSeugHWM5MY89Fkvy8D%2fdeFzMfYb%2b6NBhWujJ1cmOpyyR%2fd5p8G8%2fjs7tuVrYvJ4mncU6U1SDVp5J9tUQvPSw0TwbXfGmwgntC6
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
+        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
+        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
+        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
+        5aPM0D8AAAD//wMA5lpmj1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=BRvwyYjuiMe8Z136JOPgPJL8dVDtxw4EalYtTYBBmXzId8JvwQxDlz2WHYFCi%2bLOvhFYT%2bt%2bLyWDxEaw%2bN6%2fq7DsUhpFkF82pe5mCO4Tse5qQoj%2fegpS4ftiA1npKcbfhOsGofPovivNdsyk0%2bqyBWoJEyKhVf0VIejMZwpvdOP40T0CFfUfN3K%2fr4RvD9Fc;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BRvwyYjuiMe8Z136JOPgPJL8dVDtxw4EalYtTYBBmXzId8JvwQxDlz2WHYFCi%2bLOvhFYT%2bt%2bLyWDxEaw%2bN6%2fq7DsUhpFkF82pe5mCO4Tse5qQoj%2fegpS4ftiA1npKcbfhOsGofPovivNdsyk0%2bqyBWoJEyKhVf0VIejMZwpvdOP40T0CFfUfN3K%2fr4RvD9Fc
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BRvwyYjuiMe8Z136JOPgPJL8dVDtxw4EalYtTYBBmXzId8JvwQxDlz2WHYFCi%2bLOvhFYT%2bt%2bLyWDxEaw%2bN6%2fq7DsUhpFkF82pe5mCO4Tse5qQoj%2fegpS4ftiA1npKcbfhOsGofPovivNdsyk0%2bqyBWoJEyKhVf0VIejMZwpvdOP40T0CFfUfN3K%2fr4RvD9Fc
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroY4yx00rXw2BlPY3BWoZaq8VgO0G2U0LJf5/UBNab9Ol7
+        SLoaplR8Ni9wvS9P6DxZKX/2/QRMi76QdsaWEDqzFyxQSnimpPDV5K5RgrkgRxfPRggRww36Ik6u
+        jhuX0jgZpTpcbt9hJEAs4UAMF0wQ6wyJYp7AqWbxtHCsQ4PZHZx3ubvNzwUZYyayFSxTKkHcRcQt
+        8UMCNW4H4wnMq/niSZOPtdXY2WI6nUlrMePt3kH2Owp0sUHS93qqeAfkTuE38pTJQhEF7IZ37IzR
+        JxFzzcKJxXtpnf2vG3bx6Br0aoFWNn1dfy832491tfrc6GJ3yY/VcyXJfwAAAP//AwC881l1mwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BRvwyYjuiMe8Z136JOPgPJL8dVDtxw4EalYtTYBBmXzId8JvwQxDlz2WHYFCi%2bLOvhFYT%2bt%2bLyWDxEaw%2bN6%2fq7DsUhpFkF82pe5mCO4Tse5qQoj%2fegpS4ftiA1npKcbfhOsGofPovivNdsyk0%2bqyBWoJEyKhVf0VIejMZwpvdOP40T0CFfUfN3K%2fr4RvD9Fc
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 06 May 2020 03:39:44 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1


### PR DESCRIPTION
Previously, code was added to noggin that edited the URI we got back
from freeipa, adding the description of the token to the OTP URI. this
was done, so the token description is shown in the authenticator
application that the user uses. However, if a user added a token
description with a space in it,  the URI would be constructed to be
invalid, and not be able to be scanned via the QR code.

This PR escapes the description before adding it to the otp URI, which
resolved this issue.

Resolves: #241

Signed-off-by: Ryan Lerch <rlerch@redhat.com>