### PR TITLE
Compatibility with WTForms 2.3.x

### DIFF
--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -4,7 +4,7 @@ import python_freeipa
 
 from noggin import app
 from noggin.security.ipa import maybe_ipa_login
-from noggin.utility import FormError, handle_form_errors
+from noggin.utility.forms import FormError, handle_form_errors
 from noggin.form.sync_token import SyncTokenForm
 from noggin.security.ipa import untouched_ipa_client
 

--- a/noggin/controller/password.py
+++ b/noggin/controller/password.py
@@ -12,14 +12,8 @@ import jwt
 from noggin import app, ipa_admin, mailer
 from noggin.security.ipa import untouched_ipa_client, maybe_ipa_session
 from noggin.representation.user import User
-from noggin.utility import (
-    with_ipa,
-    user_or_404,
-    FormError,
-    handle_form_errors,
-    require_self,
-    messaging,
-)
+from noggin.utility import with_ipa, user_or_404, require_self, messaging
+from noggin.utility.forms import FormError, handle_form_errors
 from noggin.utility.password_reset import PasswordResetLock
 from noggin.utility.token import PasswordResetToken
 from noggin.form.password_reset import (
@@ -53,7 +47,7 @@ def _validate_change_pw_form(form, username, ipa=None):
             f'An unhandled error {e.__class__.__name__} happened while reseting '
             f'the password for user {username}: {e.message}'
         )
-        form.errors['non_field_errors'] = [_('Could not change password.')]
+        form.non_field_errors.errors.append(_('Could not change password.'))
 
     if res and res.ok:
         flash(_('Your password has been changed'), 'success')
@@ -260,9 +254,9 @@ def forgot_password_change():
                 f'An unhandled error {e.__class__.__name__} happened while reseting '
                 f'the password for user {username}: {e.message}'
             )
-            form.errors['non_field_errors'] = [
+            form.non_field_errors.errors.append(
                 _('Could not change password, please try again.')
-            ]
+            )
         else:
             lock.delete()
             flash(_('Your password has been changed.'), 'success')

--- a/noggin/controller/registration.py
+++ b/noggin/controller/registration.py
@@ -11,9 +11,10 @@ import python_freeipa
 from noggin import app, ipa_admin, mailer
 from noggin.form.register_user import ResendValidationEmailForm, PasswordSetForm
 from noggin.representation.user import User
+from noggin.utility import messaging
 from noggin.utility.locales import guess_locale
 from noggin.utility.token import EmailValidationToken
-from noggin.utility import messaging, FormError, handle_form_errors
+from noggin.utility.forms import FormError, handle_form_errors
 from noggin.security.ipa import untouched_ipa_client, maybe_ipa_login
 
 

--- a/noggin/controller/root.py
+++ b/noggin/controller/root.py
@@ -9,7 +9,8 @@ from noggin.representation.group import Group
 from noggin.representation.user import User
 
 from noggin.security.ipa import maybe_ipa_session
-from noggin.utility import with_ipa, handle_form_errors
+from noggin.utility import with_ipa
+from noggin.utility.forms import handle_form_errors
 
 from .authentication import handle_login_form
 from .registration import handle_register_form

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -18,14 +18,8 @@ from noggin.representation.group import Group
 from noggin.representation.user import User
 from noggin.representation.otptoken import OTPToken
 from noggin.security.ipa import maybe_ipa_login
-from noggin.utility import (
-    with_ipa,
-    user_or_404,
-    FormError,
-    handle_form_errors,
-    require_self,
-    messaging,
-)
+from noggin.utility import with_ipa, user_or_404, require_self, messaging
+from noggin.utility.forms import FormError, handle_form_errors
 
 
 @app.route('/user/<username>/')
@@ -187,7 +181,7 @@ def user_settings_otp(ipa, username):
             app.logger.error(
                 f'An error happened while creating an OTP token for user {username}: {e.message}'
             )
-            addotpform.errors['non_field_errors'] = [_('Cannot create the token.')]
+            addotpform.non_field_errors.errors.append(_('Cannot create the token.'))
         else:
             return redirect(url_for('user_settings_otp', username=username))
 

--- a/noggin/form/add_group_member.py
+++ b/noggin/form/add_group_member.py
@@ -1,10 +1,11 @@
-from flask_wtf import FlaskForm
 from wtforms import StringField
 from wtforms.validators import DataRequired
 from flask_babel import lazy_gettext as _
 
+from .base import BaseForm
 
