### PR TITLE
Pagination for the groups page

### DIFF
--- a/noggin/controller/group.py
+++ b/noggin/controller/group.py
@@ -9,6 +9,7 @@ from noggin.form.remove_group_member import RemoveGroupMemberForm
 from noggin.representation.user import User
 from noggin.representation.group import Group
 from noggin.utility import group_or_404, with_ipa, messaging, undo_button
+from noggin.utility.pagination import paginated_find
 
 
 @app.route('/group/<groupname>/')
@@ -151,5 +152,5 @@ def group_remove_member(ipa, groupname):
 @app.route('/groups/')
 @with_ipa(app, session)
 def groups(ipa):
-    groups = [Group(g) for g in ipa.group_find(fasgroup=True)['result']]
+    groups = paginated_find(ipa, Group, fasgroup=True)
     return render_template('groups.html', groups=groups)

--- a/noggin/controller/root.py
+++ b/noggin/controller/root.py
@@ -65,13 +65,13 @@ def search_json(ipa):
     res = []
 
     if username:
-        users_ = [User(u) for u in ipa.user_find(username)['result']]
+        users_ = [User(u) for u in ipa.user_find(username, sizelimit=10)['result']]
 
         for user_ in users_:
             res.append({'uid': user_.username, 'cn': user_.name})
 
     if groupname:
-        groups_ = [Group(g) for g in ipa.group_find(groupname)['result']]
+        groups_ = [Group(g) for g in ipa.group_find(groupname, sizelimit=10)['result']]
         for group_ in groups_:
             res.append({'cn': group_.name, 'description': group_.description})
 

--- a/noggin/defaults.cfg
+++ b/noggin/defaults.cfg
@@ -22,3 +22,5 @@ HEALTHZ = {
     "live": "noggin.controller.root.liveness",
     "ready": "noggin.controller.root.readiness",
 }
+
+PAGE_SIZE = 30

--- a/noggin/representation/__init__.py
+++ b/noggin/representation/__init__.py
@@ -3,6 +3,8 @@ class Representation:
     ATTR_MAP = {}
     ATTR_LISTS = []
 
+    pkey = None
+
     def __init__(self, raw):
         self.raw = raw
 
