### PR TITLE
Catch unhandled IPA errors and display a nice message

### DIFF
--- a/noggin/__init__.py
+++ b/noggin/__init__.py
@@ -6,6 +6,7 @@ from flask_wtf.csrf import CSRFProtect
 from whitenoise import WhiteNoise
 
 from noggin.security.ipa_admin import IPAAdmin
+from noggin.middleware import IPAErrorHandler
 
 app = Flask(__name__)
 app.jinja_env.add_extension('jinja2.ext.i18n')
@@ -38,13 +39,17 @@ app.register_blueprint(healthz, url_prefix="/healthz")
 # Flask-Mail
 mailer = Mail(app)
 
-
+# i18n
 babel = Babel(app)
 
 
 @babel.localeselector
 def get_locale():
     return request.accept_languages.best_match(LANGUAGES)
+
+
+# Catch IPA errors
+IPAErrorHandler(app, "ipa_error.html")
 
 
 # Whitenoise for static files

--- a/noggin/controller/root.py
+++ b/noggin/controller/root.py
@@ -1,3 +1,4 @@
+import python_freeipa
 from flask import render_template, request, redirect, url_for, session, jsonify
 from flask_healthz import HealthError
 
@@ -49,7 +50,11 @@ def logout():
     """Log the user out."""
     # Don't use the with_ipa() decorator, otherwise anonymous users visiting this endpoint will be
     # asked to login to then be logged out.
-    ipa = maybe_ipa_session(app, session)
+    try:
+        ipa = maybe_ipa_session(app, session)
+    except python_freeipa.exceptions.FreeIPAError:
+        # Not much we can do here, proceed to logout and it may help solve the issue.
+        ipa = None
     if ipa:
         ipa.logout()
     session.clear()

--- a/noggin/middleware.py
+++ b/noggin/middleware.py
@@ -1,0 +1,30 @@
+import python_freeipa
+from flask import render_template, make_response
+
+
+class IPAErrorHandler:
+    def __init__(self, app, error_template):
+        self.app = app
+        self.template = error_template
+        self.init_app()
+
+    def init_app(self):
+        self.app.wsgi_app = IPAWSGIMiddleware(
+            self.app.wsgi_app, self.get_error_response
+        )
+
+    def get_error_response(self, error):
+        self.app.logger.error(f"Uncaught IPA exception: {error}")
+        return make_response(render_template(self.template, error=error), 500)
+
+
+class IPAWSGIMiddleware:
+    def __init__(self, wsgi_app, error_factory):
+        self.wsgi_app = wsgi_app
+        self.error_factory = error_factory
+
+    def __call__(self, environ, start_response):
+        try:
+            return self.wsgi_app(environ, start_response)
+        except python_freeipa.exceptions.FreeIPAError as e:
+            return self.error_factory(e)(environ, start_response)

--- a/noggin/templates/group.html
+++ b/noggin/templates/group.html
@@ -18,7 +18,7 @@
       <form action="{{ url_for('group_remove_member', groupname=group.name) }}" method="post">
         {{ sponsor_form.hidden_tag() }}
         <button type="submit" class="btn btn-outline-danger" name="username" value="{{ current_user.username }}" id="leave-group-btn">
-          Leave group
+          {{ _("Leave group") }}
         </button>
       </form>
       {% endif %}

--- a/noggin/templates/ipa_error.html
+++ b/noggin/templates/ipa_error.html
@@ -1,0 +1,22 @@
+{% extends "main.html" %}
+
+{% block title %}IPA Error{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <div class="container section py-4">
+    <div class="row">
+      <div class="col">
+        <div class="alert alert-danger" role="alert">
+          <h4 class="alert-heading mb-3">{{_("IPA Error")}}</h4>
+          <p class="mb-0">
+            {{ _("There was a problem with the IPA backend, please try again later.")}}
+            {% if 'noggin_session' in session %}
+            {{ _("You can also <a href=\"%(url)s\">log out</a> and log back in if the problem persists.", url=url_for("logout")) }}
+            {% endif %}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/noggin/tests/unit/controller/test_authentication.py
+++ b/noggin/tests/unit/controller/test_authentication.py
@@ -53,6 +53,18 @@ def test_logout(client, logged_in_dummy_user):
     assert "noggin_ipa_server_hostname" not in session
 
 
+def test_logout_no_ipa(client, mocker):
+    """Test logout when IPA can't be reached"""
+    maybe_ipa_session = mocker.patch("noggin.controller.root.maybe_ipa_session")
+    maybe_ipa_session.side_effect = python_freeipa.exceptions.FreeIPAError
+    session = mocker.patch("noggin.controller.root.session")
+    result = client.get('/logout', follow_redirects=False)
+    assert result.status_code == 302
+    assert result.location == "http://localhost/"
+    # Make sure we did clear the session
+    session.clear.assert_called_once()
+
+
 # Login
 
 

--- a/noggin/tests/unit/test_middleware.py
+++ b/noggin/tests/unit/test_middleware.py
@@ -1,0 +1,14 @@
+import python_freeipa
+from bs4 import BeautifulSoup
+
+
+def test_ipa_error(client, mocker):
+    """Test the error page for IPA exceptions"""
+    maybe_ipa_session = mocker.patch("noggin.controller.root.maybe_ipa_session")
+    maybe_ipa_session.side_effect = python_freeipa.exceptions.FreeIPAError
+
+    result = client.get('/')
+    assert result.status_code == 500
+    page = BeautifulSoup(result.data, 'html.parser')
+    assert page.title
+    assert page.title.string == 'IPA Error - noggin'


### PR DESCRIPTION
A WSGI middleware is used to catch FreeIPA errors. Otherwise a generic 500 message would be displayed and it's not very useful.