-class AddGroupMemberForm(FlaskForm):
+
+class AddGroupMemberForm(BaseForm):
     new_member_username = StringField(
         'New Member Username',
         validators=[DataRequired(message=_('New member username must not be empty'))],

--- a/noggin/form/base.py
+++ b/noggin/form/base.py
@@ -4,7 +4,13 @@ from wtforms.widgets import TextInput
 from wtforms.widgets.core import html_params, HTMLString
 
 
-class ModestForm(FlaskForm):
+class BaseForm(FlaskForm):
+    """Add an invisible field to hold form-wide errors."""
+
+    non_field_errors = Field()
+
+
+class ModestForm(BaseForm):
     """A form that can handle not being the only form on the page."""
 
     def _get_submit_field(self):

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -1,4 +1,3 @@
-from flask_wtf import FlaskForm
 from flask_babel import lazy_gettext as _
 from wtforms import (
     FieldList,
@@ -16,10 +15,10 @@ from noggin import app
 from noggin.form.validators import Email
 from noggin.utility.locales import LOCALES
 from noggin.utility.timezones import TIMEZONES
-from .base import CSVListField
+from .base import CSVListField, BaseForm
 
 
-class UserSettingsProfileForm(FlaskForm):
+class UserSettingsProfileForm(BaseForm):
     firstname = StringField(
         _('First Name'),
         validators=[DataRequired(message=_('First name must not be empty'))],
@@ -73,7 +72,7 @@ class UserSettingsProfileForm(FlaskForm):
     )
 
 
-class UserSettingsKeysForm(FlaskForm):
+class UserSettingsKeysForm(BaseForm):
     sshpubkeys = FieldList(
         TextAreaField(validators=[Optional()], render_kw={"rows": 4}),
         label=_('SSH Keys'),
@@ -84,7 +83,7 @@ class UserSettingsKeysForm(FlaskForm):
     )
 
 
-class UserSettingsAddOTPForm(FlaskForm):
+class UserSettingsAddOTPForm(BaseForm):
     description = StringField(
         _('Token name'),
         validators=[Optional()],
@@ -98,13 +97,13 @@ class UserSettingsAddOTPForm(FlaskForm):
     )
 
 
-class UserSettingsOTPStatusChange(FlaskForm):
+class UserSettingsOTPStatusChange(BaseForm):
     token = HiddenField(
         'token', validators=[DataRequired(message=_('token must not be empty'))]
     )
 
 
-class UserSettingsAgreementSign(FlaskForm):
+class UserSettingsAgreementSign(BaseForm):
     agreement = HiddenField(
         'agreement', validators=[DataRequired(message=_('agreement must not be empty'))]
     )

--- a/noggin/form/password_reset.py
+++ b/noggin/form/password_reset.py
@@ -1,12 +1,12 @@
 from flask_babel import lazy_gettext as _
-from flask_wtf import FlaskForm
 from wtforms import PasswordField, StringField
 from wtforms.validators import DataRequired, EqualTo, Length
 
 from noggin import app
+from .base import BaseForm
 
 
-class NewPasswordForm(FlaskForm):
+class NewPasswordForm(BaseForm):
 
     password = PasswordField(
         _('New Password'),
@@ -36,7 +36,7 @@ class PasswordResetForm(NewPasswordForm):
     )
 
 
-class ForgottenPasswordForm(FlaskForm):
+class ForgottenPasswordForm(BaseForm):
 
     username = StringField(
         _('Username'),

--- a/noggin/form/register_user.py
+++ b/noggin/form/register_user.py
@@ -1,12 +1,11 @@
 from flask_babel import lazy_gettext as _
-from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField
 from wtforms.fields.html5 import EmailField
 from wtforms.validators import DataRequired, EqualTo, Length
 
 from noggin import app
 from noggin.form.validators import Email
-from .base import ModestForm, SubmitButtonField, strip
+from .base import ModestForm, SubmitButtonField, strip, BaseForm
 
 
 class RegisterUserForm(ModestForm):
@@ -43,11 +42,11 @@ class RegisterUserForm(ModestForm):
     submit = SubmitButtonField(_("Register"))
 
 
-class ResendValidationEmailForm(FlaskForm):
+class ResendValidationEmailForm(BaseForm):
     submit = SubmitButtonField(_("Resend email"))
 
 
-class PasswordSetForm(FlaskForm):
+class PasswordSetForm(BaseForm):
 
     password = PasswordField(
         _('Password'),

--- a/noggin/form/remove_group_member.py
+++ b/noggin/form/remove_group_member.py
@@ -1,10 +1,11 @@
 from flask_babel import lazy_gettext as _
-from flask_wtf import FlaskForm
 from wtforms import HiddenField
 from wtforms.validators import DataRequired
 
+from .base import BaseForm
 
-class RemoveGroupMemberForm(FlaskForm):
+
+class RemoveGroupMemberForm(BaseForm):
     username = HiddenField(
         _('Username'),
         validators=[DataRequired(message=_('Username must not be empty'))],

--- a/noggin/form/sync_token.py
+++ b/noggin/form/sync_token.py
@@ -1,10 +1,11 @@
 from flask_babel import lazy_gettext as _
-from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField
 from wtforms.validators import DataRequired, Optional
 
+from .base import BaseForm
 
-class SyncTokenForm(FlaskForm):
+
+class SyncTokenForm(BaseForm):
     username = StringField(
         _('Username'),
         validators=[DataRequired(message=_('You must provide a user name'))],

--- a/noggin/tests/unit/utility/test___init__.py
+++ b/noggin/tests/unit/utility/test___init__.py
@@ -9,11 +9,8 @@ from noggin.utility import (
     user_or_404,
     group_or_404,
     with_ipa,
-    FormError,
-    handle_form_errors,
     require_self,
 )
-from noggin.form.login_user import LoginUserForm
 
 
 @pytest.mark.vcr()
@@ -81,55 +78,6 @@ def test_with_ipa_anonymous(client):
         category, message = messages[0]
         assert message == "Please log in to continue."
         assert category == "warning"
-
-
-def test_formerror(client):
-    with current_app.test_request_context('/'):
-        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
-        form.validate()
-        error = FormError("username", "error message")
-        error.populate_form(form)
-    assert form.errors == {"username": ["error message"]}
-
-
-def test_formerror_unknown_field(client):
-    with current_app.test_request_context('/'):
-        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
-        form.validate()
-        error = FormError("non_form_errors", "error message")
-        error.populate_form(form)
-    assert form.errors == {"non_form_errors": ["error message"]}
-
-
-def test_formerror_existing_field(client):
-    with current_app.test_request_context('/'):
-        form = LoginUserForm()
-        form.validate()
-        error = FormError("username", "error message")
-        error.populate_form(form)
-        assert form.errors["username"] == [
-            "You must provide a user name",
-            "error message",
-        ]
-
-
-def test_formerror_unknown_field_append(client):
-    with current_app.test_request_context('/'):
-        form = LoginUserForm()
-        form.validate()
-        FormError("non_form_errors", "error message 1").populate_form(form)
-        FormError("non_form_errors", "error message 2").populate_form(form)
-    assert form.errors["non_form_errors"] == ["error message 1", "error message 2"]
-
-
-def test_handle_form_errors(client):
-    with current_app.test_request_context('/'):
-        form = LoginUserForm()
-        error = FormError("username", "error_message")
-        with mock.patch.object(error, "populate_form") as populate_form:
-            with handle_form_errors(form):
-                raise error
-    populate_form.assert_called_once_with(form)
 
 
 def test_require_self_wrong_route(client):

--- a/noggin/tests/unit/utility/test_forms.py
+++ b/noggin/tests/unit/utility/test_forms.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+from flask import current_app
+
+from noggin.utility.forms import FormError, handle_form_errors
+from noggin.form.login_user import LoginUserForm
+
+
+def test_formerror(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
+        form.validate()
+        error = FormError("username", "error message")
+        error.populate_form(form)
+    assert form.errors == {"username": ["error message"]}
+
+
+def test_formerror_unknown_field(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm(data={"username": "dummy", "password": "passwd"})
+        form.validate()
+        error = FormError("non_field_errors", "error message")
+        error.populate_form(form)
+    assert form.errors == {"non_field_errors": ["error message"]}
+
+
+def test_formerror_existing_field(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        form.validate()
+        error = FormError("username", "error message")
+        error.populate_form(form)
+        assert form.errors["username"] == [
+            "You must provide a user name",
+            "error message",
+        ]
+
+
+def test_formerror_unknown_field_append(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        form.validate()
+        FormError("non_field_errors", "error message 1").populate_form(form)
+        FormError("non_field_errors", "error message 2").populate_form(form)
+    assert form.errors["non_field_errors"] == ["error message 1", "error message 2"]
+
+
+def test_handle_form_errors(client):
+    with current_app.test_request_context('/'):
+        form = LoginUserForm()
+        error = FormError("username", "error_message")
+        with mock.patch.object(error, "populate_form") as populate_form:
+            with handle_form_errors(form):
+                raise error
+    populate_form.assert_called_once_with(form)

--- a/noggin/utility/__init__.py
+++ b/noggin/utility/__init__.py
@@ -1,6 +1,5 @@
 import hashlib
 from functools import wraps
-from contextlib import contextmanager
 
 from flask import abort, flash, g, redirect, url_for, session, Markup, current_app
 from flask_babel import lazy_gettext as _
@@ -76,88 +75,6 @@ def user_or_404(ipa, username):
         return ipa.user_show(username)
     except python_freeipa.exceptions.NotFound:
         abort(404)
-
-
-class FormError(Exception):
-    def __init__(self, field, message):
-        self.field = field
-        self.message = message
-
-    def populate_form(self, form):
-        try:
-            field = getattr(form, self.field)
-        except AttributeError:
-            # probably non_field_errors
-            if self.field not in form.errors:
-                form.errors[self.field] = []
-            error_list = form.errors[self.field]
-        else:
-            error_list = field.errors
-        error_list.append(self.message)
-
-
-@contextmanager
-def handle_form_errors(form):
-    """Handle form errors by raising exceptions.
-
-    The point of this context manager is to let controller developers create form errors by raising
-    exceptions instead of setting variables. This is particularly useful when you are making
-    multiple API calls in a row and handling exceptions separately: instead of doing nested
-    ``try..except..else`` statements they would have non-nested code raising exceptions.
-
-    For example, without this function you would have something similar to::
-
-        if form.validate_on_submit():
-            try:
-                api_call_1()
-            except UserError as e:
-                form.user.errors.append(e.msg)
-            else:
-                try:
-                    api_call_2()
-                except PasswordError as e:
-                    form.password.errors.append(e.msg)
-                else:
-                    try:
-                        api_call_3()
-                    except GenericError as e:
-                        form.errors['non_field_errors'] = [e.msg]
-                    else:
-                        flash("Success!")
-                        return redirect("/")
-        return render_template(..., form=form)
-
-    Every API call causes an additional level of nesting because the code must fall through the
-    initial ``if`` statement to reach the ``render_template`` call. With this function this could be
-    rewritten as::
-
-        if form.validate_on_submit():
-            with handle_form_errors(form):
-                try:
-                    api_call_1()
-                except UserError as e:
-                    raise FormError("user", e.msg)
-                try:
-                    api_call_2()
-                except PasswordError as e:
-                    raise FormError("password", e.msg)
-                try:
-                    api_call_3()
-                except GenericError as e:
-                    raise FormError("non_field_errors", e.msg)
-                flash("Success!")
-                return redirect("/")
-        return render_template(..., form=form)
-
-    This code does not nest more on each API call, which is (arguably) clearer as the number of
-    necessary API call increases.
-
-    Args: form (wtforms.Form): The form that errors should be stored to
-    """
-    try:
-        yield
-    except FormError as e:
-        e.populate_form(form)
 
 
 def undo_button(form_action, submit_name, submit_value, hidden_tag):

--- a/noggin/utility/forms.py
+++ b/noggin/utility/forms.py
@@ -1,0 +1,75 @@
+from contextlib import contextmanager
+
+
+class FormError(Exception):
+    def __init__(self, field, message):
+        self.field = field
+        self.message = message
+
+    def populate_form(self, form):
+        field = form[self.field]
+        field.errors.append(self.message)
+
+
+@contextmanager
+def handle_form_errors(form):
+    """Handle form errors by raising exceptions.
+
+    The point of this context manager is to let controller developers create form errors by raising
+    exceptions instead of setting variables. This is particularly useful when you are making
+    multiple API calls in a row and handling exceptions separately: instead of doing nested
+    ``try..except..else`` statements they would have non-nested code raising exceptions.
+
+    For example, without this function you would have something similar to::
+
+        if form.validate_on_submit():
+            try:
+                api_call_1()
+            except UserError as e:
+                form.user.errors.append(e.msg)
+            else:
+                try:
+                    api_call_2()
+                except PasswordError as e:
+                    form.password.errors.append(e.msg)
+                else:
+                    try:
+                        api_call_3()
+                    except GenericError as e:
+                        form.non_field_errors.errors.append(e.msg)
+                    else:
+                        flash("Success!")
+                        return redirect("/")
+        return render_template(..., form=form)
+
+    Every API call causes an additional level of nesting because the code must fall through the
+    initial ``if`` statement to reach the ``render_template`` call. With this function this could be
+    rewritten as::
+
+        if form.validate_on_submit():
+            with handle_form_errors(form):
+                try:
+                    api_call_1()
+                except UserError as e:
+                    raise FormError("user", e.msg)
+                try:
+                    api_call_2()
+                except PasswordError as e:
+                    raise FormError("password", e.msg)
+                try:
+                    api_call_3()
+                except GenericError as e:
+                    raise FormError("non_field_errors", e.msg)
+                flash("Success!")
+                return redirect("/")
+        return render_template(..., form=form)
+
+    This code does not nest more on each API call, which is (arguably) clearer as the number of
+    necessary API call increases.
+
+    Args: form (wtforms.Form): The form that errors should be stored to
+    """
+    try:
+        yield
+    except FormError as e:
+        e.populate_form(form)


### PR DESCRIPTION
In WTForms 2.3.x the form.errors dictionary is not mutable anymore (it's autogenerated on access from the fields' errors).
It was never really intended to be mutable but we abused the caching system, and now we can't do that anymore.