@@ -31,6 +33,15 @@ class Representation:
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.raw == other.raw
+
+    @classmethod
+    def get_ipa_pkey(cls):
+        if cls.pkey is None:
+            raise NotImplementedError
+        try:
+            return cls.ATTR_MAP[cls.pkey]
+        except KeyError:
+            raise NotImplementedError
 
     def diff_fields(self, other):
         """

--- a/noggin/representation/group.py
+++ b/noggin/representation/group.py
@@ -11,6 +11,9 @@ class Group(Representation):
     }
     ATTR_LISTS = ["members", "sponsors"]
 
+    pkey = "name"
+    ipa_object = "group"
+
     @property
     def dn(self):
         if 'dn' in self.raw:

--- a/noggin/representation/otptoken.py
+++ b/noggin/representation/otptoken.py
@@ -2,17 +2,15 @@ from noggin.representation import Representation
 
 
 class OTPToken(Representation):
-    @property
-    def uniqueid(self):
-        return self._attr('ipatokenuniqueid')
 
-    @property
-    def description(self):
-        return self._attr('description')
+    ATTR_MAP = {
+        "uniqueid": "ipatokenuniqueid",
+        "description": "description",
+        "disabled": "ipatokendisabled",
+    }
 
-    @property
-    def disabled(self):
-        return self._attr('ipatokendisabled')
+    pkey = "uniqueid"
+    ipa_object = "otptoken"
 
     @property
     def uri(self):

--- a/noggin/representation/user.py
+++ b/noggin/representation/user.py
@@ -21,6 +21,9 @@ class User(Representation):
     }
     ATTR_LISTS = ["sshpubkeys", "ircnick", "gpgkeys", "groups"]
 
+    pkey = "username"
+    ipa_object = "user"
+
     @property
     def name(self):
         if 'displayname' in self.raw:

--- a/noggin/security/ipa_admin.py
+++ b/noggin/security/ipa_admin.py
@@ -20,6 +20,7 @@ class IPAAdmin(object):
         "user_del",
         "group_add",
         "group_del",
+        "group_find",
         "group_add_member_manager",
         "pwpolicy_add",
         "pwpolicy_mod",
@@ -29,6 +30,7 @@ class IPAAdmin(object):
         "otptoken_find",
         "stageuser_del",
         "stageuser_mod",
+        "batch",
     )
 
     def __init__(self, app):

--- a/noggin/static/css/main.css
+++ b/noggin/static/css/main.css
@@ -56,7 +56,7 @@
 
 
 html, body, .bodycontent {
-  height: 100vh;
+  min-height: 100vh;
   max-width: 100vw;
   margin: 0;
   display: flex;

--- a/noggin/templates/_pagination.html
+++ b/noggin/templates/_pagination.html
@@ -1,0 +1,41 @@
+{% macro pagination_bar(result) %}
+  {% if result.total_pages > 1 %}
+    <nav aria-label="Pagination">
+      <ul class="pagination justify-content-center my-4">
+        {# Previous page #}
+        <li class="page-item {% if not result.has_previous_page %}disabled{% endif %}">
+          {% if result.has_previous_page %}
+            <a class="page-link" href="{{ result.page_url(result.page_number - 1) }}">{{ _("Previous") }}</a>
+          {% else %}
+            <span class="page-link">{{ _("Previous") }}</span>
+          {% endif %}
+        </li>
+        {# Page list #}
+        {% for page_number in range(1, result.total_pages + 1) %}
+          {% if page_number == result.page_number %}
+            <li class="page-item active" aria-current="page">
+              <span class="page-link">
+                {{ page_number }}
+                <span class="sr-only">({{ _("current") }})</span>
+              </span>
+            </li>
+          {% else %}
+            <li class="page-item">
+              <a class="page-link" href="{{ result.page_url(page_number) }}">
+                {{ page_number }}
+              </a>
+            </li>
+          {% endif %}
+        {% endfor %}
+        {# Next page #}
+        <li class="page-item {% if not result.has_next_page %}disabled{% endif %}">
+          {% if result.has_next_page %}
+            <a class="page-link" href="{{ result.page_url(result.page_number + 1) }}">{{ _("Next") }}</a>
+          {% else %}
+            <span class="page-link">{{ _("Next") }}</span>
+          {% endif %}
+        </li>
+      </ul>
+    </nav>
+  {% endif %}
+{% endmacro %}

--- a/noggin/templates/groups.html
+++ b/noggin/templates/groups.html
@@ -1,4 +1,5 @@
 {% extends "main.html" %}
+{% import '_pagination.html' as pagination_macros %}
 
 {# Here it is relatively safe to assume that 'ipa' exists and is valid. We would not be here otherwise. #}
 
@@ -12,7 +13,7 @@
         <h4>{{ _("Group List") }}</h4>
 
         <ul class="list-group">
-          {% for group in groups %}
+          {% for group in groups.items %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
               <div class="media align-items-center">
                 <i class="fa fa-group fa-2x text-muted mr-3"></i>
@@ -31,6 +32,9 @@
             </li>
           {% endfor %}
         </ul>
+
+        {{ pagination_macros.pagination_bar(groups) }}
+
       </div>
     </div>
   </div>

--- a/noggin/templates/groups.html
+++ b/noggin/templates/groups.html
@@ -32,6 +32,9 @@
             </li>
           {% endfor %}
         </ul>
+        {% if groups.items|count == 0 %}
+        <p>{{ _("No groups.") }}</p>
+        {% endif %}
 
         {{ pagination_macros.pagination_bar(groups) }}
 

--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -20,9 +20,9 @@
               {% if user.timezone %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                   <strong title="{{_('Timezone')}}">
-                    <i class="fa fa-fw fa-globe"></i> 
+                    <i class="fa fa-fw fa-globe"></i>
                     {{_("Timezone")}}
-                  </strong> 
+                  </strong>
                   <div class="text-right">
                     <div>{{ user.timezone }}</div>
                   </div>
@@ -31,9 +31,9 @@
               {% if user.timezone %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                   <strong title="{{_('Current Time')}}">
-                    <i class="fa fa-fw fa-clock-o"></i> 
+                    <i class="fa fa-fw fa-clock-o"></i>
                     {{_("Current Time")}}
-                  </strong> 
+                  </strong>
                   <div class="text-right">
                     <div id="user-time">&nbsp;</div>
                   </div>
@@ -46,14 +46,14 @@
                   </strong>
                   <div class="text-right">
                     {% for ircnick in user.ircnick %}
-                    <pre class="mb-0">{{ ircnick }}</pre>
+                    <pre class="mb-0 p-1">{{ ircnick }}</pre>
                     {% endfor %}
                   </div>
                 </li>
               {% endif %}
               {% if user.gpgkeys %}
                 <li class="list-group-item d-flex justify-content-between">
-                  <strong title='{{_("GPG Keys")}}'><i class="fa fa-fw fa-key"></i> {{_("GPG Keys")}}</strong> 
+                  <strong title='{{_("GPG Keys")}}'><i class="fa fa-fw fa-key"></i> {{_("GPG Keys")}}</strong>
                   <div class="text-right">
                     {% for pgpkey in user.gpgkeys %}<pre class="mb-1 bg-light border px-2 rounded"><i class="fa fa-fw fa-key text-muted"></i> {{ pgpkey }}</pre>{% endfor %}
                   </div>
@@ -61,7 +61,7 @@
               {% endif %}
               {% if user.rhbz_mail %}
                 <li class="list-group-item d-flex justify-content-between align-items-center">
-                  <strong title='{{_("RHBZ")}}'><i class="fa fa-fw fa-bug"></i> {{_("RHBZ")}}</strong> 
+                  <strong title='{{_("RHBZ")}}'><i class="fa fa-fw fa-bug"></i> {{_("RHBZ")}}</strong>
                   {{ user.rhbz_mail }}
                 </li>
               {% endif %}
@@ -100,7 +100,7 @@
                       </div>
                       {% if group.description %}
                         <div>{{ group.description }}</div>
-                      {% endif %}  
+                      {% endif %}
                   </div>
                 </div>
                 <div class="text-info ml-auto" style="width:5em;">{{ _('sponsor') if group in managed_groups }}</div>
@@ -121,7 +121,7 @@
 {{super()}}
 {% if user.timezone %}
   <script>
-    setInterval("generate_local_time();",1000); 
+    setInterval("generate_local_time();",1000);
     function generate_local_time(){
       var currenttime = moment().tz("{{user.timezone}}").format('dddd, h:mm:ss a')
       $("#user-time").html(currenttime)

--- a/noggin/tests/unit/controller/cassettes/test_group/test_groups_list.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_groups_list.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 09 Apr 2020 14:10:13 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=JCkjHKtWsScW8UkYqr9E0Q%2b4jloNtBDaEiTDHlsKudQH%2fOHQeneV9ANSmfMwpWQSmDFTOH2lFr6IdA52FkFPV%2fJkfcUCHRRC1le2YfjZgnp2j0QdojjNuc%2bAW5I8XoyOlCPI66wUYnQ5qrDflsEmvavjA%2fopCNDHHAoC7Y6P4i8Dxf51svjmt5YSWuHgpH77;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=T57Jgi3D%2bsfPymUYqlD5Sb5KmBI0M8iEp2ylnkvSv8sM3hAtVrEIRECtGggJyos6TwMlUOd6olclUxkY%2b0cOJcXPVVlBUCEaRLcVo8%2fzgrY46N6xIkyu77R4ybiy8szlTGhy%2f3ZiayQ%2fZVZxk2Y9p8j8AJ7xKIQKlz6jRQXPwzMFMUP8gqfClr7JNFg6BMVX;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JCkjHKtWsScW8UkYqr9E0Q%2b4jloNtBDaEiTDHlsKudQH%2fOHQeneV9ANSmfMwpWQSmDFTOH2lFr6IdA52FkFPV%2fJkfcUCHRRC1le2YfjZgnp2j0QdojjNuc%2bAW5I8XoyOlCPI66wUYnQ5qrDflsEmvavjA%2fopCNDHHAoC7Y6P4i8Dxf51svjmt5YSWuHgpH77
+      - ipa_session=MagBearerToken=T57Jgi3D%2bsfPymUYqlD5Sb5KmBI0M8iEp2ylnkvSv8sM3hAtVrEIRECtGggJyos6TwMlUOd6olclUxkY%2b0cOJcXPVVlBUCEaRLcVo8%2fzgrY46N6xIkyu77R4ybiy8szlTGhy%2f3ZiayQ%2fZVZxk2Y9p8j8AJ7xKIQKlz6jRQXPwzMFMUP8gqfClr7JNFg6BMVX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,11 +91,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -107,8 +107,8 @@ interactions:
       message: Success
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
-      "Dummy", "sn": "User", "cn": "Dummy User", "loginshell": "/bin/bash", "userpassword":
-      "dummy_password", "fascreationtime": "2020-04-09T14:10:13Z"}]}'
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-06-04T15:00:16Z"}]}'
     headers:
       Accept:
       - application/json
@@ -117,11 +117,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '220'
+      - '249'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JCkjHKtWsScW8UkYqr9E0Q%2b4jloNtBDaEiTDHlsKudQH%2fOHQeneV9ANSmfMwpWQSmDFTOH2lFr6IdA52FkFPV%2fJkfcUCHRRC1le2YfjZgnp2j0QdojjNuc%2bAW5I8XoyOlCPI66wUYnQ5qrDflsEmvavjA%2fopCNDHHAoC7Y6P4i8Dxf51svjmt5YSWuHgpH77
+      - ipa_session=MagBearerToken=T57Jgi3D%2bsfPymUYqlD5Sb5KmBI0M8iEp2ylnkvSv8sM3hAtVrEIRECtGggJyos6TwMlUOd6olclUxkY%2b0cOJcXPVVlBUCEaRLcVo8%2fzgrY46N6xIkyu77R4ybiy8szlTGhy%2f3ZiayQ%2fZVZxk2Y9p8j8AJ7xKIQKlz6jRQXPwzMFMUP8gqfClr7JNFg6BMVX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227aQBD9FcsvfQFiAyGhUqTSFKKoJKFq01ZpIjTeHcwWe9fdC5ei/Hv3YiCR
-        0uSJ8VzOzJw5yzaWqEyh4/fR9qlJuP35FX8yZbmJbhXK+KERxZSpqoANhxJfCjPONINChdit9+VI
-        hHopWWS/kWhSgAphLarYuiuUSnBnCZkDZ39BM8GhOPgZR21jzx3GwbpyodgaCBGGa/e9kFklGSes
-        ggLMunZpRhaoK1Ewsqm9NiFMVH8oNd9hzkDtTBv4quYXUpjqZjYx2WfcKOcvsbqRLGd8yLXcBDIq
-        MJz9Mcio3492Zx2ApNc8gV7WTFOEJsxOTprH7eNuknRTAIq+0I1s26+EpLiumPQEeIh20raZST/t
-        pknaudtlWwp1taJkDjzH1xJxrSVQ0OCStvF0moHCXnc6td/xYDAejS/7SMr+kp7353cXaZUtPo5+
-        DEfXt8P1aLy4nnz7MjiLHx/CwiVwyJGi39h1JfyMuhs3rJE7ipSz6mOoBiVnuIayKtCZRJR+rLko
-        kTJpiRc1zJFzHXmkoCC2RP5cct5vGOWmzOxhnD9NTk+TJGn3ej6oAmN7teWvJZvdifbYhbC3VHMs
-        ijBSxviRJWvug1YPRKI/i2bl/xkvgRUH3A/18q3d5k+luV8vpA5/Dq4m42Hr/OZql0qAC87Im6mV
-        fcQol+g2mtm3iI5jUNOdpKxbS7PzLnCjITv4SnQcidnU38+3cTq2iCr8AThaHV+HS/vgG4d+tKVL
-        KIwbvGbZN1PKKkgFNepN5cMrkJzx3CXUq8bfbQdL9hVTqo7UpV63k8uoTojCiaMVqIgLHSmrzUY0
-        E9Ji0sgOUtmjZaxgeuPjuQEJXCPSVjRQypQWPfLsyXcqcsDLANyI2q12p+c6E0Fd27STJKkjJLym
-        bRzKpnWBGyyUPPrnYrFL8PqOB5QijRxr0X3g4j72BKGUwsmTm6Jw/x/0YO914gCA2jmf3d2xe+jb
-        bZ22bN9/AAAA//8DAFPBAxraBQAA
+        H4sIAAAAAAAAA4RU227aQBD9FcsvfeFigyFQKVJpQqK2uVC1aas0ERrvDmaLvevuBXBR/r27axMS
+        KUqePDuXM7NnznoXSlQm1+H7YPfUJNx+foenpiiq4EahDO9bQUiZKnOoOBT4Uphxphnkqo7deF+G
+        RKiXkkX6B4kmOag6rEUZWneJUgnuLCEz4OwfaCY45Ac/46ht7LnDOFhXLhTbAiHCcO3OK5mWknHC
+        SsjBbBuXZmSFuhQ5I1XjtQn1RM1BqeUecwFqb9rAN7U8l8KU14uZSb9gpZy/wPJasozxKdeyqsko
+        wXD21yCj/n7xGPo4pkkbhkdJO44R2qMR6bcHvUESReNo1MO+L3Qj2/YbISluSyY9AR6iF/WiaBgl
+        8SCK4sHtPttSqMsNJUvgGb6WiFstgYIGl7QL5/MUFA6T+dyew8nkc/f0KkdSjNf0ZLy8PY/LdPXx
+        7Of07Opmuj27WF3Nvn+dHIcP9/WFC+CQIUV/Y9eV8GPqdtyyRuYoUs5qlqFalBzjFooyR2cSUfix
+        CmC5r/alH5qMzj6csTXy53rz/lxYstUS87q4mzLetbdZ+uBSFEiZtMsUzWhd5+rSx/KnsnhEryeY
+        /ppczi6mnZPry30qAS44I2+mWqEQiX5fmhUvrGJ421yKclOkVlJeGMmgP4yi5Cj2QdPo5TCsqrf/
+        +HLMa+WlfcQo1+hAFvYtouMD1HwvKevW0uy9K6w0pAdfgQ5XLOZ+fx7f6dgiqvoH4EZxAxw27YNv
+        LPrBlq4hN46S5mK+mVJWQapWo65KH96A5IxnLqGhO/xhO1hOL5lSTaQp9bqdfQqahKCmJdiACrjQ
+        gbLabAULIS0mDewgpd1NynKmKx/PDEjgGpF2golSprDogWdPvlOBA17XwK2g1+n1h64zEdS1jft2
+        nY6Q+jXtwrps3hS4weqSB/9cLHYBXovhhFKkgWMtuKu5uAs9QSilcCvlJs/d/4Me7EetOgCgds5n
+        2nPsHvomnVHH9v0PAAD//wMAGbv5KdoFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,11 +157,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=JCkjHKtWsScW8UkYqr9E0Q%2b4jloNtBDaEiTDHlsKudQH%2fOHQeneV9ANSmfMwpWQSmDFTOH2lFr6IdA52FkFPV%2fJkfcUCHRRC1le2YfjZgnp2j0QdojjNuc%2bAW5I8XoyOlCPI66wUYnQ5qrDflsEmvavjA%2fopCNDHHAoC7Y6P4i8Dxf51svjmt5YSWuHgpH77
+      - ipa_session=MagBearerToken=T57Jgi3D%2bsfPymUYqlD5Sb5KmBI0M8iEp2ylnkvSv8sM3hAtVrEIRECtGggJyos6TwMlUOd6olclUxkY%2b0cOJcXPVVlBUCEaRLcVo8%2fzgrY46N6xIkyu77R4ybiy8szlTGhy%2f3ZiayQ%2fZVZxk2Y9p8j8AJ7xKIQKlz6jRQXPwzMFMUP8gqfClr7JNFg6BMVX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,11 +212,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -263,11 +263,11 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -314,13 +314,488 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:16 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=9QdRAfwiVV49lhSiqdntlEDzUjtS%2b1H9vCZpsmTsk8FlanLigl0vmsCLcs5ETpsz4bwetYDTS7MWapR6yD6nX9hTvMw9jEE95MHIFiKd6fHyoG1CUPTru1BzQmSuGsfnEyys2ZY5DwpyFCvPPWdga3A7033iS9WAID04%2fu0TcZfowDYPwL3HPox0SeSJJU9F;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:16 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=NnHpsm%2fljKB0cTtxUDnmMa0gL05OHLvsV310hQbR5%2b3z7ILuTZMMJ5Vf1lA7NC7%2faOuAuwG6Gy0QRqDQE0uH1vpQMptn5h6eRSOZEMr20fcdLqMW8wXjzilGVi2u20PRi1Cw7f7N%2ftKTTPkn72T%2fPGpX21kYuHiwa9o2r4qfr8Lij8Wvk3P039skjrn0mZzo;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NnHpsm%2fljKB0cTtxUDnmMa0gL05OHLvsV310hQbR5%2b3z7ILuTZMMJ5Vf1lA7NC7%2faOuAuwG6Gy0QRqDQE0uH1vpQMptn5h6eRSOZEMr20fcdLqMW8wXjzilGVi2u20PRi1Cw7f7N%2ftKTTPkn72T%2fPGpX21kYuHiwa9o2r4qfr8Lij8Wvk3P039skjrn0mZzo
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_add", "params": [["dummy-group"], {"all": true, "description":
+      "A dummy group", "nonposix": false, "external": false, "no_members": false,
+      "fasgroup": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '176'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NnHpsm%2fljKB0cTtxUDnmMa0gL05OHLvsV310hQbR5%2b3z7ILuTZMMJ5Vf1lA7NC7%2faOuAuwG6Gy0QRqDQE0uH1vpQMptn5h6eRSOZEMr20fcdLqMW8wXjzilGVi2u20PRi1Cw7f7N%2ftKTTPkn72T%2fPGpX21kYuHiwa9o2r4qfr8Lij8Wvk3P039skjrn0mZzo
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xSwWrjMBD9FeHLXmxjO06aFgobSg+FDdvTUtiWMpEmRosteTVS2hDy79XIofFt
+        RvPmzXszOmUOKfQ+uxOneahHCEb/D6hVzP9mNdRqKdfrAlY3bVHXCMVOtXWxbJZtVd1W6wYX2Vsu
+        MmkSXoVhOBads2FMzwpJOj16baf6RiSEuCLs7h9KL3sgSghvxyw+J4DdGxiQODdIHtXUFlPWSejm
+        +UTEyWhJf36X9kDXaZ1WJgw7dJO7drlYVVV706TiN/JOeBeQ5bPq6O1+5iuPaQqII5DSBuMpV/Ie
+        P2EYe+RQ2iE7R4ID9AGZY76Y+B5dEXSYLJ8yfxwT6AOc0aZLfqNxfvqDjuLytproUrm0cnHz/CQu
+        ADHZEh9AwlgvCI3Pxd66yKlElDOC1zvda39M9S6AA+MRVSk2RGGI7LHJHdD9IMHEh4k4F03ZLFY8
+        WVrFY+tFVdW8HPCQPs3U9n5pYGFTy/nMW43cA7hj0qsUqun24nW+ktcsbQuds3wZE/qej6qu8ei0
+        kfHKPfOAinJ/Pr5sts+/HsuH31tWNxvflusyjv8CAAD//wMA12+N0OUCAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=NnHpsm%2fljKB0cTtxUDnmMa0gL05OHLvsV310hQbR5%2b3z7ILuTZMMJ5Vf1lA7NC7%2faOuAuwG6Gy0QRqDQE0uH1vpQMptn5h6eRSOZEMr20fcdLqMW8wXjzilGVi2u20PRi1Cw7f7N%2ftKTTPkn72T%2fPGpX21kYuHiwa9o2r4qfr8Lij8Wvk3P039skjrn0mZzo
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU224TMRD9FWtfeMlld7MJSaVKVFAhBFUroSIEQtXEO9mYeu3Flyah6r/jsTdN
+        Cq14yuycuZ45zn1m0HrpshN2fzC/32dc0W/2zrftjl1bNNmPActqYTsJOwUtPgcLJZwAaRN2HX0N
+        cm2fC16B5QbBCa2c6OuVeZnns7wqpnlezL7FOL38idxxCTaVcbrLgrtDY7UiS5sGlPgdK4E8+IVC
+        F7CnDk/tKV1bsQXOtVeOvm/NsjNCcdGBBL/tXU7wW3SdloLvem8ISBP1H9au9zXDRnszAJ/t+r3R
+        vrtcXfnlR9xZ8rfYXRrRCHWunNkl0jrwSvzyKOq4X7GACS7qagiz19WwKBCG8zmfDKfltMrzRT4v
+        cRITaeTQfqNNjdtOmEjAgcZFXh7TGKIDha7b1HwNqnmZ7xaEjGBN93qDW2g7iSOu230dDkorwUE+
+        6iCFnn89u7j6dD56e3mRTi9q5dtlYCTuVU0nszyvXhcR9P26MTV6bBr+USBr3WItTKBaB6oIGpNr
+        fMg4Ptp/Z7lD9VS3+zFenlHqcCm7RpkIGS+FGi/BriOobC8fqfltwFdB+EjKCs8IzR3WR74WqYVe
+        3TSkiFiMzh7ibHpXtDrNchqnH3B1GkEy+i52UPPT/hhk0j0eKDdJ+IQVwXbGKw7ur97WQoM2vWu3
+        64iCbANGCdWQJntWsi+hYVDQhbC2R/pUAs+uPrA+gCXC2AYsU9oxi8oN2EqbULNmYa4uKHEppHC7
+        iDceDCiHWI/YmbW+DdVZpMi8sowK36XCA1aOysksi0vV1LaYBF0SP+Ag/kWltJs+gQZLKQ+RilC7
+        haiVrGBEIGvB8XWg4yGgaIymMysvJb27+mA/qohS/xVQiDjqWI3mo9DxDwAAAP//AwClfT4yOwUA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_find", "params": [[], {"all": true, "sizelimit": 0, "pkey_only":
+      true, "fasgroup": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6SUy2rDMBBFf0Vo041jYjvPQqChZFFoaFalUEpRJMUVWLLRI6kJ+feObNOkC0FB
+        K8/M1T0zkmHOWHPjKovv0fkavp8xVf6LmZOyHZW6dg3+SBBmvgzi6kZIIO0C4yNCae2UNQmjK/5N
+        ZFNxH9Ja4kuCfsGWG9vbR9lf8q0SjR6H2eNYeB5k57HoIoguYtGTIHoSi54G0dNY9CyInsWi50H0
+        PBa9CKIXsehlEL38P9ojOhUoWQaJ1U5RYjmDwoFUhkNNcmNIyU2/F2zbcN/zRLQSqsRwQBHZlV65
+        NqJWW2HMoAxWL653T2g4gJSTe67RiRikaosMVzZBh1oDkyEYrCFW7EUlbNvppSOaKMs5S9HaGCeB
+        DiZ95PrOIA8+9uAE5WlezHB3K+bbZsV47O/FiCXdiuttn4PBD9ZbLt1bAFsS3fpylqH+DZEkln7B
+        i8CPwFzrWoOsXFVBKtg1brRQVDSk8u5uOz5s3tbb3fMmfXzZ+plumk7SRQpNfwAAAP//AwAWUoNG
+        fgUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "group_show", "params": [[],
+      {"cn": "dummy-group", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-1", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-10", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-2", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-3", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-4", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-5", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-6", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-7", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-8", "all": true}]}, {"method": "group_show", "params": [[],
+      {"cn": "test-group-9", "all": true}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '906'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8yXTWvcMBCG/4rwpZfdRbJkWw4EupQcCg3NqRRKCLI0Xly8tivJSZaw/72SvSRK
+        CQ2ut+CbRjPzavSM/KGnSIPpaxtdoKdItn3jR4Ss0GneOPPHUxhUdaJvql89VMr7IiKISiTna5Fm
+        bE0IiHWhGFknccIwzjGPgUa3TlCBkbrqbNU2Q+IWqX6/P6CdbvtuiGiLnyCtrIUZlo1s20Vuegho
+        y0bswXi7AWNBjWnO9AUZ0KE9Cnmja031+OwqhXlZTY5lDEWsX6Z3lWr6fQF63B1LaIoxy+LB+Sxw
+        gazuwe/Kqzity0Bn5cxhYPxIyIGrWSl5CY9i39Xgh7LdR0cncC/qHrxGWIibN84U+uA8TV/XbgK0
+        bvXJdIl/bUpRSB5TynxT6NiUPMveaMp/QP4WZOvyx62tyXsgw9h/I/lqtdkoS6BFzuIApRAgF4ES
+        T2GJ58PE82lKxgkADmgWJC+WQPPdJzyMnc0yPgPKQnHxCiUnNFkCSjoBJZ2Nks5HqWguCizDU8nU
+        Ip5xNgElm42SnQGlyAkoHqJUJSwBZTIBZTIbZTIfJRCeYCHCB7xI6RJQphNQprNRpmdAyTkIEp5K
+        XnK2BJTZBJTZbJTZGVCWnBP56rOT4UV8wfkElHw2Sn6GX8tUUJWk4V96XpRLQJlPQJnPRpm/j9KX
+        47ZpxA5Od1J76AadB6GbqtkNABwJP/UNtHHXzOvKmJPnlOqd25vP6BSAxpseehAGNa1FBhq7QmWr
+        naZCruJO2Kqo6soeBv+uF1o0FkBt0Na4gp26S9L3oD8Y5IXvR+EVijcxHd5bslV+WUIx9tdqJawY
+        DsOYdndK8IWNKcfj7fGPzfveqZdxp6tGumbWz7fGj1fft9c3X642n75e+zUDUbbhGyf6GwAA//8D
+        ABa0T+DoDwAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:17 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -367,13 +842,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=854yn73zN%2fx5kZSA%2fXrLNQ8nmMoy94B3NdP2YG0n0I0dhQ%2bNiAEe2KXHS8piV3ee0m0a3WwwlG8knQd9W7XHuPCVcT4BDb5bSCsnbywec9LTgTrinHy2ehZ7LuPvc329TxKl%2ftRIvimEZPyhlMlJ5fIPzBdMBPfvgNFJeW4A49fNRs4qKqbPaLQOa4tTQv%2bZ;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=lIH1Q49Wtb4ujAYjHrs7ana1ydK%2bzaoBp%2fpr9mAoQALSK5UYdhy5%2fHsbd91j8EncrFSmg3IM5cGwfGttIegGkQ%2bdSYD87esnh5XIat7bclpckEqAAqfwwhB136AZhIiyFFd%2f9GxM9tOab%2bWl6ITyldsJ5yGCcWDBkDXjC9NaF%2fYneM%2f4I8Fdp%2f0jbbOui7w5;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -395,7 +870,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=854yn73zN%2fx5kZSA%2fXrLNQ8nmMoy94B3NdP2YG0n0I0dhQ%2bNiAEe2KXHS8piV3ee0m0a3WwwlG8knQd9W7XHuPCVcT4BDb5bSCsnbywec9LTgTrinHy2ehZ7LuPvc329TxKl%2ftRIvimEZPyhlMlJ5fIPzBdMBPfvgNFJeW4A49fNRs4qKqbPaLQOa4tTQv%2bZ
+      - ipa_session=MagBearerToken=lIH1Q49Wtb4ujAYjHrs7ana1ydK%2bzaoBp%2fpr9mAoQALSK5UYdhy5%2fHsbd91j8EncrFSmg3IM5cGwfGttIegGkQ%2bdSYD87esnh5XIat7bclpckEqAAqfwwhB136AZhIiyFFd%2f9GxM9tOab%2bWl6ITyldsJ5yGCcWDBkDXjC9NaF%2fYneM%2f4I8Fdp%2f0jbbOui7w5
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -422,444 +897,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "group_add", "params": [["dummy-group"], {"all": true, "description":
-      "A dummy group", "nonposix": false, "external": false, "no_members": false,
-      "fasgroup": true}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '176'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=854yn73zN%2fx5kZSA%2fXrLNQ8nmMoy94B3NdP2YG0n0I0dhQ%2bNiAEe2KXHS8piV3ee0m0a3WwwlG8knQd9W7XHuPCVcT4BDb5bSCsnbywec9LTgTrinHy2ehZ7LuPvc329TxKl%2ftRIvimEZPyhlMlJ5fIPzBdMBPfvgNFJeW4A49fNRs4qKqbPaLQOa4tTQv%2bZ
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0xSTW/bMAz9K4Ivu9iG7Xy5BQosGHoY0GA9DQPWomAkxtBgS64opQ2C/PeJctD4
-        RurxPT5SPGcOKfQ+uxfneahHCEa/B9Qq5n8ztdrcwaaVxQbW+6KuEYq2WayKVbNaVtWyBlCYveYi
-        U0jS6dFraxJxK1QYhpPonA1jqui0MmHYo0t4XbVtVVXNepNAu/+H0sseiBLs7Zgxh9n2YGBA4twg
-        eVSTZkzZLaGb55MQJ6Ml/fkFHYBuVuTkMTksbs9fNffCu4A8FRfG8odZaR7TFBBHIKUNxlOu5AN+
-        wjD2yKG0Q3aJAkfoA7LGvFd8j/MQdJiGPWf+NKaiD3BGmy5NGkfmp9/oKO50p4muyJXK4Pb5p7gW
-        iGm34gNIGOsFofG5OFgXNZWIdkbweq977U8J7wI4MB5RlWJLFIaoHknuiO4bCRY+TsK5aMpmsebO
-        0ipuWy+qqublgId0NBPt7UpgYxPlcuGtRu0B3Cn5VQrVdBLiZb6SlyxtC52zfB4m9D1/p7rFo9NG
-        xv/tWQdUtPv98c929/z0WP74tWN3s/bLsi1j+/8AAAD//wMAVPmQTOUCAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:14 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=854yn73zN%2fx5kZSA%2fXrLNQ8nmMoy94B3NdP2YG0n0I0dhQ%2bNiAEe2KXHS8piV3ee0m0a3WwwlG8knQd9W7XHuPCVcT4BDb5bSCsnbywec9LTgTrinHy2ehZ7LuPvc329TxKl%2ftRIvimEZPyhlMlJ5fIPzBdMBPfvgNFJeW4A49fNRs4qKqbPaLQOa4tTQv%2bZ
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
-        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
-        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
-        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
-        P+UK/QMAAP//AwBCBmNsWAEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=9QdRAfwiVV49lhSiqdntlEDzUjtS%2b1H9vCZpsmTsk8FlanLigl0vmsCLcs5ETpsz4bwetYDTS7MWapR6yD6nX9hTvMw9jEE95MHIFiKd6fHyoG1CUPTru1BzQmSuGsfnEyys2ZY5DwpyFCvPPWdga3A7033iS9WAID04%2fu0TcZfowDYPwL3HPox0SeSJJU9F
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
-      "sizelimit": 0, "whoami": true}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '107'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=9QdRAfwiVV49lhSiqdntlEDzUjtS%2b1H9vCZpsmTsk8FlanLigl0vmsCLcs5ETpsz4bwetYDTS7MWapR6yD6nX9hTvMw9jEE95MHIFiKd6fHyoG1CUPTru1BzQmSuGsfnEyys2ZY5DwpyFCvPPWdga3A7033iS9WAID04%2fu0TcZfowDYPwL3HPox0SeSJJU9F
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4RUbW/TMBD+K1a+8KXtkrZry6RJTDAhBNMmoSE0hKaLfUnMHDv4ZW2Z9t/xOena
-        wQSfermX5+6ee9yHzKILymcn7GFvfnvIuKbf7F1o2y27dmiz7yOWCek6BVsNLb4Ullp6Ccr1sevk
-        q5Eb91JyBY5bBC+N9nLAm+bTPJ/nr4t5kRezm5Rnyh/IPVfgehhvuiy6O7TOaLKMrUHLXwkJ1N4v
-        NfoYe+4I1J7KjZMb4NwE7en7zpadlZrLDhSEzeDykt+h74ySfDt4Y0I/0fDhXLPDjBvtzBj47Jr3
-        1oTusroK5UfcOvK32F1aWUt9rr3d9qR1ELT8GVCKtJ+YVzOAfDFewqIcFwXCGKrlcnw8PZ5HcgoA
-        gamQRo7t18YK3HTSJgL2NC7zVaJxfrPLjhT6bi14A7p+ge8hMUihQ1vGPSijyFerPM+ni8UOhYM2
-        WnJQTyoQdNg351/PLq4+nU/eXl6k1BakOgjjBtpO4YSbttfFv9q4fo8nrRxe5z9tw45Gig6d7lE/
-        l2zyKxPv4BpU/ZhHpdRHJbgmBRvTopA23tnEO6U4uY72sNoN8lGG38WMKgofSVnxGaG9R3Hga5E2
-        NdVtTYpIcHT2mOf6d0X70uinCX/E9WkKkjF0cSPBTwcSySQeH6m2l/AJK6LtbdAc/B+9nYMaXf+u
-        /bYjHrI1WC11TZocqMm+xIZRQRfSuSEylFLw7OoDGxJYfze2Bse08cyh9iNWGRsxBYtzdVGJpVTS
-        b1O8DmBBe0QxYWfOhTais0SRfeUYAd/3wCM2nUxniywtJahtMctz2kuAh/QX1ZfdDgU0WF/ymKiI
-        2C2kc2UFIwJZC543kY7HGEVrDalNB6Xo3Ym9/SQuKv1bVzHjoON8sprEjr8BAAD//wMA0/2RYjsF
-        AAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "group_find", "params": [[], {"all": true, "sizelimit": 0}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '71'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=9QdRAfwiVV49lhSiqdntlEDzUjtS%2b1H9vCZpsmTsk8FlanLigl0vmsCLcs5ETpsz4bwetYDTS7MWapR6yD6nX9hTvMw9jEE95MHIFiKd6fHyoG1CUPTru1BzQmSuGsfnEyys2ZY5DwpyFCvPPWdga3A7033iS9WAID04%2fu0TcZfowDYPwL3HPox0SeSJJU9F
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xZXY/rthH9K8K+9GV3YX34K0CAXLRBUSAXzUNRFCiCYCyNLa5l0iWl3TgX+e8Z
-        8lAW5d32bnLb7pNsazicmcOZc7if7iy7oevvvso+TY///HSnzjRo9a+BVeO/uFtXW95VNT2sabV6
-        yHOmB9rQ5mFZLKvFosqJGr774T67a9jVVp17ZXQw/FDXZtB9Rs1JaeV6S72xLjtYM5yDwUE1ejjt
-        2IbX88Vmswh/4Ueze+K6rztyLvzcm/Odt/HWZq/pxM5/PhunfsKS8snv3bFNP2Md/0Gz67n589V9
-        jW2G7bnwzYn9bn70S0w/3SE0ZZkX/vlE9lL4hyM/K13Fr44r/7Dr6Mgb/0T6wB3lsOAD6TzY1K2V
-        TJhzyzYPpr01lzzYkvedB+POaK24CMZ9a07kimDd0IsuKvhWfVsEu5OqW+46LqLfxvJLGf12yjkq
-        sdtLx2WwbcmarimD8Zl6q2pF5QbJ5YOxl2oxGlTBtGXqZcNVsH5i51RN1cy8CuY7q0gHW61qIzuK
-        7w+uGjdK3AXDp8H1Sgcrbl6URqJIdhYT1ZLW1CJHO8u6IWSpl13FLJFrO74gSztrzJGRpZ9J/EiN
-        sF3TauTpiWoBdac0l2Mdj0jNQWlCal7YyZJIjYDlLLtQjNw8kTMamWnoWTVIzdPQSfTB1g0/y54Z
-        iYl7QF6Oype2i6jxKdMEd2QlNKRe1oxZOKk+VBTBi18BISN652uni0WSTsQcUo84OxpkUaDBGnHc
-        l8WU8jIWcb+3EugmWQixwR0ianhnLLWIiLQgUSOG2jQXoJf0hTYTEo4xAuoFMC95dT0m2H6CfsQQ
-        PSAGObsdQjj61wghPLGchT1bBNFImBHGja9NF0MgiX8MQDoD9h/ghN13ZlAOvxstaJZkpaGHV5ja
-        1QTeDTZMTb4YcQRkigPFCM0OzvlCoTZ08jkigFNan+31CM+AmOK2AxSxeWiBZTzLphOYAN22bwcL
-        qHYCS8Eh3BvXDhGuvtTy/SqNq4zupbxISEtKMA241rIpFbOjWXVIzphiQWvo474vSnf8Gp3xXp5C
-        Qw1PhKbu7pv6a/6JTueO/WNtTne/3Gevp8dqvShpvVz46bHF9Nismu07pgcGRbY3Nmv4mTtzZut+
-        y2hAv3/fbNiTO9wOhhuv11e+yno78BvjIgGZnC+2l3KGq7ENbG/wxNZe8uVrCMlh11zkb4JGZos0
-        hWJ9i5QrCspbfBylyNy35fYWEzgwyzeAgPhkS3T4XWHOwDRl88sA1SzXW1pvag+oXQRUUS7fA6hm
-        OJ0un+MfxWr9vwLZnKu8CTm/w4fp69eYm/I5vfplCV1XtOJNsUj43a7aN59P6HdKJhU34Hcue2lN
-        VpPOuFF9ZjxhyHwq3H+iesX/l+r5rZm4o2si45dfnMTlbr/a/OYk/on3Mvb6pNlR1yWJ+2/DMMlG
-        fOlt6psy3t40TR7H7OU6Nz3nLK8DHhSIZJgvR3K1uhITCn1qIscjbdyCWExM2ZMmGXY5vE20+clw
-        l5c3nTCSQ7q2z4lLn6hRQtdy9MeJWD8ZWXELQjBRbN+60GdTsh2JblFigI/MG0xricCvJPwYGPK1
-        Jb/ByanYXp8jP+eT6i5ljDWh6n42oIFPpJ0aOpVL9O6JvreCP1Wu05xi/h+lEmj1M07/LBNF3FT5
-        uDhGgEyaF12VWDHh+jKPhJqMsyHh/WDAM7+guiBlVfDcCyYDnu5TaTDOmHyiWsUEgzK6ipLB132Z
-        EDUUl0mAEZwnMqKXMaqC31RQyPAS5ZBf2SDgdKX2wFSqNRrBBQFOqewI+wecUgXSSW+QgioCqFJF
-        4hFhLxq4SuXJs6ql3wBWc6kSAbccMRA5oT8GgFWEJwjEjZwJABlPaRQ2HlUSArA0qRycIf8xuEpF
-        z96SrpWrDUB1o4GSw1fGTUyiiJ/lMZ/QMe7AmwNbiViKagLQmiknlBTYmqkorBrcQtbAbXg9T4nH
-        Lc0uYzmusqunk1D4ZXLuRnH1AlglukzSfFSMkzRJtIaUuwBWtXRmjwECtA6yX6BqLuMElGQbAGsm
-        6TxHIyBLqL2kG9CyvOO6jrhKZV+v9ntRXcDVTAOijrFf8W4n7a2Kh6w1MkCK5dS/VslZB7ZS2Rhx
-        vEXLELirCLKo8oCzVFzK9kiaUjlVMLYttLvlHEwR153kEzib61GoRyBsJk6TolYj1AVRRYqocsow
-        oGZDpwfSZorWdOpZrGPqwZsBtdpeRH/GNhaJ82IKOU/8FaiJRue6CmNfylhrmdAQv+OIwFG+Kud4
-        7LdJfgGyQyeeY+/qxkkYdxMhlupsWfsYO1ciueN0DT5Z2n8+3tT0fgeA1ytZ7qn62LpmEj326xJB
-        n4Tlxd7lqwx8TSoetQe6UkVPAR/F1EDKeKZk9Es3y5GUVPV7XgFsJfp/FB/pOS5TXANa6TWBH8k6
-        4mq6MRiTMTavMMGAag8+24yYul4sXJEMVCX3DBg4wJTjEU9SmrqKtGPUThHYeYq+Io0rRX8wHQWW
-        R9t6qsbsiinWc7y18I7z6GLUm2gm+RjTeJeRyNDZtcY0ZwCiG40aGEKE0ezKI1Gvye0Hbi+KWypX
-        TAguIn+cLkVSrZtckPj0Rk6VCGDqLh4HOTKWXpukwji9RNnZS81A0ew+BceynLWHSK5SKZ3ctEgK
-        +RRhlCpsEGTEnFzAJMJ7uosZkxjb0iTIx0MkKwW/Qf/NlcxI6L9MypS77bbYc+GlzDpKmd2u/LyU
-        +Zvgpnf//rr/nVLmVru8ljavpUzvXWefvcmfZSu1eX/GfkCNtP9nycofRjto6ezsc7enzuFeSCB4
-        YIf/p/SXM3uXMv+10ocQksTqv/q7FEuy91FaV/wlmvofP3z/lyy+kEE7Zy/kMm36zLHu771Y9Jwi
-        k33J3FA71an+En4/DNIwdc/cPGYfnBskxIMY2We2f3CZX/gZC99nxWNRRuA13m1eLhZ5OLM9hX8N
-        wezHaOA3BpNfQipkbS8K/dcrlNplMpWE+DQeXXKkrfEV0EPX+eI10/NZZmEt1ey8cUDzN9/+48PH
-        77/79vGPf/0YqMfks3rcPIrPXwEAAP//AwBO/CfLtRoAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.example.com/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=wJhVBLDVJeJ5v8el4GrIPrwv%2boaS0r%2bwNQSwxZjK6tXab9I44pXlcUQVEB1JDH3JG1RwvdccWwV6Iy6QTUfVMw1Fnweub6SecqCH2%2bRoeCbSkVWLVEpHmJEn9%2f3Uufd29G32mIkhnfVpa%2bH%2bJFgFsp4bihtgswG0JsxqIYHrm08rF%2box2%2b8kP3E6%2bKY2F7ny;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=wJhVBLDVJeJ5v8el4GrIPrwv%2boaS0r%2bwNQSwxZjK6tXab9I44pXlcUQVEB1JDH3JG1RwvdccWwV6Iy6QTUfVMw1Fnweub6SecqCH2%2bRoeCbSkVWLVEpHmJEn9%2f3Uufd29G32mIkhnfVpa%2bH%2bJFgFsp4bihtgswG0JsxqIYHrm08rF%2box2%2b8kP3E6%2bKY2F7ny
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -883,7 +925,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=wJhVBLDVJeJ5v8el4GrIPrwv%2boaS0r%2bwNQSwxZjK6tXab9I44pXlcUQVEB1JDH3JG1RwvdccWwV6Iy6QTUfVMw1Fnweub6SecqCH2%2bRoeCbSkVWLVEpHmJEn9%2f3Uufd29G32mIkhnfVpa%2bH%2bJFgFsp4bihtgswG0JsxqIYHrm08rF%2box2%2b8kP3E6%2bKY2F7ny
+      - ipa_session=MagBearerToken=lIH1Q49Wtb4ujAYjHrs7ana1ydK%2bzaoBp%2fpr9mAoQALSK5UYdhy5%2fHsbd91j8EncrFSmg3IM5cGwfGttIegGkQ%2bdSYD87esnh5XIat7bclpckEqAAqfwwhB136AZhIiyFFd%2f9GxM9tOab%2bWl6ITyldsJ5yGCcWDBkDXjC9NaF%2fYneM%2f4I8Fdp%2f0jbbOui7w5
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -911,11 +953,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -939,7 +981,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=wJhVBLDVJeJ5v8el4GrIPrwv%2boaS0r%2bwNQSwxZjK6tXab9I44pXlcUQVEB1JDH3JG1RwvdccWwV6Iy6QTUfVMw1Fnweub6SecqCH2%2bRoeCbSkVWLVEpHmJEn9%2f3Uufd29G32mIkhnfVpa%2bH%2bJFgFsp4bihtgswG0JsxqIYHrm08rF%2box2%2b8kP3E6%2bKY2F7ny
+      - ipa_session=MagBearerToken=lIH1Q49Wtb4ujAYjHrs7ana1ydK%2bzaoBp%2fpr9mAoQALSK5UYdhy5%2fHsbd91j8EncrFSmg3IM5cGwfGttIegGkQ%2bdSYD87esnh5XIat7bclpckEqAAqfwwhB136AZhIiyFFd%2f9GxM9tOab%2bWl6ITyldsJ5yGCcWDBkDXjC9NaF%2fYneM%2f4I8Fdp%2f0jbbOui7w5
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -966,11 +1008,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -996,7 +1038,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9QdRAfwiVV49lhSiqdntlEDzUjtS%2b1H9vCZpsmTsk8FlanLigl0vmsCLcs5ETpsz4bwetYDTS7MWapR6yD6nX9hTvMw9jEE95MHIFiKd6fHyoG1CUPTru1BzQmSuGsfnEyys2ZY5DwpyFCvPPWdga3A7033iS9WAID04%2fu0TcZfowDYPwL3HPox0SeSJJU9F
+      - ipa_session=MagBearerToken=syduT%2b0XDAQCGyyxw2wCnP9a9vuj8o0N%2bpxMKJ%2fn47giEBwEX2Wtx9i7ArNZUNs105DPc5QLVFVVXmuoyD%2bABA5s4DGbile0PaVVdciyb2M0OpPeZvPZdQ79A1py5JP7FQX%2ba5U7S9hofk9CVldt5i1l1z3ujuhXQrhT61V3NIaOT5PWLNETHSJ2BdO0PQuX
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1023,11 +1065,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -1074,13 +1116,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 09 Apr 2020 14:10:15 GMT
+      - Thu, 04 Jun 2020 15:00:17 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=puFMUQo2wGsHK2CwYgrd%2b%2b3Bw5aJvGiy2pX4tBOvr6oFfThLu2dNsHN5LpHD6o1a4Tyf1LmVmnspnBw3R%2fXZZFNJ13HAhUCE6ILz%2bjZM9wGLj7SyEV%2b6GfYEKpzxUrqB9VTgBW1hH%2bEONC7etY42Tbt3N2h%2bJeiiB9KIKJ9iZEgeaT41Us9vNsF1AZxJHZ6s;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=ziFnZ625R%2be5auwL24ouGeapQoiFOyklPaA0cm%2bEeUh0svTgppRkQThgzqqMJcO1Pce9jVPEzWtrTHB5VcMkSQRLbLEYS9Fjl4OGt8CM8NKbSx1DPsqQwaCgRNvzbOIupkHOCVZHvjqI05vFNBBzGgFdmfj1%2bX%2fEHwTRx2rw4k%2bxLYhdklVNI2rDiFvQGdtO;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1104,7 +1146,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=puFMUQo2wGsHK2CwYgrd%2b%2b3Bw5aJvGiy2pX4tBOvr6oFfThLu2dNsHN5LpHD6o1a4Tyf1LmVmnspnBw3R%2fXZZFNJ13HAhUCE6ILz%2bjZM9wGLj7SyEV%2b6GfYEKpzxUrqB9VTgBW1hH%2bEONC7etY42Tbt3N2h%2bJeiiB9KIKJ9iZEgeaT41Us9vNsF1AZxJHZ6s
+      - ipa_session=MagBearerToken=ziFnZ625R%2be5auwL24ouGeapQoiFOyklPaA0cm%2bEeUh0svTgppRkQThgzqqMJcO1Pce9jVPEzWtrTHB5VcMkSQRLbLEYS9Fjl4OGt8CM8NKbSx1DPsqQwaCgRNvzbOIupkHOCVZHvjqI05vFNBBzGgFdmfj1%2bX%2fEHwTRx2rw4k%2bxLYhdklVNI2rDiFvQGdtO
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1131,11 +1173,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:16 GMT
+      - Thu, 04 Jun 2020 15:00:18 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1160,7 +1202,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=puFMUQo2wGsHK2CwYgrd%2b%2b3Bw5aJvGiy2pX4tBOvr6oFfThLu2dNsHN5LpHD6o1a4Tyf1LmVmnspnBw3R%2fXZZFNJ13HAhUCE6ILz%2bjZM9wGLj7SyEV%2b6GfYEKpzxUrqB9VTgBW1hH%2bEONC7etY42Tbt3N2h%2bJeiiB9KIKJ9iZEgeaT41Us9vNsF1AZxJHZ6s
+      - ipa_session=MagBearerToken=ziFnZ625R%2be5auwL24ouGeapQoiFOyklPaA0cm%2bEeUh0svTgppRkQThgzqqMJcO1Pce9jVPEzWtrTHB5VcMkSQRLbLEYS9Fjl4OGt8CM8NKbSx1DPsqQwaCgRNvzbOIupkHOCVZHvjqI05vFNBBzGgFdmfj1%2bX%2fEHwTRx2rw4k%2bxLYhdklVNI2rDiFvQGdtO
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1188,11 +1230,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:16 GMT
+      - Thu, 04 Jun 2020 15:00:18 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1216,7 +1258,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=puFMUQo2wGsHK2CwYgrd%2b%2b3Bw5aJvGiy2pX4tBOvr6oFfThLu2dNsHN5LpHD6o1a4Tyf1LmVmnspnBw3R%2fXZZFNJ13HAhUCE6ILz%2bjZM9wGLj7SyEV%2b6GfYEKpzxUrqB9VTgBW1hH%2bEONC7etY42Tbt3N2h%2bJeiiB9KIKJ9iZEgeaT41Us9vNsF1AZxJHZ6s
+      - ipa_session=MagBearerToken=ziFnZ625R%2be5auwL24ouGeapQoiFOyklPaA0cm%2bEeUh0svTgppRkQThgzqqMJcO1Pce9jVPEzWtrTHB5VcMkSQRLbLEYS9Fjl4OGt8CM8NKbSx1DPsqQwaCgRNvzbOIupkHOCVZHvjqI05vFNBBzGgFdmfj1%2bX%2fEHwTRx2rw4k%2bxLYhdklVNI2rDiFvQGdtO
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1243,11 +1285,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 14:10:16 GMT
+      - Thu, 04 Jun 2020 15:00:18 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.41 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:

--- a/noggin/tests/unit/controller/test_group.py
+++ b/noggin/tests/unit/controller/test_group.py
@@ -3,6 +3,7 @@ import pytest
 import python_freeipa
 from bs4 import BeautifulSoup
 from fedora_messaging import testing as fml_testing
+from flask import Markup
 
 from noggin import ipa_admin
 from noggin_messages import MemberSponsorV1
@@ -108,21 +109,23 @@ def test_group_add_member(client, dummy_user_as_group_manager, make_user):
             '/group/dummy-group/members/', data={"new_member_username": "testuser"}
         )
 
-    expected_message = """You got it! testuser has been added to dummy-group.
+    expected_message = (
+        """You got it! testuser has been added to dummy-group.
     <span class='ml-auto' id="flashed-undo-button">
-        <form action="/group/dummy-group/members/remove" method="post">
-            
-            <button type="submit" class="btn btn-outline-success btn-sm"
+        <form action="/group/dummy-group/members/remove" method="post">"""
+        "\n            \n           "
+        """ <button type="submit" class="btn btn-outline-success btn-sm"
              name="username" value="testuser">
                 Undo
             </button>
         </form>
-    </span>"""  # noqa
+    </span>"""
+    )  # noqa
 
     assert_redirects_with_flash(
         result,
         expected_url="/group/dummy-group/",
-        expected_message=expected_message,
+        expected_message=Markup(expected_message),
         expected_category="success",
     )
 

--- a/noggin/tests/unit/representation/test___init__.py
+++ b/noggin/tests/unit/representation/test___init__.py
@@ -1,5 +1,6 @@
 import pytest
 
+from noggin.representation import Representation
 from noggin.representation.user import User
 from noggin.representation.group import Group
 
@@ -30,3 +31,16 @@ def test_wrong_attribute(dummy_user_dict):
     with pytest.raises(AttributeError) as e:
         user.does_not_exist
     assert str(e.value) == "does_not_exist"
+
+
+def test_pkey_unset():
+    with pytest.raises(NotImplementedError):
+        Representation.get_ipa_pkey()
+
+
+def test_pkey_missing_map():
+    class Dummy(Representation):
+        pkey = "dummy"
+
+    with pytest.raises(NotImplementedError):
+        Dummy.get_ipa_pkey()

--- a/noggin/tests/unit/utility/cassettes/test_pagination/test_groups_page.yaml
+++ b/noggin/tests/unit/utility/cassettes/test_pagination/test_groups_page.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 04 Jun 2020 15:00:18 GMT
+      - Thu, 04 Jun 2020 15:00:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=vgIQh%2fyAiq8P40hHFfYQXpogqAyTH0NL97%2fQvrJtgQBW0r8SnvkrkjsYl4vmc22zhTZYFbLKwb%2byLN3gkwK4rgWCDTgGPYI82eOZ0hafHM3TetZK7CePNQwGVoh%2flsGuWZmtJ34Yjii2iiN2RPOnoREp2SY4TjIOWT5YiebCMmKBOFVEpvRH0toiCUq4QhWa;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=PCnGINiApUaUoFn27Ikefwt1gdLoqAEv83Il00KBEayY0XGujfp23elIfmJ994voEYjhK%2fE5%2bO3eHPDZ%2fU63PzKGLaVxC0fVGe9DWpKvCWQR6y3sUP4o7iqYQ%2bgIibLS%2bBx9S0pajYvsK3thCp6QeT%2bD2TJrPfXWLvoftzBW99%2fz5fie150a6gTVCdhlz32F;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vgIQh%2fyAiq8P40hHFfYQXpogqAyTH0NL97%2fQvrJtgQBW0r8SnvkrkjsYl4vmc22zhTZYFbLKwb%2byLN3gkwK4rgWCDTgGPYI82eOZ0hafHM3TetZK7CePNQwGVoh%2flsGuWZmtJ34Yjii2iiN2RPOnoREp2SY4TjIOWT5YiebCMmKBOFVEpvRH0toiCUq4QhWa
+      - ipa_session=MagBearerToken=PCnGINiApUaUoFn27Ikefwt1gdLoqAEv83Il00KBEayY0XGujfp23elIfmJ994voEYjhK%2fE5%2bO3eHPDZ%2fU63PzKGLaVxC0fVGe9DWpKvCWQR6y3sUP4o7iqYQ%2bgIibLS%2bBx9S0pajYvsK3thCp6QeT%2bD2TJrPfXWLvoftzBW99%2fz5fie150a6gTVCdhlz32F
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:18 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-06-04T15:00:18Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-06-04T15:00:26Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vgIQh%2fyAiq8P40hHFfYQXpogqAyTH0NL97%2fQvrJtgQBW0r8SnvkrkjsYl4vmc22zhTZYFbLKwb%2byLN3gkwK4rgWCDTgGPYI82eOZ0hafHM3TetZK7CePNQwGVoh%2flsGuWZmtJ34Yjii2iiN2RPOnoREp2SY4TjIOWT5YiebCMmKBOFVEpvRH0toiCUq4QhWa
+      - ipa_session=MagBearerToken=PCnGINiApUaUoFn27Ikefwt1gdLoqAEv83Il00KBEayY0XGujfp23elIfmJ994voEYjhK%2fE5%2bO3eHPDZ%2fU63PzKGLaVxC0fVGe9DWpKvCWQR6y3sUP4o7iqYQ%2bgIibLS%2bBx9S0pajYvsK3thCp6QeT%2bD2TJrPfXWLvoftzBW99%2fz5fie150a6gTVCdhlz32F
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227bMAz9FcMve0lSO7cmAwosbdNi6C3D1m3oVgS0xDhaZMmT5CRe0H+fJNtJ
-        C3Trkyke8pA6pLwLFeqCm/B9sHtuEmE/P8LzIsvK4F6jCh9bQUiZzjmUAjJ8DWaCGQZcV9i996VI
-        pH4tWCa/kBjCQVewkXlo3TkqLYWzpEpBsD9gmBTAD34m0FjspaNwtC5darYFQmQhjDuvVJIrJgjL
-        gUOxrV2GkRWaXHJGytprA6qO6oPWy4ZzAboxLfBZLy+VLPK7xaxIrrDUzp9hfqdYysRUGFVWYuRQ
-        CPa7QEb9/eIkpqPhsNuG4XG/HccI7XGvt2gPuoN+FI2jURd7PtG1bMtvpKK4zZnyAniKbtSNomHU
-        jwdRFB8/NNFWQpNvKFmCSPF/gbg1CigYcEG7cD5PQOOwP5/bcziZXJ2e33Ik2XhNz8bLh8s4T1an
-        F9+mF7f30+3F9ep29uXT5CR8eqwunIGAFCn6G7uqRJxQN+OWNVInkXZWPQzdouQEt5DlHJ1JZObb
-        4tKqppfIuec4Spg4sm0tPbiUGVKm7FRkXePIuY58mb1YzXz3a+nhD9Pvk5vZ9bRzdnfjQzNg/Blc
-        99JpGrFMBIQUjLzJpKtx7Fe5qEd8aCtlVBRZYnE/+v6gN4yi/nGvBtcoXr6hhubfSXYJiUK/C4Zl
-        r4x5VI05t48Y1RpdRwv7FtHJCHrerJR1G1U03hWWBpKDL0NXXy7mfn6+iNtjy6irH4C7uWv0MGkP
-        vjHoJ5u6Bl64tmuVfDGt7QbpahtNmXt4A0owkbqAWqPwq61g733DtK6ROtXv7exjUAcElXzBBnQg
-        pAm03c1WsJDKctLANpJb/RLGmSk9nhagQBhE2gkmWheZZQ+8euqdDhzxuiJuBd1Otzd0lYmkrmzc
-        s5I7QarXtAurtHmd4BqrUp78c7HcGfgVDieUIg2casHPSoufoRcIlZJu9KLg3P0/6MHer7gjAGr7
-        fLGTTt1D3X5n1LF1/wIAAP//AwCruZ5Z2gUAAA==
+        H4sIAAAAAAAAA4RU227bMAz9FcMve0lS59p2QIFlbVoMvWXYug1di4CWGEeLLHmSnMQL+u/TxU5W
+        oGufQvNySB4eZRsr1CU38fto+69JhP35GZ+VeV5FdxpV/NiKYsp0waESkONLYSaYYcB1iN15X4ZE
+        6peSZfoLiSEcdAgbWcTWXaDSUjhLqgwE+wOGSQF872cCjY09d5QO1pVLzTZAiCyFcd9LlRaKCcIK
+        4FBuapdhZImmkJyRqvbahDBR/aH1osGcg25MG/iiFxdKlsXtfFqml1hp58+xuFUsY2IijKoCGQWU
+        gv0ukVG/Xy/pHvUgxTaMDgftbhehndI5toe94SBJjpOjHvZ9oRvZtl9LRXFTMOUJqCF6STJKBt1h
+        kvRG9022pdAUa0oWIDJ8LRE3RgEFAy5pG89mKWgcDWYz+x2Px5eXZzccSX68oqfHi/uLbpEuP55/
+        n5zf3E0251fLm+nXz+OT+OkxLJyDgAwp+o1dVyJOqLtxyxqZo0g7qz6GblFyghvIC47OJDL3Y5WM
+        ijJPLb0OojsY9kdJMjgc+mAOjHu/x/1Ql3eaWnsYotDzY1j+/9UXMkfKlD2urEc9cK4DjxpUylYo
+        nsu6mW7fv858ZV4urQT0AnmY+iBl4sByvGgOQEBIwQjwXauw2OTH+Hp6Nemc3l7vJNCo9o1UHaSx
+        e1aFfcSoVujmntu3iG5/0LNGUtZtVNl4l1gZSPe+HN1qcj7z9/PITscWUYc/ANfNsbK/tA++cegn
+        W7oCXrpFai59M62tgnRQo6kKH16DEkxkLqFePf5mO9gbXzOt60hd6nU7/RTVCVG4TLQGHQlpIm21
+        2YrmUllMGtlBCquVlHFmKh/PSlAgDCLtRGOty9yiR5499U5HDngVgFtRr9Prj1xnIqlr2+0nSdcR
+        El7TNg5ls7rADRZKnvxzsdg5eO3FY0qRRo616CFw8RB7glAp6VQlSs7d/wfd2zsxOACgds5nOnDs
+        7vsOOkcd2/cvAAAA//8DAF74P3zaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:18 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vgIQh%2fyAiq8P40hHFfYQXpogqAyTH0NL97%2fQvrJtgQBW0r8SnvkrkjsYl4vmc22zhTZYFbLKwb%2byLN3gkwK4rgWCDTgGPYI82eOZ0hafHM3TetZK7CePNQwGVoh%2flsGuWZmtJ34Yjii2iiN2RPOnoREp2SY4TjIOWT5YiebCMmKBOFVEpvRH0toiCUq4QhWa
+      - ipa_session=MagBearerToken=PCnGINiApUaUoFn27Ikefwt1gdLoqAEv83Il00KBEayY0XGujfp23elIfmJ994voEYjhK%2fE5%2bO3eHPDZ%2fU63PzKGLaVxC0fVGe9DWpKvCWQR6y3sUP4o7iqYQ%2bgIibLS%2bBx9S0pajYvsK3thCp6QeT%2bD2TJrPfXWLvoftzBW99%2fz5fie150a6gTVCdhlz32F
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -314,13 +314,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -367,13 +367,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=pwUlDZZsilH0Ue%2faVpfxwwUTy9QAY9%2fdMrHAPcSTppIrz39RzjkiKudprYolbQQV1c1j0T65%2fQnoFfN64lHILCF7bDTXEfxoiTMco8NSxyBfjXHIxO2UcPl34T4byD%2byVILslA6ICshAElAYqsi8eM4BtycihLKJZc7s7NysBbkfnVRevwSNuXZwsPVnQ1Zq;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=mBv9x3DbgjJ2nrBVBONWpfyi5a09aKRixOWnP8NhrXJR50jsH3ZqmqdEZbcHmkOfllqGfkKRDIXg7iyB2K1RG6vek84zDMaDmvasft8tgin9sJn6ISUv2sgYqyH2s%2fn0u%2fpeEImYLaIXJyev03H%2fqlWn%2bOm69f3RZnnj%2f9odJexJMpbqyOBFf%2b2d5vL4ygEi;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -395,7 +395,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=pwUlDZZsilH0Ue%2faVpfxwwUTy9QAY9%2fdMrHAPcSTppIrz39RzjkiKudprYolbQQV1c1j0T65%2fQnoFfN64lHILCF7bDTXEfxoiTMco8NSxyBfjXHIxO2UcPl34T4byD%2byVILslA6ICshAElAYqsi8eM4BtycihLKJZc7s7NysBbkfnVRevwSNuXZwsPVnQ1Zq
+      - ipa_session=MagBearerToken=mBv9x3DbgjJ2nrBVBONWpfyi5a09aKRixOWnP8NhrXJR50jsH3ZqmqdEZbcHmkOfllqGfkKRDIXg7iyB2K1RG6vek84zDMaDmvasft8tgin9sJn6ISUv2sgYqyH2s%2fn0u%2fpeEImYLaIXJyev03H%2fqlWn%2bOm69f3RZnnj%2f9odJexJMpbqyOBFf%2b2d5vL4ygEi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -422,7 +422,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:28 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -437,9 +437,8 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "group_add", "params": [["dummy-group"], {"all": true, "description":
-      "A dummy group", "nonposix": false, "external": false, "no_members": false,
-      "fasgroup": true}]}'
+    body: '{"method": "group_find", "params": [[], {"all": true, "sizelimit": 0, "fasgroup":
+      true}]}'
     headers:
       Accept:
       - application/json
@@ -448,11 +447,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '176'
+      - '89'
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=pwUlDZZsilH0Ue%2faVpfxwwUTy9QAY9%2fdMrHAPcSTppIrz39RzjkiKudprYolbQQV1c1j0T65%2fQnoFfN64lHILCF7bDTXEfxoiTMco8NSxyBfjXHIxO2UcPl34T4byD%2byVILslA6ICshAElAYqsi8eM4BtycihLKJZc7s7NysBbkfnVRevwSNuXZwsPVnQ1Zq
+      - ipa_session=MagBearerToken=mBv9x3DbgjJ2nrBVBONWpfyi5a09aKRixOWnP8NhrXJR50jsH3ZqmqdEZbcHmkOfllqGfkKRDIXg7iyB2K1RG6vek84zDMaDmvasft8tgin9sJn6ISUv2sgYqyH2s%2fn0u%2fpeEImYLaIXJyev03H%2fqlWn%2bOm69f3RZnnj%2f9odJexJMpbqyOBFf%2b2d5vL4ygEi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -462,14 +461,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0xSwYrbMBD9FeFLL06wHSe7XVhoKHsoNHRPpdBdykSaGBVbcjVSdkPIv3dGDhvf
-        ZjTvvXl60rkISKmPxYM6z0s7QnL2X0JruP9d1Hto9KaGBWzu2kVdI1eAerFu1m1Vfa7uG1wVr6Uq
-        DJIOdozWu0zcKpOG4aS64NOYEX7/F3XUPRBlRPRjwccZ4A8OBiTpHVJEM9G4FUOEYd5PQtKMnuz7
-        x+gAdNvWWePSsMcwXaNdrzZV1d61eagnj9nh4sb5EHhQMSSUWwmQ4Y8zaMltLkgq0NonF6k0+hHf
-        YRh7lFL7obiwwBH6hKIx38XnfFmCDnMS5yKexgx6g+Cs63IMnIcc/cRAnOnOEl0nV6oMt8/f1BWg
-        ptuqNyDlfFSELpbq4ANrGsV2Roh2b3sbT3neJQjgIqJZqi1RGlidSeGI4RMpET5OwqVqls1qI5u1
-        N7K2XlVVLeFAhPxpJtqfK0GMTZTLRVJl7QHCKfs1Bs30JdTLPJKXIqeFIXh5MJf6Xt7a3OoxWKf5
-        8XvRAcN2vzz92u6evz8tv/7YibvZ+nZ5v+T1/wEAAP//AwBlDRSY5QIAAA==
+        H4sIAAAAAAAAA8yWzYucMBTA/5XgpRcdjPEjLix0KHsodOieSqGU8kyeU4tGm8TdDsv+70102HWh
+        h4oXb+/7vfyM+p4CjWZsbXBDnl7Fb09BM8Comt8jNtIbgqoSPGEsjSAvWEQpQlQWBY2yJEvjuIx5
+        giz4HpKgr36hsKIFY6ZE2w+BM591Pw59raBD43WFxqKcrF717QzqpT4X8koNZnb4+kLNZV1+NFkj
+        Otlfgm6I1SM6i/SRLv52GRs6fRKNl0CIflTWhFLc4h/ohha9KPoueA7JPyjUyKoyTRYUAFDsgkK8
+        BkO8kYNIOUWMFxwqWlZ74JCswJBspVBJDm8ocMqyPVBgKyiwjRQkK6GKxfIupHIX70S6gkK6lQKU
+        FCVfUpA17oFCtoJCtpECUp7FAMs3osrZHijkKyjkWylwjkCXd4HXPN0DhWIFhWIrhZpzKt58HYt4
+        F/8IvoIC37ox5MBkli/3prKq90ChXEGh/H8KUzPvdVXcnkECV1YJcFM7Qw2t8T3caQyc0czLpr0M
+        6Hs+glaNOk/ndAf2pi+oTdOrU2PM1XNN9c7j/UdyDSBq7CrU5BEMUb0lBpUNSd1rV1MSN9gAtqma
+        trGXyX8eQYOyiPJAjsaMnavukvQD6neG+MIPc+GQJIeE5cF0KunbUhbH1HMCC9PePKf9uCb4weaU
+        54mFq92BvngzjcnMkHRgxU9HxN2ZALXutXOrsW39I5Sv8qAbJdwzbX02SDfk+7uvx9P9p7vDh88n
+        P9OiaXrgB9f0LwAAAP//AwD8TljI0wsAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -482,7 +484,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:28 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -510,7 +512,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=pwUlDZZsilH0Ue%2faVpfxwwUTy9QAY9%2fdMrHAPcSTppIrz39RzjkiKudprYolbQQV1c1j0T65%2fQnoFfN64lHILCF7bDTXEfxoiTMco8NSxyBfjXHIxO2UcPl34T4byD%2byVILslA6ICshAElAYqsi8eM4BtycihLKJZc7s7NysBbkfnVRevwSNuXZwsPVnQ1Zq
+      - ipa_session=MagBearerToken=mBv9x3DbgjJ2nrBVBONWpfyi5a09aKRixOWnP8NhrXJR50jsH3ZqmqdEZbcHmkOfllqGfkKRDIXg7iyB2K1RG6vek84zDMaDmvasft8tgin9sJn6ISUv2sgYqyH2s%2fn0u%2fpeEImYLaIXJyev03H%2fqlWn%2bOm69f3RZnnj%2f9odJexJMpbqyOBFf%2b2d5vL4ygEi
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -537,537 +539,9 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
+      - Thu, 04 Jun 2020 15:00:28 GMT
       Keep-Alive:
       - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
-      "sizelimit": 0, "whoami": true}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '107'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4RUXU/bMBT9K1Ze9tKWJP2gRUIa2tA0bQikiWlimpDj3CYejp352rQB8d/n66S0
-        bGh7qnM/zr3n+LiPiQX0yiUn7HF//P6YCE2/yXvfNB27RrDJjxFLSomt4p3mDbyWllo6yRX2uesY
-        q0AYfK14zVFY4E4a7eSAl6d5mi7SWTZP02x5E+tM8ROEE4pjD+NMm4RwCxaNppOxFdfyISJxtY9L
-        DS7kXgY8jad2g3LLhTBeO/q+s0VrpRay5Yr77RByUtyBa42SohuioaDfaPhArHeYgdHuGBJfsP5g
-        jW8v11e++AQdUryB9tLKSupz7WzXi9Zyr+UvD7KM/LIiK5eLRT7mi+PZOMuAj1fT6Xo8z+ezNF2l
-        yxymsZFWDuM3xpawbaWNAuxlXKV5lHF1s6sOErp2U4qa6+oVvYdCZcJ6WINSseSokPqo4Fj3tylL
-        7ZsikIyrzubTRZrOjvuF/MCgpIuOkdo0UEob1DKBbYSj0NG+4lD3Z1vF9Nvzb2cXV5/PJ+8uL2Ip
-        9uSeDdRwqQ7KYcubVsFEmGaHLLg2Wor/Ivt/sarkPeiXjo9xjYN9lBF3IbcOxgdyVnhGYO+hPIg1
-        QOhmfVuRIyIQXXuow/5dETVa4zQuOBL6NCbpMEzBUSlOB450JJpP1Ntb+IRl4eys14K7P2Yj8gqw
-        f9eua4lIsuFWS12RJwduydcwMDjoQiIOmaGVkmdXH9lQwHqt2IYj08YxBO1GbG1swCxZ2KsNTiyk
-        kq6L+cpzy7UDKCfsDNE3AZ1FiewbZAR83wOPWD7Jp4skkippbDYNviR9uOPxL6pvux0aaLG+5SlK
-        EbAbHo2WZIwEZA13og5yPIUsWGvohrVXit5duT8/W5Ba//ZIqDiYOJssJ2HibwAAAP//AwBUaMbl
-        OwUAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "group_find", "params": [[], {"all": true, "sizelimit": 0, "pkey_only":
-      true, "fasgroup": true}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '108'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6SUy2rDMBBFf0Vo041jYjvPQqChZFFoaFalUEpRJMUVWLLRI6kJ+feObNOkC0FB
-        K8/M1T0zkmHOWHPjKovv0fkavp8xVf6LmZOyHZW6dg3+SBBmvgzi6kZIIO0C4yNCae2UNQmjK/5N
-        ZFNxH9Ja4kuCfsGWG9vbR9lf8q0SjR6H2eNYeB5k57HoIoguYtGTIHoSi54G0dNY9CyInsWi50H0
-        PBa9CKIXsehlEL38P9ojOhUoWQaJ1U5RYjmDwoFUhkNNcmNIyU2/F2zbcN/zRLQSqsRwQBHZlV65
-        NqJWW2HMoAxWL653T2g4gJSTe67RiRikaosMVzZBh1oDkyEYrCFW7EUlbNvppSOaKMs5S9HaGCeB
-        DiZ95PrOIA8+9uAE5WlezHB3K+bbZsV47O/FiCXdiuttn4PBD9ZbLt1bAFsS3fpylqH+DZEkln7B
-        i8CPwFzrWoOsXFVBKtg1brRQVDSk8u5uOz5s3tbb3fMmfXzZ+plumk7SRQpNfwAAAP//AwAWUoNG
-        fgUAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "batch", "params": [[{"method": "group_show", "params": [[],
-      {"cn": "dummy-group", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-1", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-10", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-2", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-3", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-4", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-5", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-6", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-7", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-8", "all": true}]}, {"method": "group_show", "params": [[],
-      {"cn": "test-group-9", "all": true}]}], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '906'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA8yXW2vbMBSA/4rwy16SIFmyLRcKC6MPg5X1aQxGGbJ0HDwc25PktqHkv0+yQ6sM
-        1pk5A7/pXHXOd+SLniMNpq9tdIWeI9n2jV8RskInvXHit+fQqepE31Q/e6iUt0WkELFMiViLNGNr
-        QsCtBMh1EicM4xzzGGh07xLKZvBX/X5/WO9023eDWoGRuups1Y72LRo80KtHW/wAaWUtzFBNZNsu
-        curBoS0bsQfj5QaMBTWGOdHXaUCH8pjIC11rqqcXUynM6267SjX9vgA9dscSmmLMMjYYXzyvkNU9
-        +PJ91a6366CvlROHhfErIQeuZqXkNTyJfVeDX8p2Hx1dggdR9+BzhGCc3jhR6IOzNH1dOwVo3eqT
-        6ALfHEpRSB5TyvxQ6DiUPMvIH4diHbtx6zX5X8zPKL8BMqzl30iedTMbZQm0yFkcoHzzfIeb4yWx
-        xPNh4vk0JeMEAAc0C5IXU2jGC4IZz2YZXwBlobg4Q8kJTaagpAtCSWejpPNRKpqLAsvwVDI16Rln
-        C0LJZqNkF0ApcgKKhyhVCVNQJgtCmcxGmcxHCYQnWIjwAS9SOgVluiCU6WyU6QVQcg6ChKeSl5xN
-        QZktCGU2G2V2AZQl50SefXYyPOkLzheEks9GyS/wa5kKqpI0/EvPi3IKynxBKPPZKPO/o/TluHaM
-        2MHpTmoP3ZDnUeimanZDo65jr/oC2rj75G1lzMlyCvXG7d1HdHJA400PPQqDmtYiA41dobLVLqdC
-        ruJO2Kqo6soeBvuuF1o0FkBt0Na4gl12F6QfQL8zyCd+GBOvULyJ6fDekq3y2xKKsb9WK2HFcBjG
-        sO+nAF/YGHI83h9/a97PSL2uO1010g2tfrk1vr/5ur29+3Sz+fD51u8ZJGUbvnFJfwEAAP//AwCI
-        ty4t6A8AAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:19 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.example.com/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '20'
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=aVrIFAgLDZv%2bfAt8EBiwnIZec5OdwC%2bhCGp3JCq9UQ0LKxVWlmO4Hv0ko%2fFbEGuiO63R2ugH48M4BiHRDzIW2eEOydzNGHfWk182pB5qxrzQIWMt6jJnUKYD5cIzEG6j067pjpYrLiGXlpcMQ3zzL8sw4EG%2bwYkIGvdenEeU6Fg%2f%2bOzOhLfITyLfeFgzN54s;path=/ipa;httponly;secure;
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=aVrIFAgLDZv%2bfAt8EBiwnIZec5OdwC%2bhCGp3JCq9UQ0LKxVWlmO4Hv0ko%2fFbEGuiO63R2ugH48M4BiHRDzIW2eEOydzNGHfWk182pB5qxrzQIWMt6jJnUKYD5cIzEG6j067pjpYrLiGXlpcMQ3zzL8sw4EG%2bwYkIGvdenEeU6Fg%2f%2bOzOhLfITyLfeFgzN54s
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
-        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
-        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
-        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
-        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "group_del", "params": [["dummy-group"], {"continue": false}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '73'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=aVrIFAgLDZv%2bfAt8EBiwnIZec5OdwC%2bhCGp3JCq9UQ0LKxVWlmO4Hv0ko%2fFbEGuiO63R2ugH48M4BiHRDzIW2eEOydzNGHfWk182pB5qxrzQIWMt6jJnUKYD5cIzEG6j067pjpYrLiGXlpcMQ3zzL8sw4EG%2bwYkIGvdenEeU6Fg%2f%2bOzOhLfITyLfeFgzN54s
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0xQS0sDQQz+K2EuXurSh4h4ctEeBBd7EsEWSTvpMjCPJTPTspT97062C/aW5Hvk
-        Sy6KKWab1DNcbssjGku6lD+7YQbqhDaTdEpn5/r7lkPu1K4gjmLElqKAF5X6TmjqjOyNb1UheHTj
-        6Is4muAbE+OETFIB6807TATw2e2J4YwRfEgQyacZHAMXTw2H4DpMZm+sSf2ItxkZfSLSFdQxZlfc
-        i4hPxHcRxPh0NZ7BslquHmXzIWhZu1jN54vSakw4Xn2V/U4CCXaVDIOcWrwdci/jN7KUSMP4B9je
-        fmWrlHyMmAMXqs/Wltbo/7pj4w+mQytOqEvgl/V33Ww+1tXrZyP5bgI8VE9VCfAHAAD//wMA+V8w
-        4qgBAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=aVrIFAgLDZv%2bfAt8EBiwnIZec5OdwC%2bhCGp3JCq9UQ0LKxVWlmO4Hv0ko%2fFbEGuiO63R2ugH48M4BiHRDzIW2eEOydzNGHfWk182pB5qxrzQIWMt6jJnUKYD5cIzEG6j067pjpYrLiGXlpcMQ3zzL8sw4EG%2bwYkIGvdenEeU6Fg%2f%2bOzOhLfITyLfeFgzN54s
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
-        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
-        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
-        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
-        P+UK/QMAAP//AwBCBmNsWAEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=s1lH04Kn7thRX7HztQtW%2f7rI9yR%2bw2aEsaHNkR23BVFwXFWSKPNQhTzVf%2fw1CC%2fmx%2fnuoZg0I4Fl5K68iNYuJ14304ZoutjWW8vdfVyLNgbvSD3mu1Ishffj58XKY79IdLOVS%2brqs1qlIrcP%2fi4xFmfjagt%2beuUzlirMeM5ilJtGkCagnSU5DjeLll%2fo2Qdk
-      Referer:
-      - https://ipa.example.com/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.example.com/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
-        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
-        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
-        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
-        5aPM0D8AAAD//wMA5lpmj1gBAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
-      Keep-Alive:
-      - timeout=30, max=99
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
@@ -1116,13 +590,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
+      - Thu, 04 Jun 2020 15:00:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=s3mdTYeB4smhm0wuhcdrCWG0%2bsRnVge7SlhWQrEYjeM4vWaY24PPZeKQYdgAMh085kXmNKYSCCJjVJvzziqRbxaBMJbmaAtUWoaKM4xjc0MRzyU7wdKV32jzMappjgcoBLbQXdwdGfQPDDDLfX23h25tOJxOsDzfpmH1ripi7g%2bVNK8RHMz7lrKmjv3z%2f6cz;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=jURjpZiTrld7Qxtvh2fAIBBqaNqrBuJFNlnCeoUoToEPlo3tdB8OlYZ4Bc8Q1tuxe8Fc%2fV4lCoCdIhxx7DX%2fJrlcp3KRSW3DgmFzuyuo%2fR5wWKKTnc1Do0I35WWhEjY%2bpj0%2frxRGeCS%2bDu8SWq1dNmGTYfsBXowGumRsCfsnYE5f2pX9nLUDHwI4BCo%2b9AXv;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1146,7 +620,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=s3mdTYeB4smhm0wuhcdrCWG0%2bsRnVge7SlhWQrEYjeM4vWaY24PPZeKQYdgAMh085kXmNKYSCCJjVJvzziqRbxaBMJbmaAtUWoaKM4xjc0MRzyU7wdKV32jzMappjgcoBLbQXdwdGfQPDDDLfX23h25tOJxOsDzfpmH1ripi7g%2bVNK8RHMz7lrKmjv3z%2f6cz
+      - ipa_session=MagBearerToken=jURjpZiTrld7Qxtvh2fAIBBqaNqrBuJFNlnCeoUoToEPlo3tdB8OlYZ4Bc8Q1tuxe8Fc%2fV4lCoCdIhxx7DX%2fJrlcp3KRSW3DgmFzuyuo%2fR5wWKKTnc1Do0I35WWhEjY%2bpj0%2frxRGeCS%2bDu8SWq1dNmGTYfsBXowGumRsCfsnYE5f2pX9nLUDHwI4BCo%2b9AXv
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1173,7 +647,993 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
+      - Thu, 04 Jun 2020 15:00:28 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "group_del", "params": [["test-group-1"],
+      {}]}, {"method": "group_del", "params": [["test-group-10"], {}]}, {"method":
+      "group_del", "params": [["test-group-2"], {}]}, {"method": "group_del", "params":
+      [["test-group-3"], {}]}, {"method": "group_del", "params": [["test-group-4"],
+      {}]}, {"method": "group_del", "params": [["test-group-5"], {}]}, {"method":
+      "group_del", "params": [["test-group-6"], {}]}, {"method": "group_del", "params":
+      [["test-group-7"], {}]}, {"method": "group_del", "params": [["test-group-8"],
+      {}]}, {"method": "group_del", "params": [["test-group-9"], {}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '628'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=jURjpZiTrld7Qxtvh2fAIBBqaNqrBuJFNlnCeoUoToEPlo3tdB8OlYZ4Bc8Q1tuxe8Fc%2fV4lCoCdIhxx7DX%2fJrlcp3KRSW3DgmFzuyuo%2fR5wWKKTnc1Do0I35WWhEjY%2bpj0%2frxRGeCS%2bDu8SWq1dNmGTYfsBXowGumRsCfsnYE5f2pX9nLUDHwI4BCo%2b9AXv
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6yUy2oDIRSGX0XcdJMMc8ll0lVDm0WhoVmVQhOKGU8GwdFBnYQQ8u49TgaaQjeC
+        O4//5VMXXqgB20lHH8mFVrpTfpWlIzLsWxy/LvemAxMSuN/eXdF2ZLIDP1EH1o1ro7t2nNEdSrZr
+        GmbOKNIXkOCAk14m2z/eLaVoBmO0QavqpMTecGQawkzjQPMAZh4HWQQgizjISQByEgc5DUBO4yBn
+        AchZHOQ8ADmPgywDkGUc5CIAufgH6dMNWMtqGH4jd249hZ6YUULVPqFY0299gLFCq7WwdlCGqBeX
+        m1cyGLC62YMhJ2aJ0o5YUG5EDtpgJyeVblrmxF5I4c69XnfMMOUAeEKWFi+D7RgyRzAPlvji4614
+        RPIkL2aeXGnusVmRphmOnDnWP9ot9j0E/MFukeu1f8T7y+Mo+O+6NUJVomXShxjHQzytPpfrzdsq
+        eX5fe+Zd6SQpEyz9AQAA//8DACadVFfiBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:28 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=jURjpZiTrld7Qxtvh2fAIBBqaNqrBuJFNlnCeoUoToEPlo3tdB8OlYZ4Bc8Q1tuxe8Fc%2fV4lCoCdIhxx7DX%2fJrlcp3KRSW3DgmFzuyuo%2fR5wWKKTnc1Do0I35WWhEjY%2bpj0%2frxRGeCS%2bDu8SWq1dNmGTYfsBXowGumRsCfsnYE5f2pX9nLUDHwI4BCo%2b9AXv
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:28 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Lrnkwtzg8zkqkMYB%2bkQ3hYDDEZZ3AWzJJdvINjbuMqcZ00RMJ9wKc7IpF3bhLUN1nibZ64iUK8SHlOA3tyxP4elMSB7jlgRsqmovDnXEYYgFudOjsp9ZxdwFchKPVCK379SV5iiepw073DaPCjnz9xJYcKE4etNLQ%2fBJjrabR4tT%2fzGx09cNN27BogPsJdDN;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Lrnkwtzg8zkqkMYB%2bkQ3hYDDEZZ3AWzJJdvINjbuMqcZ00RMJ9wKc7IpF3bhLUN1nibZ64iUK8SHlOA3tyxP4elMSB7jlgRsqmovDnXEYYgFudOjsp9ZxdwFchKPVCK379SV5iiepw073DaPCjnz9xJYcKE4etNLQ%2fBJjrabR4tT%2fzGx09cNN27BogPsJdDN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "group_add", "params": [["dummy-group-01"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-02"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-03"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-04"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-05"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-06"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-07"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-08"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-09"],
+      {"fasgroup": true}]}, {"method": "group_add", "params": [["dummy-group-10"],
+      {"fasgroup": true}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '807'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Lrnkwtzg8zkqkMYB%2bkQ3hYDDEZZ3AWzJJdvINjbuMqcZ00RMJ9wKc7IpF3bhLUN1nibZ64iUK8SHlOA3tyxP4elMSB7jlgRsqmovDnXEYYgFudOjsp9ZxdwFchKPVCK379SV5iiepw073DaPCjnz9xJYcKE4etNLQ%2fBJjrabR4tT%2fzGx09cNN27BogPsJdDN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9TXQWvbMBQA4L8ifNklCZIs23KhsDJ6GKyspzFYy5AlOXg4sifZbUPJf5+khNYt
+        M8iZD/NN0tN7z9aXIPwcaWn6uosuwHPEm165EYIrcFo3dvrjebipKX5J3vGaGR+LuqaN7Patbvq2
+        KRXbSePmSppOCr/qplXLeiP1cH4s5CZtY6qnl1DJzHF878pWQvW7QmrfC5EkTiEkWeqDrqiqfvey
+        Ej6MES5YLuCapRlZIyTZmlIerxOcEAhzSLGMfSJXfr/od7v92jdbQ+QjL80vQKd7aVeE22szLt/u
+        XtkVPzZuxLg/O7MS/FI+sV1bSzfkzS462BoPrO6lK/Ouow0Zu8L03gWvhJAC+CC4e7f1LnKbpdaN
+        OwnV17Wt+/+5ZGMuJSwIHbjkkqVhLniSC57BBYe74IW40BGXGHNRvvm/oDgJc4knucQzuMThLvFC
+        XPIxlxTlSTp0yWAR5kImuZAZXEi4C1mGC4VjLgwVmJ51vySTXJIZXJJwl2QhLmjEhUAUcza8X/Ki
+        DHNJJ7mkM7ik4S7pQlzwmEsik5Kfdb9kk1yyGVyycJdsIS7xmEtOM3Te/UInudAZXGi4C12ICxlz
+        EYik/Kz7JZ/kks/gkoe75AtxSUZcEihwPvy/5LRgQS4ITnGxX97/7GI7hrog+BcX97j2sA3bytPX
+        f7dvfZdHplWltp7Berilb1KbqlE3lTGnyCnVN779DE4bwPG0wSMzQDUdMFJ1K1A22tYUwL5Py7qq
+        qOqq2/v4tmeaqU5KsQFXxr6MrW6T9IPUHwxwhR+OhVcAb3Dsr1TeCNcWxdB+ntszYR3zv6xj2s9T
+        gnuwY8rhcH949/IOX7yOW10pbn8NtUtiwj7Ex+vvVze3X643n77euJ6DomRDN7boHwAAAP//AwDT
+        RW7nUhEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Lrnkwtzg8zkqkMYB%2bkQ3hYDDEZZ3AWzJJdvINjbuMqcZ00RMJ9wKc7IpF3bhLUN1nibZ64iUK8SHlOA3tyxP4elMSB7jlgRsqmovDnXEYYgFudOjsp9ZxdwFchKPVCK379SV5iiepw073DaPCjnz9xJYcKE4etNLQ%2fBJjrabR4tT%2fzGx09cNN27BogPsJdDN
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE+Q4muOL8fPqm7ejuXre51m3oku95TzHwAAAP//AwBI2e3iggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU224TMRD9FWtfeEnS3c2lF6kSFVQIQdVKqAgVITRrTzamXnvxpUmo+u94vE7T
+        QgVPmZ0zc8ZzfJz7wqILyhcn7H4ffr0vuKbf4m3oui27dmiLbyNWCOl6BVsNHb4ESy29BOUG7Drl
+        WuTGvVS8BMctgpdGe5n56rIuy0U5q+ZlWS9uUp1pfiD3XIEbaLzpi5ju0TqjKTK2BS1/JSZQ+7zU
+        6CP2PBFoPLUbJzfAuQna0/etbXorNZc9KAibnPKS36LvjZJ8m7OxYDhR/nButeOMG+3CCHxyq3fW
+        hP5yeRWaD7h1lO+wv7Sylfpce7sdROshaPkzoBRZg+qohgbHsDicjasKYdyIJY7n9XxWlsflUY3T
+        1EhHjuPXxgrc9NImAfYyHpd1kvHwZlcdJfT9WvAV6PYFvXNhB1IlUNB9vcYNdL3CCTfdjoeDNlpy
+        UI8+GErPv5xdXH08n7y5vEilysRF3QrVwHfQSH3QgFslMEihQ9dEuQirZvPpoixnh/MErkyHQtqo
+        sokqpWZKHaQ5u/b95MFo8g71c2fm/D8GPb32/2zjBm0f/atdto8y/DZCy2h8JGfFZ4T2DsWTXId0
+        ALP83pIjEg9de6xzw7sibtrpNM0ecX2aQAryFDcS/DRfBoV0Hw/UO1j4hFUx9jZoDv6P2c5Bi254
+        137b05LFGqyWuiVP5r2Lz3FgdNCFdC4juZXAs6v3LBewQU62Bse08cyh9iO2NDZyChbP1UcnNlJJ
+        v014G8CC9ohiws6cC11kZ0ki+8oxIr4biEesntTTRZGWEjS2mpYl7SXAQ/qLGtq+5wY62NDykKSI
+        3B0kwxQVIwFZB56vohwPEUVrDZlAB6Xo3Yl9/OgBav37+mPFk4mzydEkTvwNAAD//wMA96+jjTsF
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_find", "params": [[], {"all": true, "sizelimit": 0, "pkey_only":
+      true, "fasgroup": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6SUXUvDMBSG/0rIjTdd6cc+hYFDdiE43JUIIpIlWQ00acnH5hj77560hSloEHLV
+        0/Pmfc7JCckZa25cbfEtOl/D1zOmyn8xc1KeRpVuXDvKcvyWIMy8Avryp5ZApouNjwiljVPWJIwu
+        +SeRbc19SBuJLwn6HV8E8EU8vgzgy3j8OIAfx+MnAfwkHj8N4Kfx+FkAP4vHzwP4eTx+EcAvovF5
+        9jc+z/6P95BOBQ74ELbaKUosZ5DYk9pwyEluDKm46S+5PbXcVz0SrYSqMCxQRHapZ66NaNRGGDMo
+        g9WLq+0DGhYg5eSOa3QkBqnGIsOVTdC+0cBkCBpriRU7UQt76vTKEU2U5ZylaGWMk0AHkz5wfWOQ
+        Bx96cIKKtCinuNsV82XzMoNnBiZFLOneq972Phh8Y73l0s0C2JLok0/nGepniCSx9AMmAoeBudaN
+        Blm5uoZfwa5xq4WioiW1d3cHcrd+WW22j+v0/mnje/pWdJzOUyj6BQAA//8DABJcs9JLBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "group_show", "params": [[],
+      {"cn": "dummy-group-04", "all": true}]}, {"method": "group_show", "params":
+      [[], {"cn": "dummy-group-05", "all": true}]}, {"method": "group_show", "params":
+      [[], {"cn": "dummy-group-06", "all": true}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '280'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8yUTWvcMBCG/4rwpZf1In+uHQh0KTkUujSnUiihyPKsUbElVx+bLMv+945ks3ED
+        IQT2kNvM+2rekR8bnyINxvU2uiGniCsnfZWtyCwb7H6dlmfEyJwUfx2I1ntRmmRlUhdlzMpNHicJ
+        sLja0CYu0iKntKZVCln0gIGq+QPc8p6ZEBpZNUYod1q5Ue0lG8D4XoKx0AbVt36dAb3spyDfjMqI
+        p4u1Z2aq/bZOtNINDeiwK8mLrKQ039TB5DKorRuGYxxmYpoH55JxQ6x2gErrz+LE7f+nV6iE2viK
+        8YDOrFp+C09sGHvwJVdDdMaMA+sd+JgXG9EyqDB9RFO6vkcBtFZ6bnH2LfYsadJqyb7i2cdkX9FX
+        2RfvYl9cgX1xBfY5TTLOFuzrutl/UPbJq+zLd7Evr8C+fJu9vxJyMayD+Q9kj2NIemRaCtkFYojO
+        Sz9AG6HkThgzO/OoN7f3X8l8gExgyCMzRCpLDEi7InulMbMleOeRWdGIXthj8DvHNJMWoF2TrcEL
+        YzoO6QPoT4b44MMUvCLpOs3CY3HV+rVJRmniITLLwtczjf2eB/zFppHz+eH84uH9y26f61ELyfHt
+        9xeOn+9+bnf33+7WX77v/M5FaL6u1hj6DwAA//8DAJdQysDVBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=e3zDR%2b%2fux%2bHu5tvibieNJyk0IG7z4DrY22qyg0lfVPiU8hfWOlLl4rTGotet82zjWUDVlt%2fOKIPcnYgVDNSKlF1t2mYOF5wXCXG%2b5ror4xbOZ1a6DaMmiqWYyMqgHgwf9p363qHmMI3zyHjeTQ7dByl0bQ4tT7UkzwY%2fBiu%2f7yPKIA%2f4NfNP%2b3b5nnR2CbfE;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=e3zDR%2b%2fux%2bHu5tvibieNJyk0IG7z4DrY22qyg0lfVPiU8hfWOlLl4rTGotet82zjWUDVlt%2fOKIPcnYgVDNSKlF1t2mYOF5wXCXG%2b5ror4xbOZ1a6DaMmiqWYyMqgHgwf9p363qHmMI3zyHjeTQ7dByl0bQ4tT7UkzwY%2fBiu%2f7yPKIA%2f4NfNP%2b3b5nnR2CbfE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "batch", "params": [[{"method": "group_del", "params": [["dummy-group-01"],
+      {}]}, {"method": "group_del", "params": [["dummy-group-02"], {}]}, {"method":
+      "group_del", "params": [["dummy-group-03"], {}]}, {"method": "group_del", "params":
+      [["dummy-group-04"], {}]}, {"method": "group_del", "params": [["dummy-group-05"],
+      {}]}, {"method": "group_del", "params": [["dummy-group-06"], {}]}, {"method":
+      "group_del", "params": [["dummy-group-07"], {}]}, {"method": "group_del", "params":
+      [["dummy-group-08"], {}]}, {"method": "group_del", "params": [["dummy-group-09"],
+      {}]}, {"method": "group_del", "params": [["dummy-group-10"], {}]}], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '647'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=e3zDR%2b%2fux%2bHu5tvibieNJyk0IG7z4DrY22qyg0lfVPiU8hfWOlLl4rTGotet82zjWUDVlt%2fOKIPcnYgVDNSKlF1t2mYOF5wXCXG%2b5ror4xbOZ1a6DaMmiqWYyMqgHgwf9p363qHmMI3zyHjeTQ7dByl0bQ4tT7UkzwY%2fBiu%2f7yPKIA%2f4NfNP%2b3b5nnR2CbfE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6yUu2rDMBSGX0Vo6ZIYX3Lt1NBmKDQ0Uyk0pSjWiRHIkpHkBBPy7j1yDA2li4o2
+        n/NfPkmDz9SAbaWj9+RMS90q/5WlIzLsLY4f51vTgQkJ3K8/L2g7MtmCnyhv67obV0a3zTjN6CeK
+        FlfMdCjTJ5DggJNeJ7tf7h2laAdjtEGzaqXE7n9g8yBsHgtbBGGLWNhJEHYSCzsNwk5jYWdB2Fks
+        7DwIO4+FXQRhF7GwyyDsMhI2S0OwWfoH1udrsJZVMPyzXNd4Ej0xo4SqfEKxul+9gbFCq42wdlCG
+        qBdX22cyGLC63oMhJ2aJ0o5YUG5EDtpgJyelrhvmxF5I4bper1pmmHIAPCEri9fBdgyZI5g7S3zx
+        8Vo8InmSFzNPLjX32KxI0wxHzhzrH+4a+xoC/mDXyOXSP+Tt5XEU/Oe7MUKVomHShxjHQzys31eb
+        7cs6eXzdeOZN6SRZJFj6DQAA//8DABRvO68IBgAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:29 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=e3zDR%2b%2fux%2bHu5tvibieNJyk0IG7z4DrY22qyg0lfVPiU8hfWOlLl4rTGotet82zjWUDVlt%2fOKIPcnYgVDNSKlF1t2mYOF5wXCXG%2b5ror4xbOZ1a6DaMmiqWYyMqgHgwf9p363qHmMI3zyHjeTQ7dByl0bQ4tT7UkzwY%2fBiu%2f7yPKIA%2f4NfNP%2b3b5nnR2CbfE
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Hco29c6JOLyz6HxmEaqV9tMnB3%2fXumZyiH9NvTb%2fR7rHi5VXVYzm7xpEf9hFcn%2bO%2bMcTMqvWaqS9W95QgPErKWv%2fwmTgjek3Yo%2bPC4Rw%2bRbwi0Ehe1f4Sz%2fc%2bWEvKwxXlxMjwTa73bN6rgd8xxbLPibxdePx%2bs6nN57n2lkQdT1j09PB9i9UjPE7HAVbQdrU
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
+        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
+        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
+        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
+        5aPM0D8AAAD//wMA5lpmj1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Uq0Q8tgOieB00g1ypGUS%2bVUKMIG0FTSYmbokDXE39z6Cg3QHT4YE2O1pdeE1aaNhkg%2bTQkVS9R6il1k1o1EIzPo4DCx7%2bH3O1VlFdQV5jiRsTEXjE1bBDyXlBzlmR6uJNzqtOwao8LePG4V0HFlnwrQhFqM7Sf2%2fx%2fobv1PgXQW7jHg%2bRlO%2bwLQnLgMB4DUC;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Uq0Q8tgOieB00g1ypGUS%2bVUKMIG0FTSYmbokDXE39z6Cg3QHT4YE2O1pdeE1aaNhkg%2bTQkVS9R6il1k1o1EIzPo4DCx7%2bH3O1VlFdQV5jiRsTEXjE1bBDyXlBzlmR6uJNzqtOwao8LePG4V0HFlnwrQhFqM7Sf2%2fx%2fobv1PgXQW7jHg%2bRlO%2bwLQnLgMB4DUC
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1202,7 +1662,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=s3mdTYeB4smhm0wuhcdrCWG0%2bsRnVge7SlhWQrEYjeM4vWaY24PPZeKQYdgAMh085kXmNKYSCCJjVJvzziqRbxaBMJbmaAtUWoaKM4xjc0MRzyU7wdKV32jzMappjgcoBLbQXdwdGfQPDDDLfX23h25tOJxOsDzfpmH1ripi7g%2bVNK8RHMz7lrKmjv3z%2f6cz
+      - ipa_session=MagBearerToken=Uq0Q8tgOieB00g1ypGUS%2bVUKMIG0FTSYmbokDXE39z6Cg3QHT4YE2O1pdeE1aaNhkg%2bTQkVS9R6il1k1o1EIzPo4DCx7%2bH3O1VlFdQV5jiRsTEXjE1bBDyXlBzlmR6uJNzqtOwao8LePG4V0HFlnwrQhFqM7Sf2%2fx%2fobv1PgXQW7jHg%2bRlO%2bwLQnLgMB4DUC
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1230,7 +1690,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:20 GMT
+      - Thu, 04 Jun 2020 15:00:30 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1258,7 +1718,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=s3mdTYeB4smhm0wuhcdrCWG0%2bsRnVge7SlhWQrEYjeM4vWaY24PPZeKQYdgAMh085kXmNKYSCCJjVJvzziqRbxaBMJbmaAtUWoaKM4xjc0MRzyU7wdKV32jzMappjgcoBLbQXdwdGfQPDDDLfX23h25tOJxOsDzfpmH1ripi7g%2bVNK8RHMz7lrKmjv3z%2f6cz
+      - ipa_session=MagBearerToken=Uq0Q8tgOieB00g1ypGUS%2bVUKMIG0FTSYmbokDXE39z6Cg3QHT4YE2O1pdeE1aaNhkg%2bTQkVS9R6il1k1o1EIzPo4DCx7%2bH3O1VlFdQV5jiRsTEXjE1bBDyXlBzlmR6uJNzqtOwao8LePG4V0HFlnwrQhFqM7Sf2%2fx%2fobv1PgXQW7jHg%2bRlO%2bwLQnLgMB4DUC
       Referer:
       - https://ipa.example.com/ipa
       User-Agent:
@@ -1285,7 +1745,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 04 Jun 2020 15:00:21 GMT
+      - Thu, 04 Jun 2020 15:00:30 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/utility/cassettes/test_pagination/test_groups_page_nopaging.yaml
+++ b/noggin/tests/unit/utility/cassettes/test_pagination/test_groups_page_nopaging.yaml
@@ -1,0 +1,610 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=iY5QiVqcoMklbNVCMZ32FJw5WcPQ15CZaldg7MtWn%2fSMmyzfwidFmbSMSSfrxNp41Z91Rik5v3LHOjSSbEs4JgGhjNGoj0j9si3ccEesPrE3zt%2faA4PhvFeqcqCeJGrgl1Vt7Hi6qbl1CNfPxDtY1LO8evG3vxIq%2brTL%2fcjvM2niXo%2focwCQzQAA267izNXi;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=iY5QiVqcoMklbNVCMZ32FJw5WcPQ15CZaldg7MtWn%2fSMmyzfwidFmbSMSSfrxNp41Z91Rik5v3LHOjSSbEs4JgGhjNGoj0j9si3ccEesPrE3zt%2faA4PhvFeqcqCeJGrgl1Vt7Hi6qbl1CNfPxDtY1LO8evG3vxIq%2brTL%2fcjvM2niXo%2focwCQzQAA267izNXi
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:30 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-06-04T15:00:30Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=iY5QiVqcoMklbNVCMZ32FJw5WcPQ15CZaldg7MtWn%2fSMmyzfwidFmbSMSSfrxNp41Z91Rik5v3LHOjSSbEs4JgGhjNGoj0j9si3ccEesPrE3zt%2faA4PhvFeqcqCeJGrgl1Vt7Hi6qbl1CNfPxDtY1LO8evG3vxIq%2brTL%2fcjvM2niXo%2focwCQzQAA267izNXi
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUa2/aMBT9K1G+7AvQhNdgUqWxllZTHzBt3aauFbqxL+Dh2JntABnqf58fAVap
+        Wz9xc+7LPueYXaxQl9zE76Ld3yER9udHfF7meRXdaVTxYyOKKdMFh0pAji+lmWCGAdchd+exBRKp
+        XyqW2U8khnDQIW1kEVu4QKWlcJFUCxDsNxgmBfAjzgQam3sOlG6sa5eabYEQWQrjvlcqKxQThBXA
+        odzWkGFkhaaQnJGqRm1BOFH9ofVyP3MOeh/axGe9vFSyLCbzaZldYaUdnmMxUWzBxFgYVQUyCigF
+        +1Uio/5+7Xavn6ZD0oT+224zTRGag6zfafbavW6SDJNBGzu+0R3Zrt9IRXFbMOUJCCOSdpL0k27a
+        S5JOcr+vthSaYkPJEsQC/1eIW6OAggFXtItnsww09ruzmf2OR6OryfktR5IP1/RsuLy/TIts9eHi
+        2/ji9m68vbhe3U6/fBqdxk+P4cI5CFggRX9jt5WIU+o0bthg4SjSLqrF0A1KTnELecHRhUTm/lg5
+        MO67fev7uqK1T5c1ez67R0SZZ1YPh6fdXqefJN1BP7iNrVE8t2eN/6fJ6ksUepoNy//NoA4qHBxs
+        GSUgpGAE+GFnuMb4++hmej1unU1uDprubfhKKZfWRnqJPNBykjFxYnVa+uRS5kiZsjaVNeknDjo5
+        0lPYR4xqjY62uX2L6LpAz/aWsrBR5R5dYWUgO2I5OpLkfOb18wucj+1EHf4AHAVOgqPSPvmK0E+2
+        dQ28dPeupfTLtLYO0sGNpip8egNKMLFwBTVT8Ve7wYpzw7SuM3Wr9+30Y1QXREHjaAM6EtJE2nqz
+        Ec2lsjNpZA9SWJEzxpmpfH5RggJhEGkrGmld5nZ65NlTb3TkBq/D4EbUbrU7fbeZSOrWpp0kSR0h
+        4TXt4tA2qxvcwULLk38udnYOXrF4RCnSyLEWPQQuHmJPEColnT9Fybn7/6DH+OAdNwCoPecz2zh2
+        j3u7rUHL7v0DAAD//wMA7+Erx9oFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=iY5QiVqcoMklbNVCMZ32FJw5WcPQ15CZaldg7MtWn%2fSMmyzfwidFmbSMSSfrxNp41Z91Rik5v3LHOjSSbEs4JgGhjNGoj0j9si3ccEesPrE3zt%2faA4PhvFeqcqCeJGrgl1Vt7Hi6qbl1CNfPxDtY1LO8evG3vxIq%2brTL%2fcjvM2niXo%2focwCQzQAA267izNXi
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=zgTNUMiMEM6LQuAluSI2Ew02yV%2bf0Y7xwJbSlUJVre%2f%2buSskkEiAFUn%2flvTYkwGiULONNMpuxnb4YGHUAFdWsnktm2JYTi8UPeEhfA0ZCS3LIim5Xd3%2fev%2f5D9fcrELx9lmWB8SFkTLieoWWBgQlZhNmsSeiYzOOnzqnWpasYwx3wvTeFn0clGGRbGuUHkyu;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=zgTNUMiMEM6LQuAluSI2Ew02yV%2bf0Y7xwJbSlUJVre%2f%2buSskkEiAFUn%2flvTYkwGiULONNMpuxnb4YGHUAFdWsnktm2JYTi8UPeEhfA0ZCS3LIim5Xd3%2fev%2f5D9fcrELx9lmWB8SFkTLieoWWBgQlZhNmsSeiYzOOnzqnWpasYwx3wvTeFn0clGGRbGuUHkyu
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPzUvEMBDF/5UhFy8l7IeIeLLIHgSLexJBRLLNWAL5KDPJLqX0fzdpC/X2Mu+9
+        32RGQcjJRvEE4yZ9srYC4ZBZdch58jWKOPSYlbgp8sZ3Ige8cvPoA4lN8I1hXp21Wsz6/AprIIPd
+        BQluisGHCIw+VvAbKDM1tMH1KpqLsSYOs98lRcpHRC2hZk4u03OJrkh3DAV8XcAVHOTh+FA2t0GX
+        tfvjbrfPT62imo9baj9roXxsqUzT95RzSBRoO93oTfdkfGt6ZUtJJ+eG59Nn3ZzfTvLlvSk7/0Hv
+        5aPM0D8AAAD//wMA5lpmj1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.example.com/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Udt8vJhUnEGawivpXqPGyooLATW0Lbzz1bag3NF%2fpCV86f%2bIUnloBLwRBMCg4QUbi2Jf0%2bKwZOgggcb%2bpndfGLa45R%2fS4UkKFHLFGh6KacskOect40gJdZgTwM3Je31bpAcS%2bq45Jm%2f2JkhkrIbrmGn8GysAZ9F%2fq4boEZXA7m5x7PniqW5V8%2bIV4tIgYPBl;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Udt8vJhUnEGawivpXqPGyooLATW0Lbzz1bag3NF%2fpCV86f%2bIUnloBLwRBMCg4QUbi2Jf0%2bKwZOgggcb%2bpndfGLa45R%2fS4UkKFHLFGh6KacskOect40gJdZgTwM3Je31bpAcS%2bq45Jm%2f2JkhkrIbrmGn8GysAZ9F%2fq4boEZXA7m5x7PniqW5V8%2bIV4tIgYPBl
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZcQ+jHK2Glh9FBYWE5jMMZQYzcYYjtI9koI+e+TE7P2YJAl
+        Pa9eaZKoKfZBPotJUrQWcORYnppKkMZfjYIfGe/EY/lUHkpRNaf/1K7c7Q+yENJqIug0Mfo1yTAO
+        OolcAZ1xXWpwYJfUx0rWhihXMpqKSTo3CBftmYdfgYTzgb24UIiLR9ZUovV2gGDOpjdhXOpdBAQX
+        tFbskHgRVs8LPNC95+JmuvUqjd3uN5stfxUEWM+wYD8ZSMZWZJ6/Z+7TiB4562Lf89eoWzygca0Z
+        oE8QKDbxcvys6ubtWL6+12nmnehyTzn/AQAA//8DAOyF6AGCAQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Udt8vJhUnEGawivpXqPGyooLATW0Lbzz1bag3NF%2fpCV86f%2bIUnloBLwRBMCg4QUbi2Jf0%2bKwZOgggcb%2bpndfGLa45R%2fS4UkKFHLFGh6KacskOect40gJdZgTwM3Je31bpAcS%2bq45Jm%2f2JkhkrIbrmGn8GysAZ9F%2fq4boEZXA7m5x7PniqW5V8%2bIV4tIgYPBl
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2vDMAz+K8KXXUroY4yx00rXw2BlPY3BWoZaq8VgO0G2U0LJf5/UBNab9Ol7
+        SLoaplR8Ni9wvS9P6DxZKX/2/QRMi76QdsaWEDqzFyxQSnimpPDV5K5RgrkgRxfPRggRww36Ik6u
+        jhuX0jgZpTpcbt9hJEAs4UAMF0wQ6wyJYp7AqWbxtHCsQ4PZHZx3ubvNzwUZYyayFSxTKkHcRcQt
+        8UMCNW4H4wnMq/niSZOPtdXY2WI6nUlrMePt3kH2Owp0sUHS93qqeAfkTuE38pTJQhEF7IZ37IzR
+        JxFzzcKJxXtpnf2vG3bx6Br0aoFWNn1dfy832491tfrc6GJ3yY/VcyXJfwAAAP//AwC881l1mwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Udt8vJhUnEGawivpXqPGyooLATW0Lbzz1bag3NF%2fpCV86f%2bIUnloBLwRBMCg4QUbi2Jf0%2bKwZOgggcb%2bpndfGLa45R%2fS4UkKFHLFGh6KacskOect40gJdZgTwM3Je31bpAcS%2bq45Jm%2f2JkhkrIbrmGn8GysAZ9F%2fq4boEZXA7m5x7PniqW5V8%2bIV4tIgYPBl
+      Referer:
+      - https://ipa.example.com/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.example.com/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPy2rDQAxFf0XMphtj8qKUrmpKFoWaZFUKpRTFo5oBe8ZI44Rg/O/V2AZ3p8e9
+        50qDYZK+ieYZhrX0fdNkYFoSwZpEJ1+DifeOtDI3ZO98bVTgsZ1GH8Tigi+dyLJZrGlZnN9gESi4
+        vRDDDQV8iCDkYwa/gZVpoQpth9FdXOPifdrXPTL6SGRzKET6Vulq4ivxg0ACX2dwBrt8t39MyVWw
+        KXa732y22lqMOD03234WQzpstozj96g6Yg68vu7sWnfsfOU6bJIJrR7xcvwsyvP7MX89lSnzH/SQ
+        P+UK/QMAAP//AwBCBmNsWAEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 04 Jun 2020 15:00:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/utility/test_pagination.py
+++ b/noggin/tests/unit/utility/test_pagination.py
@@ -1,0 +1,85 @@
+import pytest
+from bs4 import BeautifulSoup
+
+from noggin import ipa_admin
+from noggin.utility.pagination import PagedResult
+
+
+@pytest.fixture
+def many_dummy_groups(ipa_testing_config):
+    all_fas_groups = ipa_admin.group_find(fasgroup=True)["result"]
+    ipa_admin.batch(
+        methods=[
+            {"method": "group_del", "params": [[entry["cn"][0]], {}]}
+            for entry in all_fas_groups
+        ]
+    )
+    group_list = [f"dummy-group-{i:02d}" for i in range(1, 11)]
+    ipa_admin.batch(
+        methods=[
+            {"method": "group_add", "params": [[name], {"fasgroup": True}]}
+            for name in group_list
+        ]
+    )
+    yield
+    ipa_admin.batch(
+        methods=[{"method": "group_del", "params": [[name], {}]} for name in group_list]
+    )
+
+
+@pytest.mark.vcr()
+def test_groups_page(client, logged_in_dummy_user, many_dummy_groups):
+    """Test the paginated groups list"""
+    result = client.get("/groups/?page_number=2&page_size=3")
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, 'html.parser')
+    groups = page.select("ul.list-group li")
+    group_names = [g.find("span", class_="title").get_text(strip=True) for g in groups]
+    assert group_names == [
+        "dummy-group-04",
+        "dummy-group-05",
+        "dummy-group-06",
+    ]
+
+    pagination_bar = page.select_one("ul.pagination")
+    assert pagination_bar is not None
+    # Prev
+    prev_link = pagination_bar.select_one("li:first-child a.page-link")
+    assert prev_link is not None
+    assert prev_link["href"] == "/groups/?page_number=1&page_size=3"
+    # Next
+    next_link = pagination_bar.select_one("li:last-child a.page-link")
+    assert next_link is not None
+    assert next_link["href"] == "/groups/?page_number=3&page_size=3"
+    # Other links
+    assert len(pagination_bar.select("li.page-item")) == 6
+
+
+@pytest.mark.vcr()
+def test_groups_page_nopaging(client, logged_in_dummy_user, mocker):
+    ipa = mocker.Mock(name="ipa")
+    mocker.patch("noggin.utility.maybe_ipa_session", return_value=ipa)
+    ipa.user_find.return_value = {"result": [{"uid": "dummy"}]}
+    ipa.group_find.return_value = {"result": [{"cn": "dummy-1"}, {"cn": "dummy-2"}]}
+    result = client.get("/groups/?page_size=0")
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, 'html.parser')
+    groups = page.select("ul.list-group li")
+    assert len(groups) == 2
+    ipa.group_find.assert_called_with(fasgroup=True, all=True)
+    ipa.batch.assert_not_called()
+
+
+def test_pagination_result_no_paging():
+    result = PagedResult(items=["dummy"], page_size=0, page_number=1)
+    assert result.total_pages == 1
+
+
+def test_pagination_result():
+    result = PagedResult(items=["dummy"], page_size=2, page_number=1)
+    assert result.page_url(0) is None
+    assert result.page_url(2) is None
+    assert repr(result) == "<PagedResult items=[1 items] page=1>"
+    assert result == PagedResult(items=["dummy"], page_size=2, page_number=1)
+    with pytest.raises(ValueError):
+        result == object()

--- a/noggin/utility/pagination.py
+++ b/noggin/utility/pagination.py
@@ -1,0 +1,92 @@
+import math
+
+from flask import current_app, request
+
+
+class PagedResult:
+    def __init__(self, items=None, total=None, page_size=None, page_number=None):
+        self.items = items or []
+        self.total = total or len(self.items)
+        self.page_size = page_size
+        self.page_number = page_number
+
+    @property
+    def total_pages(self):
+        if self.page_size == 0:
+            return 1
+        return math.ceil(self.total / self.page_size)
+
+    @property
+    def has_previous_page(self):
+        return self.page_number > 1
+
+    @property
+    def has_next_page(self):
+        return self.page_number < self.total_pages
+
+    def page_url(self, page_number):
+        if page_number < 1 or page_number > self.total_pages:
+            return None
+        qs = dict(request.args)
+        qs.update({"page_size": self.page_size, "page_number": page_number})
+        qs = "&".join(f"{k}={v}" for k, v in qs.items())
+        return f"{request.path}?{qs}"
+
+    def __repr__(self):
+        return f"<PagedResult items=[{len(self.items)} items] page={self.page_number}>"
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            raise ValueError("Unsupported operation")
+        return all(
+            [
+                getattr(self, attr) == getattr(other, attr)
+                for attr in ["items", "total", "page_size", "page_number"]
+            ]
+        )
+
+
+def paginated_find(ipa, representation, *args, **kwargs):
+    pkey_name = representation.get_ipa_pkey()
+    object_name = representation.ipa_object
+    find_method = getattr(ipa, f"{object_name}_find")
+    # Get parameters from the query string
+    try:
+        page_number = int(request.args.get('page_number'))
+    except (TypeError, ValueError):
+        page_number = 1
+    try:
+        page_size = int(request.args.get('page_size'))
+    except (TypeError, ValueError):
+        page_size = current_app.config["PAGE_SIZE"]
+    # If we don't want pagination, take a shortcut
+    if page_size == 0:
+        results = find_method(*args, **kwargs, all=True)["result"]
+        return PagedResult(
+            items=[representation(result) for result in results],
+            page_size=page_size,
+            page_number=page_number,
+        )
+    # Get all primary keys regardless of paging
+    pkeys = find_method(pkey_only=True, *args, **kwargs)["result"]
+    total = len(pkeys)
+    # Find out which items we need for this page
+    first = (page_number - 1) * page_size
+    last = first + page_size
+    pkeys_page = [item[pkey_name][0] for item in pkeys[first:last]]
+    # Batch-request the itemps in the page
+    batch_methods = [
+        {
+            "method": f"{object_name}_show",
+            "params": [args, {pkey_name: pkey, 'all': True}],
+        }
+        for pkey in pkeys_page
+    ]
+    items = [
+        representation(result['result'])
+        for result in ipa.batch(methods=batch_methods)['results']
+    ]
+
+    return PagedResult(
+        items=items, page_size=page_size, page_number=page_number, total=total,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
     NOGGIN_CONFIG_PATH={toxinidir}/noggin/tests/unit/noggin.cfg
 sitepackages = False
 commands =
-    poetry install -q
+    poetry install
     unittest: poetry run pytest -vv --cov --cov-append --cov-report= noggin/tests/unit {posargs}
     integration: poetry run pytest -vv --no-cov noggin/tests/integration {posargs}
 depends =
@@ -42,17 +42,17 @@ commands=
 
 [testenv:lint]
 commands =
-    poetry install -q
+    poetry install
     poetry run flake8 {posargs}
 
 [testenv:format]
 commands =
-    poetry install -q
+    poetry install
     poetry run black --check {posargs:.}
 
 [testenv:licenses]
 commands =
-    poetry install -q
+    poetry install
     poetry export -f requirements.txt -o /tmp/noggin-requirements.txt
     poetry run liccheck -s .license_strategy.ini -r /tmp/noggin-requirements.txt
     rm -f /tmp/noggin-requirements.txt
@@ -62,7 +62,7 @@ whitelist_externals =
 
 [testenv:bandit]
 commands =
-    poetry install -q
+    poetry install
     poetry run bandit -r noggin/ -x noggin/tests/ -ll
 
 


### PR DESCRIPTION
This PR adds a pagination system and makes the groups page paginated.

Since we can't set limits and offsets in the IPA queries, this uses the same system that we use with LDAP in FASJSON: 

1. request the entire list of primary keys (in the case of groups, their names),
2. build the list of groups for the current page
3. query details for those groups in batch (one API call)

This PR also contains a couple or minor fixes in separate commits.