### PR TITLE
Add email blocklist validator

### DIFF
--- a/noggin.cfg.default
+++ b/noggin.cfg.default
@@ -47,6 +47,9 @@ MAIL_DEFAULT_SENDER = "Noggin <noggin@example.com>"
 # Set to False for prod
 MAIL_SUPPRESS_SEND = True
 
+# email domains that a user cannot use to register or change to
+# MAIL_DOMAIN_BLOCKLIST = ['fedoraproject.org']
+
 # URL for the avatar service, typically either
 # AVATAR_SERVICE_URL = "https://seccdn.libravatar.org/"
 # or

--- a/noggin/defaults.cfg
+++ b/noggin/defaults.cfg
@@ -15,3 +15,5 @@ HIDE_GROUPS_IN = "hidden_groups"
 
 AVATAR_SERVICE_URL = "https://seccdn.libravatar.org/"
 AVATAR_DEFAULT_TYPE = "robohash"
+
+MAIL_DOMAIN_BLOCKLIST = ['fedoraproject.org']

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -10,8 +10,10 @@ from wtforms import (
 )
 
 from wtforms.fields.html5 import EmailField
-from wtforms.validators import AnyOf, DataRequired, Email, Optional, Length
+from wtforms.validators import AnyOf, DataRequired, Optional, Length
 
+from noggin import app
+from noggin.form.validators import Email
 from noggin.utility.locales import LOCALES
 from noggin.utility.timezones import TIMEZONES
 from .base import CSVListField
@@ -32,7 +34,10 @@ class UserSettingsProfileForm(FlaskForm):
         _('E-mail Address'),
         validators=[
             DataRequired(message=_('Email must not be empty')),
-            Email(message=_('Email must be valid')),
+            Email(
+                message=_('Email must be valid'),
+                blocklist=app.config["MAIL_DOMAIN_BLOCKLIST"],
+            ),
         ],
     )
 

--- a/noggin/form/register_user.py
+++ b/noggin/form/register_user.py
@@ -2,9 +2,10 @@ from flask_babel import lazy_gettext as _
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField
 from wtforms.fields.html5 import EmailField
-from wtforms.validators import DataRequired, EqualTo, Email, Length
+from wtforms.validators import DataRequired, EqualTo, Length
 
 from noggin import app
+from noggin.form.validators import Email
 from .base import ModestForm, SubmitButtonField, strip
 
 
@@ -31,7 +32,10 @@ class RegisterUserForm(ModestForm):
         _('E-mail Address'),
         validators=[
             DataRequired(message=_('Email must not be empty')),
-            Email(message=_('Email must be valid')),
+            Email(
+                message=_('Email must be valid'),
+                blocklist=app.config["MAIL_DOMAIN_BLOCKLIST"],
+            ),
         ],
         filters=[strip],
     )

--- a/noggin/form/validators.py
+++ b/noggin/form/validators.py
@@ -1,0 +1,19 @@
+from flask_babel import lazy_gettext as _
+from wtforms.validators import ValidationError
+from wtforms.validators import Email as WTFormsEmailValidator
+
+
+class Email(WTFormsEmailValidator):
+    """ Extend the WTForms email validator, adding the ability to blocklist
+        email addresses
+    """
+
+    def __init__(self, blocklist=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.blocklist = blocklist
+
+    def __call__(self, form, field):
+        super().__call__(form, field)
+        domain = field.data.split("@")[1]
+        if domain in self.blocklist:
+            raise ValidationError(_('Email addresses from that domain are not allowed'))

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -393,6 +393,18 @@ def test_invalid_email(client, post_data_step_1):
 
 
 @pytest.mark.vcr()
+def test_blocklisted_email(client, post_data_step_1):
+    """Register a user with an invalid email address"""
+    post_data_step_1["register-mail"] = "dude@fedoraproject.org"
+    result = client.post('/', data=post_data_step_1)
+    assert_form_field_error(
+        result,
+        field_name="register-mail",
+        expected_message='Email addresses from that domain are not allowed',
+    )
+
+
+@pytest.mark.vcr()
 def test_empty_email(client, post_data_step_1):
     """Register a user with an empty email address"""
     del post_data_step_1["register-mail"]


### PR DESCRIPTION
Add extra validation on email fields to read a new validator blacklist
from the noggin configuration, and not let users change their email
addresses to any email domain in the blacklist.

Resolves: #234