### PR TITLE
Add Basset support

### DIFF
--- a/devel/create-test-data.py
+++ b/devel/create-test-data.py
@@ -67,6 +67,7 @@ for x in range(50):
             fasircnick=[username, username + "_"],
             faslocale="en-US",
             fastimezone=fake.random_sample(timezones.TIMEZONES, length=1)[0],
+            fasstatusnote="active",
             fasgpgkeyid=[],
         )
         # 'change' the password as the user, so its not expired

--- a/noggin.cfg.default
+++ b/noggin.cfg.default
@@ -62,3 +62,7 @@ MAIL_SUPPRESS_SEND = True
 # The default to show if a user has not set an avatar with the service
 # other options are: "mp", "identicon", "monsterid", "wavatar", "retro", "robohash"
 # AVATAR_DEFAULT_TYPE = "robohash"
+
+# Spam checking
+BASSET_URL = None
+SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes

--- a/noggin.cfg.default
+++ b/noggin.cfg.default
@@ -25,7 +25,11 @@ SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = False
 
 # Default values for new users
-# USER_DEFAULTS = {"locale": "en-US", "timezone": "UTC"}
+# USER_DEFAULTS = {
+#     "locale": "en-US",
+#     "timezone": "UTC",
+#     "status_note": "spamcheck_awaiting",
+# }
 
 # How many minutes before the new account activation link expires
 # ACTIVATION_TOKEN_EXPIRATION = 30

--- a/noggin.cfg.default
+++ b/noggin.cfg.default
@@ -29,6 +29,7 @@ SESSION_COOKIE_SECURE = False
 #     "locale": "en-US",
 #     "timezone": "UTC",
 #     "status_note": "spamcheck_awaiting",
+#     "locked": True,
 # }
 
 # How many minutes before the new account activation link expires

--- a/noggin/controller/password.py
+++ b/noggin/controller/password.py
@@ -19,7 +19,7 @@ from noggin.security.ipa import maybe_ipa_session, untouched_ipa_client
 from noggin.utility import messaging, require_self, user_or_404, with_ipa
 from noggin.utility.forms import FormError, handle_form_errors
 from noggin.utility.password_reset import PasswordResetLock
-from noggin.utility.token import PasswordResetToken
+from noggin.utility.token import Audience, make_token, read_token
 from noggin_messages import UserUpdateV1
 
 
@@ -138,7 +138,10 @@ def forgot_password_ask():
                 raise FormError(
                     "username", _("User %(username)s does not exist", username=username)
                 )
-            token = PasswordResetToken.from_user(user).as_string()
+            token = make_token(
+                {"sub": user.username, "lpc": user.last_password_change},
+                audience=Audience.password_reset,
+            )
             # Send the email
             email_context = {"token": token, "username": username}
             email = Message(
@@ -175,11 +178,11 @@ def forgot_password_change():
         flash('No token provided, please request one.', 'warning')
         return redirect(url_for('forgot_password_ask'))
     try:
-        token_obj = PasswordResetToken.from_string(token)
+        token_data = read_token(token, audience=Audience.password_reset)
     except jwt.exceptions.DecodeError:
         flash(_("The token is invalid, please request a new one."), "warning")
         return redirect(url_for('forgot_password_ask'))
-    username = token_obj.username
+    username = token_data["sub"]
     lock = PasswordResetLock(username)
     valid_until = lock.valid_until()
     now = datetime.datetime.now()
@@ -188,7 +191,7 @@ def forgot_password_change():
         flash(_("The token has expired, please request a new one."), "warning")
         return redirect(url_for('forgot_password_ask'))
     user = User(ipa_admin.user_show(username))
-    if not token_obj.validate_last_change(user):
+    if user.last_password_change != token_data["lpc"]:
         lock.delete()
         flash(
             _(
@@ -246,7 +249,10 @@ def forgot_password_change():
             # Oh noes, the token is now invalid since the user's password was changed! Let's
             # re-generate a token so they can keep going.
             user = User(ipa_admin.user_show(username))
-            token = PasswordResetToken.from_user(user).as_string()
+            token = make_token(
+                {"sub": user.username, "lpc": user.last_password_change},
+                audience=Audience.password_reset,
+            )
             form.otp.errors.append(_("Incorrect value."))
         except python_freeipa.exceptions.FreeIPAError as e:
             # If we made it here, we hit something weird not caught above.

--- a/noggin/controller/registration.py
+++ b/noggin/controller/registration.py
@@ -83,6 +83,7 @@ def handle_register_form(form):
             fascreationtime=f"{now.isoformat()}Z",
             faslocale=guess_locale(),
             fastimezone=app.config["USER_DEFAULTS"]["timezone"],
+            fasstatusnote=app.config["USER_DEFAULTS"]["status_note"],
         )
         user = User(user)
     except python_freeipa.exceptions.DuplicateEntry:
@@ -189,7 +190,7 @@ def activate_account():
                 raise FormError(
                     "non_field_errors",
                     _(
-                        "Something went wrong while activating your account, "
+                        "Something went wrong while creating your account, "
                         "please try again later."
                     ),
                 )
@@ -209,7 +210,7 @@ def activate_account():
                 # Tell the user what's going to happen.
                 flash(
                     _(
-                        'Your account has been activated, but the password you chose does not '
+                        'Your account has been created, but the password you chose does not '
                         'comply with the policy (%(policy_error)s) and has thus been set as '
                         'expired. You will be asked to change it after logging in.',
                         policy_error=e.policy_error,
@@ -229,7 +230,7 @@ def activate_account():
                 # the login page with an appropriate warning.
                 flash(
                     _(
-                        'Your account has been activated, but an error occurred while setting your '
+                        'Your account has been created, but an error occurred while setting your '
                         'password (%(message)s). You may need to change it after logging in.',
                         message=e.message,
                     ),
@@ -245,7 +246,7 @@ def activate_account():
             if ipa:
                 flash(
                     _(
-                        'Congratulations, your account is now active! Welcome, %(name)s.',
+                        'Congratulations, your account has been created! Welcome, %(name)s.',
                         name=user.name,
                     ),
                     'success',
@@ -255,7 +256,7 @@ def activate_account():
                 # expired).
                 flash(
                     _(
-                        'Congratulations, your account is now active! Go ahead and sign in '
+                        'Congratulations, your account has been created! Go ahead and sign in '
                         'to proceed.'
                     ),
                     'success',

--- a/noggin/defaults.cfg
+++ b/noggin/defaults.cfg
@@ -3,7 +3,11 @@
 TEMPLATES_AUTO_RELOAD = False
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = True
-USER_DEFAULTS = {"locale": "en-US", "timezone": "UTC"}
+USER_DEFAULTS = {
+    "locale": "en-US",
+    "timezone": "UTC",
+    "status_note": "active",
+}
 THEME = "default"
 PASSWORD_POLICY = {
     "min": 8, "max": -1

--- a/noggin/defaults.cfg
+++ b/noggin/defaults.cfg
@@ -7,6 +7,7 @@ USER_DEFAULTS = {
     "locale": "en-US",
     "timezone": "UTC",
     "status_note": "active",
+    "locked": False,
 }
 THEME = "default"
 PASSWORD_POLICY = {

--- a/noggin/defaults.cfg
+++ b/noggin/defaults.cfg
@@ -28,3 +28,6 @@ HEALTHZ = {
 }
 
 PAGE_SIZE = 30
+
+BASSET_URL = None
+SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes

--- a/noggin/representation/base.py
+++ b/noggin/representation/base.py
@@ -70,3 +70,6 @@ class Representation:
             )
 
         return [key for key in self if getattr(self, key) != getattr(other, key)]
+
+    def as_dict(self):
+        return {attr: getattr(self, attr) for attr in self.attr_names}

--- a/noggin/representation/user.py
+++ b/noggin/representation/user.py
@@ -23,6 +23,7 @@ class User(Representation):
         "displayname": "displayname",
         "gecos": "gecos",
         "commonname": "cn",
+        "status_note": "fasstatusnote",
     }
     attr_types = {
         "sshpubkeys": "list",

--- a/noggin/representation/user.py
+++ b/noggin/representation/user.py
@@ -38,3 +38,8 @@ class User(Representation):
     @property
     def name(self):
         return self.displayname or self.gecos or self.commonname
+
+    @property
+    def locked(self):
+        # Unlike the others nsAccountLock is not a list.
+        return self.raw.get("nsaccountlock", False)

--- a/noggin/signals.py
+++ b/noggin/signals.py
@@ -1,7 +1,12 @@
-from blinker import Namespace, ANY
+import time
 
-from noggin_messages import UserCreateV1
+import requests
+from blinker import ANY, Namespace
+from flask import current_app, request, url_for
+
 from noggin.utility import messaging
+from noggin.utility.token import Audience, make_token
+from noggin_messages import UserCreateV1
 
 
 noggin_signals = Namespace()
@@ -16,3 +21,40 @@ def send_registered_message(sender, **kwargs):
     messaging.publish(
         UserCreateV1({"msg": {"agent": user.username, "user": user.username}})
     )
+
+
+@user_registered.connect_via(ANY)
+def request_basset_check(sender, **kwargs):
+    user = sender
+    basset_url = current_app.config.get("BASSET_URL")
+    if not basset_url:
+        return
+
+    token = make_token(
+        {"sub": user.username},
+        audience=Audience.spam_check,
+        ttl=current_app.config["SPAMCHECK_TOKEN_EXPIRATION"],
+    )
+    user_dict = user.as_dict()
+    user_dict["email"] = user_dict["mail"]
+    user_dict["human_name"] = user_dict["commonname"]
+
+    response = requests.post(
+        basset_url,
+        json={
+            "action": "fedora.noggin.registration",
+            "time": int(time.time()),
+            "data": {
+                "user": user_dict,
+                "request_headers": dict(request.headers),
+                "request_ip": request.remote_addr,
+                "token": token,
+                "callback": url_for('spamcheck_hook', _external=True),
+            },
+        },
+    )
+    if not response.ok:
+        current_app.logger.warning(
+            "Error requesting a Basset check: "
+            f"{response.status_code} {response.reason}: {response.text}"
+        )

--- a/noggin/signals.py
+++ b/noggin/signals.py
@@ -1,0 +1,18 @@
+from blinker import Namespace, ANY
+
+from noggin_messages import UserCreateV1
+from noggin.utility import messaging
+
+
+noggin_signals = Namespace()
+
+
+user_registered = noggin_signals.signal('user-registered')
+
+
+@user_registered.connect_via(ANY)
+def send_registered_message(sender, **kwargs):
+    user = sender
+    messaging.publish(
+        UserCreateV1({"msg": {"agent": user.username, "user": user.username}})
+    )

--- a/noggin/templates/spamcheck.html
+++ b/noggin/templates/spamcheck.html
@@ -1,0 +1,58 @@
+{% extends "main.html" %}
+
+{% block content %}
+  {{ super() }}
+
+  <div class="bg-light border-bottom py-5">
+    <div class="container section">
+      <div class="row">
+        <div class="col-md-7">
+          {{ front_page_blurb() }}
+        </div>
+        <div class="col">
+          <div class="alert alert-{% if g.current_user.status_note == 'spamcheck_denied' %}warning{% else %}info{% endif %}" role="alert">
+            {% if g.current_user.status_note == "spamcheck_awaiting" %}
+              <h4 class="alert-heading">
+                {{ _("Your account is being checked") }}
+              </h4>
+              <p>
+                {{ _("Your account is being checked for spam likelihood, it should only take a few seconds, please wait...") }}
+              </p>
+            {% elif g.current_user.status_note == "spamcheck_manual" %}
+              <h4 class="alert-heading">
+                {{ _("Your account requires admin activation") }}
+              </h4>
+              <p>
+                {{ _("Your account needs to be approved by an administrator.") }}
+                {{ _("You will be notified by email when the decision has been taken.") }}
+                {{ _("Thank you for your patience.") }}
+              </p>
+            {% elif g.current_user.status_note == "spamcheck_denied" %}
+              <h4 class="alert-heading">
+                {{ _("Your account is blocked") }}
+              </h4>
+              <p class="mb-1">{{ _("Your account has been flagged as spam.") }}</p>
+              {% if spamcheck_contact is defined %}
+                {{ spamcheck_contact() }}
+              {% endif %}
+            {% else %}
+              <h4 class="alert-heading">
+                {{ _("Something went wrong") }}
+              </h4>
+              <p>
+                {{ _("Unsupported spam status: %s, please contact the administrators", g.current_user.status_note) }}
+              </p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if g.current_user.status_note == "spamcheck_awaiting" %}
+  <script>
+    // refresh page every two seconds
+    setTimeout(function(){ location.reload(); }, 3000);
+  </script>
+  {% endif %}
+{% endblock %}

--- a/noggin/tests/unit/cassettes/test_signals/test_signal_basset.yaml
+++ b/noggin/tests/unit/cassettes/test_signals/test_signal_basset.yaml
@@ -1,0 +1,729 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=aqxydY54vFP7HmUeU183pEEOfVkxedWCUM1FUHlqSksCqHkrN1RW9nkh%2bi%2b4rSKMOlxiI9Q%2f6eWmpzf3hOTJYF%2bH%2fne%2fl4bAmQhyvUTe7VZIdfMNMEfRQawg5QQVjRtaWCJLKOJ5UKHh8lIfcoKPWbYlvbKAv6MLNxrit1xPbYpCeERQq5ewXR0OweoI7XP9;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aqxydY54vFP7HmUeU183pEEOfVkxedWCUM1FUHlqSksCqHkrN1RW9nkh%2bi%2b4rSKMOlxiI9Q%2f6eWmpzf3hOTJYF%2bH%2fne%2fl4bAmQhyvUTe7VZIdfMNMEfRQawg5QQVjRtaWCJLKOJ5UKHh8lIfcoKPWbYlvbKAv6MLNxrit1xPbYpCeERQq5ewXR0OweoI7XP9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:58:24Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aqxydY54vFP7HmUeU183pEEOfVkxedWCUM1FUHlqSksCqHkrN1RW9nkh%2bi%2b4rSKMOlxiI9Q%2f6eWmpzf3hOTJYF%2bH%2fne%2fl4bAmQhyvUTe7VZIdfMNMEfRQawg5QQVjRtaWCJLKOJ5UKHh8lIfcoKPWbYlvbKAv6MLNxrit1xPbYpCeERQq5ewXR0OweoI7XP9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBDkkIlZCatpTSqoDE5YGCovHu2NnG3nX3kksR/96dXYcU
+        CZWnjOdyZubM2TymGo2rbfo+efzXZNL//Ew/u6bZJDcGdfrQS1IuTFvDRkKDr4WFFFZAbWLsJvgq
+        ZMq8lqyKX8gsq8HEsFVt6t0taqMkWUpXIMUfsEJJqHd+IdH62EuHI1gqV0asgTHlpKXvhS5aLSQT
+        LdTg1p3LCrZA26pasE3n9Qlxou7DmPkWswSzNX3gysxPtXLtRXnpiu+4MeRvsL3QohLyRFq9iWS0
+        4KT47VDwsB/PD7OyGI/32GQw3MtzhL0JjiZ7o8FomGWDcgzDg1BII/v2K6U5rluhAwEBYpANsuww
+        P8zz0WRwcLfN9hTadsXZHGSF/0vEtdXAwQIlPaazWQEGx8PZzH+n0+m3cjH/UrLmaMk/Hc3vTvO2
+        WHy8uM7416ubobs9ub2+nU6P06eHuHADEirkGDamrkwec7pxzxsVUWTI6o5hepwdS1V5jsiyaGwY
+        ywkuXVN4egkiH40zz0Z2NAzBBkQdySPcD7iGpq2xz1QTwibS8iwpfyimMfBlRfMKFcNIxVw1yIX2
+        x1bd6Pvk2g9domr/N1Wt/BJmjnWcbb8Qct8zOd/us5t4SzwDqaRgUD+/nLjQ+cXp6dl5//rk6vr5
+        9Fu1vpFaiSXKlw8x+Fv/iFEvkaYo/VtE2hfMbCsp77babb0L3Fgodr4GaWlVzsL9AjTp2COa+AdA
+        jNOOu0uH4BuHfvKlS6gdDdsxE5oZ4xVkohrtpg3hFWgpZEUJ3Xrpre/gb/pDGNNFutKg28uzpEtI
+        4s2SFZhEKpsYr81eUirtMXniVdN6bRSiFnYT4pUDDdIi8n4yNcY1Hj0J7Ol3JiHgZQTuJYP+4GBM
+        nZni1DY/yLKcCImv6TGNZbOugAaLJU/huXjsBoLW0innyBNiLbmPXNyngSDUWpHepKtr+v/gO/tZ
+        FAQA3M/5Qg/E7q7vsD/p+75/AQAA//8DANBYyQjaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aqxydY54vFP7HmUeU183pEEOfVkxedWCUM1FUHlqSksCqHkrN1RW9nkh%2bi%2b4rSKMOlxiI9Q%2f6eWmpzf3hOTJYF%2bH%2fne%2fl4bAmQhyvUTe7VZIdfMNMEfRQawg5QQVjRtaWCJLKOJ5UKHh8lIfcoKPWbYlvbKAv6MLNxrit1xPbYpCeERQq5ewXR0OweoI7XP9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=pyaI86KOSFlQxwV%2b0QtjXePSiZ5s9HD%2bD3wwwpn2SKLMyK7WpSjoUPwwA8b5zNpS3ZkAq8Lm77pEHGZlBt7KQGRF%2f8AiCGo6hYLjw2ss7gmLxWopYpKz000aR8M0McJkMMXbPgw9gbI8KGx%2bdRoO1vOkzOI9d0OlIDqSaPcX0bvR1QANxQBWiRv10A%2fgU9Eg;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pyaI86KOSFlQxwV%2b0QtjXePSiZ5s9HD%2bD3wwwpn2SKLMyK7WpSjoUPwwA8b5zNpS3ZkAq8Lm77pEHGZlBt7KQGRF%2f8AiCGo6hYLjw2ss7gmLxWopYpKz000aR8M0McJkMMXbPgw9gbI8KGx%2bdRoO1vOkzOI9d0OlIDqSaPcX0bvR1QANxQBWiRv10A%2fgU9Eg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pyaI86KOSFlQxwV%2b0QtjXePSiZ5s9HD%2bD3wwwpn2SKLMyK7WpSjoUPwwA8b5zNpS3ZkAq8Lm77pEHGZlBt7KQGRF%2f8AiCGo6hYLjw2ss7gmLxWopYpKz000aR8M0McJkMMXbPgw9gbI8KGx%2bdRoO1vOkzOI9d0OlIDqSaPcX0bvR1QANxQBWiRv10A%2fgU9Eg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9lJKUtpSJiGt0rjtAoybJiZUndinqVfHznyBdoj/vmMnbWFi
+        4ynH37n6O5/zmBq0Xrr0ffL43GSKPj/Sj76qlsm1RZPedZKUC1tLWCqo8DW3UMIJkLbxXUesRKbt
+        a8G6+InMMQm2cTtdpwTXaKxWwdKmBCV+gxNagdzgQqEj30vAh7IhXVuxAMa0Vy6c56aojVBM1CDB
+        L1rICTZHV2sp2LJFKaCZqD1YO1vVnIJdmeS4tLMjo319Nj33xWdc2oBXWJ8ZUQp1oJxZNmTU4JX4
+        5VHweD+e72bTYjjcYqNefyvPEbZGOBhtDXqDfpb1pkPo78TEMDK1f9CG46IWJhIQS/SyXpZn+SDP
+        B1TjdhVNFLr6gbMZqBLXgdluvvtXIC6cAQ4OQtBjOpkUYHHYn0zonI7Hn8r57HB6e3zjiu9yfDXf
+        O77I5NkXeXF4nX8bp093zUUrUFAix3jT0I2pfR522yGjDNTYYLVLsB3O9pUuiZtgObQujiM1IXaG
+        UsYa24VQ2zTOLDorEA0c637ABVS1xC7T1eoqDJRWgoFca7EJPT07Ojo57V4dXF7F0JmukAtDe9Xt
+        tNsB2o7Ra7pXCnmjmF+tcp1cCq58VZA4Ap4PhhntMtvrRyfphhmM63Oi+vdmbLPd9cvw/ytaintU
+        Lx9gxJVtCZeazck3pXeIgQCwk5WcCHbGr9A5Lh0UG6ym54/mHvmz7ArDHHo6iXuNLYOuKc42P4Qw
+        ehh4o4DofEMAT5R6D9KHS7RsxmbWkrJso063rKP7AYwSqgwB7bXTG+pApH4V1raeNjXq+PwkaQOS
+        hsbkAWyitEssabaTTLWhmjwhNdW0nEJI4ZbRX3owoBwi7yZja31F1ZPIiXlnk1D4vincSXrd3s4w
+        dGaah7b5TpblgZDmdT2mTdqkTQiDNSlP8RlR7QqiIJWXMtCBxmjTnsPfg2/stTxDFeA01QtlBi43
+        XfrdUZe6/AEAAP//AwDxCKvD2AUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pyaI86KOSFlQxwV%2b0QtjXePSiZ5s9HD%2bD3wwwpn2SKLMyK7WpSjoUPwwA8b5zNpS3ZkAq8Lm77pEHGZlBt7KQGRF%2f8AiCGo6hYLjw2ss7gmLxWopYpKz000aR8M0McJkMMXbPgw9gbI8KGx%2bdRoO1vOkzOI9d0OlIDqSaPcX0bvR1QANxQBWiRv10A%2fgU9Eg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=IDfCSkxkYrezORWwEVoWqZxblf7koxuZLT3LvaCB1gynA6SuJT%2fGz0bItB61LSJ5vLjD6ohPQ52oud7Lt7OhmoqH3PO918l0o6bhOpX0WPh40uOLP7rgxGGuj4j2BGVAheKsHJTFwAc%2bfgGpkNga07PT%2bPZmv65daHh4QpH1xGr8Zv2GoneRtlimBwEqiW8o;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=IDfCSkxkYrezORWwEVoWqZxblf7koxuZLT3LvaCB1gynA6SuJT%2fGz0bItB61LSJ5vLjD6ohPQ52oud7Lt7OhmoqH3PO918l0o6bhOpX0WPh40uOLP7rgxGGuj4j2BGVAheKsHJTFwAc%2bfgGpkNga07PT%2bPZmv65daHh4QpH1xGr8Zv2GoneRtlimBwEqiW8o
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=IDfCSkxkYrezORWwEVoWqZxblf7koxuZLT3LvaCB1gynA6SuJT%2fGz0bItB61LSJ5vLjD6ohPQ52oud7Lt7OhmoqH3PO918l0o6bhOpX0WPh40uOLP7rgxGGuj4j2BGVAheKsHJTFwAc%2bfgGpkNga07PT%2bPZmv65daHh4QpH1xGr8Zv2GoneRtlimBwEqiW8o
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=IDfCSkxkYrezORWwEVoWqZxblf7koxuZLT3LvaCB1gynA6SuJT%2fGz0bItB61LSJ5vLjD6ohPQ52oud7Lt7OhmoqH3PO918l0o6bhOpX0WPh40uOLP7rgxGGuj4j2BGVAheKsHJTFwAc%2bfgGpkNga07PT%2bPZmv65daHh4QpH1xGr8Zv2GoneRtlimBwEqiW8o
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/cassettes/test_signals/test_signal_basset_disabled.yaml
+++ b/noggin/tests/unit/cassettes/test_signals/test_signal_basset_disabled.yaml
@@ -1,0 +1,729 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:25 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=oc4pssLDD3boowP5HK1fw0Oz72VQKQ%2fkGWyOQUI1oZAxmEa3oA%2f%2f6cZzeJCTUbfxxysLIECQ7r8POyQJ32kYai%2bpQwQss1D38OoouydIxDl1oSt07CyJD0WgzNJvS9R6PrY%2fuPiKgux80e8UErJEzOYOf8ZZfrPCat26U%2fM6VNzl82s%2b4lT0ZcU1fuX1qm6P;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oc4pssLDD3boowP5HK1fw0Oz72VQKQ%2fkGWyOQUI1oZAxmEa3oA%2f%2f6cZzeJCTUbfxxysLIECQ7r8POyQJ32kYai%2bpQwQss1D38OoouydIxDl1oSt07CyJD0WgzNJvS9R6PrY%2fuPiKgux80e8UErJEzOYOf8ZZfrPCat26U%2fM6VNzl82s%2b4lT0ZcU1fuX1qm6P
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:58:25Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oc4pssLDD3boowP5HK1fw0Oz72VQKQ%2fkGWyOQUI1oZAxmEa3oA%2f%2f6cZzeJCTUbfxxysLIECQ7r8POyQJ32kYai%2bpQwQss1D38OoouydIxDl1oSt07CyJD0WgzNJvS9R6PrY%2fuPiKgux80e8UErJEzOYOf8ZZfrPCat26U%2fM6VNzl82s%2b4lT0ZcU1fuX1qm6P
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU30/bQAz+V6K87KWUJLQFJiGt2xhj0wCJ0gcGqpw7N7k1ucvuR2mH+N/nu6Tt
+        kBg81flsf/Z9tvsYazSusvH76PFfk0n6+Rl/dnW9jm4M6vi+F8VcmKaCtYQaX3ILKayAyrS+m4AV
+        yJR5KVjlv5BZVoFp3VY1McENaqOkt5QuQIo/YIWSUO1wIdGS7zngPK1PV0asgDHlpPXfC503Wkgm
+        GqjArTrICrZA26hKsHWHUkDbUfdhTLnhnIPZmOS4NuWZVq65nF+5/DuujcdrbC61KIQ8lVavWzEa
+        cFL8dih4eB/PhunwIEn22FE22EtThL1jhNHeMBsOkiSbj2BwEBJ9y1T+QWmOq0boIECgyJIsSQ7T
+        wzQdHmXD2000SWibB85KkAW+Fogrq4GDBR/0GM9mORgcDWYz+o7H42/lovwyZ/Xxkn86Lm/P0iZf
+        fLycJPzr9c3ATU+nk+l4fBI/3bcPrkFCgRzDi31VJk+4n3GPjMJLZLzVDcP0ODuRqiCNvGXR2NBW
+        pQgxJVZV4NjPhdyntsrgrEG0cOD9gCuomwr7TNWbJzGQSgoG1XYn29CLy7Oz84v+5PR6EkJLVSMX
+        muarum73PbQforeybzblDTK3Gek2uRBcujqnJfF4OhwlNNPkeBictD9MYxijFfX/J2TaKW8vxL1G
+        WoglyueHGPCGjhj1En2Hc7pF9I8HM9usFMFWuw26wLWFfIfV6Oup+SzML1D7PSZG0/4B+BZ9Y7tJ
+        B+cbg36i1CVUzjfbqRaKGUMbZNpttOsmuB9ASyELH9A9L55SBRLvhzCm83SpYW+vzqMuIGrlih7A
+        RFLZyNBu9qK50sTJI9qahoaQi0rYdfAXDjRIi8j70dgYVxN7FNTT70zkiZctcS/K+tnByFdmivuy
+        KV1y6gVpr+kxbtNmXYJvrE15CudC3DWExYvHnCOPvGrRXavFXRwEQq2VH7V0VeX/P/jO3i6mJwBO
+        fT7bSa/uru6gf9Snun8BAAD//wMAf5NLDNoFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oc4pssLDD3boowP5HK1fw0Oz72VQKQ%2fkGWyOQUI1oZAxmEa3oA%2f%2f6cZzeJCTUbfxxysLIECQ7r8POyQJ32kYai%2bpQwQss1D38OoouydIxDl1oSt07CyJD0WgzNJvS9R6PrY%2fuPiKgux80e8UErJEzOYOf8ZZfrPCat26U%2fM6VNzl82s%2b4lT0ZcU1fuX1qm6P
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=oDGWAnyFeZ1uHoohsB%2bzb0JzduzndV9smvys3RaWmsuksFG5pRaN8Wd%2fayLs427lFS3s6zrooDabWKXMWOyBxSgddPQTlwqDBwpklBWitj5Wz7BLF%2fFLO%2b1m3yIE3%2f2ouPRJIZrRVEmD0qgPvzjRKYvfKdStIcu%2feDVpuEfv6g%2fWDlzOBqYYTbkkFwB7vWYH;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oDGWAnyFeZ1uHoohsB%2bzb0JzduzndV9smvys3RaWmsuksFG5pRaN8Wd%2fayLs427lFS3s6zrooDabWKXMWOyBxSgddPQTlwqDBwpklBWitj5Wz7BLF%2fFLO%2b1m3yIE3%2f2ouPRJIZrRVEmD0qgPvzjRKYvfKdStIcu%2feDVpuEfv6g%2fWDlzOBqYYTbkkFwB7vWYH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oDGWAnyFeZ1uHoohsB%2bzb0JzduzndV9smvys3RaWmsuksFG5pRaN8Wd%2fayLs427lFS3s6zrooDabWKXMWOyBxSgddPQTlwqDBwpklBWitj5Wz7BLF%2fFLO%2b1m3yIE3%2f2ouPRJIZrRVEmD0qgPvzjRKYvfKdStIcu%2feDVpuEfv6g%2fWDlzOBqYYTbkkFwB7vWYH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUXW/TMBT9K1FeeOm6JGvKhjSJSsA2PlZgG0IgVN3Yt6mpYwfb6Vqm/Xeu7bTd
+        0ARPuT730+ce5y41aDvp0hfJ3UOTKfp8T191TbNJbiya9McgSbmwrYSNggafcgslnABpo+8mYDUy
+        bZ8K1tVPZI5JsNHtdJsS3KKxWnlLmxqU+A1OaAVyjwuFjnyPgc6X9enaijUwpjvl/HlpqtYIxUQL
+        Erp1DznBluhaLQXb9CgFxIn6g7WLbc052K1Jjiu7ODO6a6fzj131DjfW4w22UyNqoV4rZzaRjBY6
+        JX51KHi4Hy/KvDzKsgN2XIwO8hzh4ARhfFAW5SjLivkYRkch0Y9M7W+14bhuhQkEhBJFVmR5lpd5
+        Xh4X42/baKLQtbecLUDVuAvMnufP/wrEtTPAwYEPuktnswosjkezGZ3TyeStWC7ezL+df3HVVzm5
+        Xp6cf87k9L38/OYm/zRJ73/EizagoEaO4aa+G1On3O92QEbtqbHe6pdgB5ydKl0TN95yaF3UhVih
+        eiykgDcgZOTLQy9xDU0rcch0E9xSUyG7QBmDDiuhDukWi+DsBFddU9GqvC8vxxkxm52UW+e+bkBs
+        ZHWnyIda2U0Wx7icnp1dXA6vX19dh9CFbpALQ3LRPQmHHjrcF6//NQt1YqC0Euy/nUh8zGDQgBPN
+        E+st43qV7QmXmi0pak7vEP2kYGdbORHsTLdFl7hxUO2xlp4/mhXyB9kN+ivo+SzsNTT3uqY4G38I
+        nkJP7V4BwfkfAdxT6gpk56/TLyQ0s5aUZaM63aYN7lswSqjaB/RUpV+oA/HxQVjbe/rUoOOPF0kf
+        kMQNJLdgE6VdYkmzg2SuDdXkCUmqJV4rIYXbBH/dgQHlEPkwmVjbNVQ9CZyYZzbxhVex8CAphsXR
+        2Hdmmvu2Ob3s3BMSX9ddGtNmfYIfLKbch2dEtRsIylGdlJ4ONEab/uz/Hnxv70TpqwCnqR6pxHO5
+        7zIaHg+pyx8AAAD//wMA84LUN9gFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=oDGWAnyFeZ1uHoohsB%2bzb0JzduzndV9smvys3RaWmsuksFG5pRaN8Wd%2fayLs427lFS3s6zrooDabWKXMWOyBxSgddPQTlwqDBwpklBWitj5Wz7BLF%2fFLO%2b1m3yIE3%2f2ouPRJIZrRVEmD0qgPvzjRKYvfKdStIcu%2feDVpuEfv6g%2fWDlzOBqYYTbkkFwB7vWYH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=proOhvDuD4wMv2kUHQLe4Y9IVc1mnxKfuma%2bnz7OLHzNd0ERqyQjrCjvm8eA5Xs9G3XiX%2fiALqo8b5OPun685jt9mujm2TcNusgVtSHqTcqzXr8emh6%2fZzjJ4Zyk7r7RXbsEmiXTJzcOAI2MFDtIeyovuYTTJHWTckUITGXwaMQCucRgVYNXbumDwd6NYfOi;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=proOhvDuD4wMv2kUHQLe4Y9IVc1mnxKfuma%2bnz7OLHzNd0ERqyQjrCjvm8eA5Xs9G3XiX%2fiALqo8b5OPun685jt9mujm2TcNusgVtSHqTcqzXr8emh6%2fZzjJ4Zyk7r7RXbsEmiXTJzcOAI2MFDtIeyovuYTTJHWTckUITGXwaMQCucRgVYNXbumDwd6NYfOi
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=proOhvDuD4wMv2kUHQLe4Y9IVc1mnxKfuma%2bnz7OLHzNd0ERqyQjrCjvm8eA5Xs9G3XiX%2fiALqo8b5OPun685jt9mujm2TcNusgVtSHqTcqzXr8emh6%2fZzjJ4Zyk7r7RXbsEmiXTJzcOAI2MFDtIeyovuYTTJHWTckUITGXwaMQCucRgVYNXbumDwd6NYfOi
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:26 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=proOhvDuD4wMv2kUHQLe4Y9IVc1mnxKfuma%2bnz7OLHzNd0ERqyQjrCjvm8eA5Xs9G3XiX%2fiALqo8b5OPun685jt9mujm2TcNusgVtSHqTcqzXr8emh6%2fZzjJ4Zyk7r7RXbsEmiXTJzcOAI2MFDtIeyovuYTTJHWTckUITGXwaMQCucRgVYNXbumDwd6NYfOi
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:58:27 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/cassettes/test_signals/test_signal_basset_failed.yaml
+++ b/noggin/tests/unit/cassettes/test_signals/test_signal_basset_failed.yaml
@@ -1,0 +1,729 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:39 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=8S3Z0%2fqPy16X2ghA%2f%2fyIZy4Of2VfkwfUB5X0kNT%2frmjpO2Qh08lP9zxKNQH92TEn%2ffub4HfMmJqmem8Uk21xXqkhgEALewdUXyqvB4QjAP24rd45mUeiy%2bk4RcMAnb0Dg%2bkW3c2xafvjrXjvTbQV7NI8Z7pGxbERmAi8M%2bWUsk443BCRAHTxO70xgbRJ5j63;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8S3Z0%2fqPy16X2ghA%2f%2fyIZy4Of2VfkwfUB5X0kNT%2frmjpO2Qh08lP9zxKNQH92TEn%2ffub4HfMmJqmem8Uk21xXqkhgEALewdUXyqvB4QjAP24rd45mUeiy%2bk4RcMAnb0Dg%2bkW3c2xafvjrXjvTbQV7NI8Z7pGxbERmAi8M%2bWUsk443BCRAHTxO70xgbRJ5j63
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:39 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T12:28:39Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8S3Z0%2fqPy16X2ghA%2f%2fyIZy4Of2VfkwfUB5X0kNT%2frmjpO2Qh08lP9zxKNQH92TEn%2ffub4HfMmJqmem8Uk21xXqkhgEALewdUXyqvB4QjAP24rd45mUeiy%2bk4RcMAnb0Dg%2bkW3c2xafvjrXjvTbQV7NI8Z7pGxbERmAi8M%2bWUsk443BCRAHTxO70xgbRJ5j63
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU2W7aQBT9FcsvfQFizBKoFKm0TWlaNUQN4SFNhK5nLmaKPePOwlKUf+8sBhop
+        Sp64Pnc/9wz7WKIyhY7fR/v/TcLtz6/4synLXXSnUMaPjSimTFUF7DiU+JKbcaYZFCr47jyWIxHq
+        pWCR/UaiSQEquLWoYgtXKJXgzhIyB87+gmaCQ3HCGUdtfc8B48q6dKHYFggRhmv3vZJZJRknrIIC
+        zLaGNCMr1JUoGNnVqA0IE9UfSi0PNRegDqZ13KrlWApTTRY3JvuOO+XwEquJZDnjl1zLXSCjAsPZ
+        H4OM+v2SrIedbJE0ySAdNttthGYG0Gv20l43SdJFH7odn+hGtu03QlLcVkx6AnyJNEmT5Lx93k7T
+        QWdwf4i2FOpqQ8kSeI6vBeJWS6CgwQXt4/k8A4X97nxuv+PR6Fta/vyyIOVwTT8Nl/fjdpWtPk6m
+        Cf16e9c1s8vZdDYaXcRPj2HhEjjkSNFv7LoSfkHdjRvWyB1Fyln1MVSDkgsucsuRszQq7ccyjHJT
+        ZpZeV6Ld6yeWjWQ48M4SWOFxX/cDbqGsCmwRUXq3CrQcJWUPRSR6vjQrX6BiGKhYihIpk/bYoh79
+        zEFnvktQ7WtTFcIuoZZYhNnOMsbPLJPLwz6niQ/EE+CCMwLF8eWEha4n4/HVdWt6eTs9nv6g1jdC
+        c7ZG/vwheryyjxjlGt0UC/sW0e0Lan6QlIW1NAd0hTsN2Qkr0S0tFnN/P1/a6dhWVOEPwDHudjxd
+        2jvfOPSTTV1DYdywNTO+mVJWQSqoUe8q796A5IznLqBeL57ZDvamP5hStadO9bq9uYrqgCjcLNqA
+        irjQkbLabEQLIW1NGlnVVFYbGSuY3nl/bkAC14i0FY2UMqWtHnn25DsVucLrULgRpa2003ediaCu
+        bbuTJG1HSHhN+zikzesEN1hIefLPxdYuwWstHlGKNHKsRQ+Bi4fYE4RSCqc3borC/X/Qk30UhSsA
+        1M75TA+O3VPfbmvQsn3/AQAA//8DAFBFasvaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:39 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8S3Z0%2fqPy16X2ghA%2f%2fyIZy4Of2VfkwfUB5X0kNT%2frmjpO2Qh08lP9zxKNQH92TEn%2ffub4HfMmJqmem8Uk21xXqkhgEALewdUXyqvB4QjAP24rd45mUeiy%2bk4RcMAnb0Dg%2bkW3c2xafvjrXjvTbQV7NI8Z7pGxbERmAi8M%2bWUsk443BCRAHTxO70xgbRJ5j63
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:39 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:39 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=pU8S5l2Dc8aNWvd74lwMdiCspNZUCT38Uh3TqkFlD9sDyb4BUK06AMzs%2b9zdJtT0eEZYrh3h8Lj92Vbxb%2bpT2nhc%2bRUDxGGMJuh%2fXs9rwskwug7y1%2bW%2bjp8m217mU%2bitUEF98oggX5N1j%2fn6m5Ayz6aAZ3ZtKGBAnqnml%2bgMZXjKUekDtGMa5U0w080%2boYtL;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pU8S5l2Dc8aNWvd74lwMdiCspNZUCT38Uh3TqkFlD9sDyb4BUK06AMzs%2b9zdJtT0eEZYrh3h8Lj92Vbxb%2bpT2nhc%2bRUDxGGMJuh%2fXs9rwskwug7y1%2bW%2bjp8m217mU%2bitUEF98oggX5N1j%2fn6m5Ayz6aAZ3ZtKGBAnqnml%2bgMZXjKUekDtGMa5U0w080%2boYtL
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pU8S5l2Dc8aNWvd74lwMdiCspNZUCT38Uh3TqkFlD9sDyb4BUK06AMzs%2b9zdJtT0eEZYrh3h8Lj92Vbxb%2bpT2nhc%2bRUDxGGMJuh%2fXs9rwskwug7y1%2bW%2bjp8m217mU%2bitUEF98oggX5N1j%2fn6m5Ayz6aAZ3ZtKGBAnqnml%2bgMZXjKUekDtGMa5U0w080%2boYtL
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUyW7bMBD9FUGXXhxbkmPHKRCgBpqtS5JmQ5EiMEbUWGZNkSoXx26Qf++Qku2k
+        SJuThm9WvnnUY6zROGHj99Hjc5NJ+vyIP7qqWkU3BnV834nigptawEpCha+5ueSWgzCN7yZgJTJl
+        XgtW+U9klgkwjduqOia4Rm2U9JbSJUj+GyxXEsQW5xIt+V4Czpf16crwJTCmnLT+PNd5rblkvAYB
+        btlClrM52loJzlYtSgHNRO3BmNm65hTM2iTHlZkda+Xq8+mFyz/jyni8wvpc85LLQ2n1qiGjBif5
+        L4e8CPdL8gH282myw0bZ/k6aIuzkAIOdQTbYTZJsOoTdfkj0I1P7B6ULXNZcBwJCiSzJkjRJB2mW
+        jfr7d+tootDWDwWbgSxxE5jspXt/BeLSaijAgg96jCeTHAwOdycTOsfj8ad+dXk0vTu5tfl3Mb6e
+        759cJuL8i7g8ukm/jeOn++aiFUgoscBwU9+NyYPC77ZDRumpMd5ql2A6BTuQqiRuvGXR2DCOUISY
+        GQoRavRyLns0ziw4K+ANHOp+wCVUtcAuU9X6KgykkpyB2GixCT07Pz4+PeteH15dh9CZqrDgmvaq
+        2ml7HuqF6A3da4W8Ucy1q9wml7yQrspJHB5PB8OEdpnsj4KTdMM0hvVZXv17M6bZ7uZluP8VLfkC
+        5csHGHBpWsKFYnPyTekdoicAzGQtJ4Ktdmt0jisL+Rar6fmjXmDxLLtCP4eaTsJeQ0uva4ozzQ/B
+        j+4H3iogON8QwBOlLkA4f4mWzdDMGFKWadRpV3VwP4CWXJY+oL12fEsdiNSv3JjW06YGHV+cRm1A
+        1NAYPYCJpLKRIc12oqnSVLOISE01LSfngttV8JcONEiLWHSjsTGuoupR4ES/M5EvvGgKd6Ksm/WH
+        vjNThW+b9pMk9YQ0r+sxbtImbYIfrEl5Cs+IalcQBCmdEJ4O1Frp9uz/HsXW3sjTV4GCpnqhTM/l
+        tstud9SlLn8AAAD//wMA8Dh5PdgFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pU8S5l2Dc8aNWvd74lwMdiCspNZUCT38Uh3TqkFlD9sDyb4BUK06AMzs%2b9zdJtT0eEZYrh3h8Lj92Vbxb%2bpT2nhc%2bRUDxGGMJuh%2fXs9rwskwug7y1%2bW%2bjp8m217mU%2bitUEF98oggX5N1j%2fn6m5Ayz6aAZ3ZtKGBAnqnml%2bgMZXjKUekDtGMa5U0w080%2boYtL
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=4n03XU%2f7pnlFS7s9iG2arzez6xrfwR1xJpbpbTZcpW0jvW%2f9iUUHNP87KigxD%2bawi%2faLHpsWnyuzAPbRROJ9EQ6IQhThbGo08HehHg%2bsRaACraT94QKY%2fNI0hTIn6M32G02Vp%2flChC6aK3G516TZHqUktbaMptOh3Rqk7jXWiKzilkQtpAWNjoLuxQ9Hc86x;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=4n03XU%2f7pnlFS7s9iG2arzez6xrfwR1xJpbpbTZcpW0jvW%2f9iUUHNP87KigxD%2bawi%2faLHpsWnyuzAPbRROJ9EQ6IQhThbGo08HehHg%2bsRaACraT94QKY%2fNI0hTIn6M32G02Vp%2flChC6aK3G516TZHqUktbaMptOh3Rqk7jXWiKzilkQtpAWNjoLuxQ9Hc86x
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=4n03XU%2f7pnlFS7s9iG2arzez6xrfwR1xJpbpbTZcpW0jvW%2f9iUUHNP87KigxD%2bawi%2faLHpsWnyuzAPbRROJ9EQ6IQhThbGo08HehHg%2bsRaACraT94QKY%2fNI0hTIn6M32G02Vp%2flChC6aK3G516TZHqUktbaMptOh3Rqk7jXWiKzilkQtpAWNjoLuxQ9Hc86x
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=4n03XU%2f7pnlFS7s9iG2arzez6xrfwR1xJpbpbTZcpW0jvW%2f9iUUHNP87KigxD%2bawi%2faLHpsWnyuzAPbRROJ9EQ6IQhThbGo08HehHg%2bsRaACraT94QKY%2fNI0hTIn6M32G02Vp%2flChC6aK3G516TZHqUktbaMptOh3Rqk7jXWiKzilkQtpAWNjoLuxQ9Hc86x
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 12:28:40 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[active].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[active].yaml
@@ -1,0 +1,1179 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:31Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfUmCnRtQCalpS1OECqiEPFBQNN4dO9vYu+5eQtyIf+9enKRI
+        CJ6yPjNzZvbM2WxjicqUOv4Ybf8/Em5/fsVfTVU10Z1CGT92opgyVZfQcKjwtTDjTDMoVYjdeaxA
+        ItRrySL7jUSTElQIa1HHFq5RKsHdScgCOPsLmgkO5QFnHLWNvQSMo3XlQrENECIM1+57JbNaMk5Y
+        DSWYTQtpRlaoa1Ey0rSoTQgTtR9KLXecOajd0QZu1XIqhamv8xuTXWKjHF5hfS1Zwfg517IJYtRg
+        OPtjkFF/vzEMyGCcY5ec9IfdNEXonqQ57Y76o2GS9PMxDAe+0I1s2z8JSXFTM+kF8BT9pJ8kx+lx
+        mo5Gg+R+l20l1PUTJUvgBb6ViBstgYIGl7SNF4sMFI6Hi4X9jieTy2b181tOqtM1/XK6vJ+mdbb6
+        fD1L6Pfbu6GZn89n88nkLH5+DBeugEOBFP2NXVfCz6jbccceCieRcqd2GapDyRkXhdXInTQq7ccq
+        hUXUEsvScxxljB/ZsZY+WAELsOf9hBuo6hJ7RFS7KxHggjMC5d6TIfXqejq9uOrNzm9nPnUpKqRM
+        2v2KdtojBx357L3sO6e8Q2balR6KC0a5qTJrEoeno3Fid5qcpj5o/UMk+jVqVr2yoTRsSIUt71+I
+        eYu0YGvkLx+ix2v7iFGu0U2Y27eI7vKgFjtLWVhLs0NX2GjIDliFrp/IF35/ntr52DKq8AfgRnSD
+        HTbtg+8s+tmWrqE0bthWNd9MKesgFdyom9qHn0ByxguX0F4vntsOVrwfTKk20pZ6395cRG1CFOSK
+        nkBFXOhIWW92olxIy0kj65raLiFjJdONjxcGJHCNSHvRRClTWfbIqyc/qMgRrwNxJ+r3+oOx60wE
+        dW3TQZKkTpDwmrZxKFu0BW6wUPLsn4vlrsAbL55QijRyqkUPQYuH2AuEUgq3am7K0v1/0MN5b0xH
+        ANTO+cKTTt1D32HvpGf7/gMAAP//AwDR9/lA2gUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:31 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207cMBD9lSgvfdlLsjegElJXKjfRdik3VVRoNbEnWXcdO7Ud2AXx7x07WRYq
+        Wp4yPnP1meM8xgZtLV38MXp8aTJFn5/x57os19GVRRPfdqKYC1tJWCso8S23UMIJkLbxXQWsQKbt
+        W8E6+4XMMQm2cTtdxQRXaKxW3tKmACUewAmtQG5xodCR7zVQ+7I+XVuxAsZ0rZw/L01WGaGYqEBC
+        vWohJ9gSXaWlYOsWpYBmovZg7WJTMwe7MclxYRdHRtfVLD+rs1NcW4+XWM2MKIQ6UM6sGzIqqJX4
+        XaPg4X4TGLLhJMcu2x2MummK0N1Nc94dD8ajJBnkExgNQ6Ifmdrfa8NxVQkTCAglBskgSZN0nKbj
+        8TC92UQTha6652wBqsDnwGQn3fkrEFfOAAcHPugxns8zsDgZzed0jqfT04fl+WF+c3ztsh9yernc
+        Oz5P5OyLPD+8Sr9P46fb5qIlKCiQY7ip78bUPve77ZBReGqst9ol2A5n+0oXxI23HFrX6ELcoXot
+        pICXIGSAQslPuIKykthjugxuqamQXaBsgvqZUH26xSI4a8FVXWa0Ku9Lx5OEmE320o1zWzcgtmH1
+        WZEvtfI8WTPGt9nR0cm33uXBxWUIXegSuTAkF92S0PdQf1u8+N8s1ImB0kqwdzuR+JjBoAEnyn+v
+        V9mWcKnZkqJyeofoJwU738iJYGfqDbrEtYNsi1X0/NHcIX+RXaK/gs7nYa+hudc1xdnmh+Ap9NRu
+        FRCc7wjgiVLvQNb+Ou1CQjNrSVm2UadbV8F9D0YJVfiAlqr4mjoQH1+Fta2nTQ06PjuJ2oCo2UB0
+        DzZS2kWWNNuJcm2oJo9IUhXxmgkp3Dr4ixoMKIfIe9HU2rqk6lHgxHywkS981xTuRIPeYDjxnZnm
+        vm06TJLUE9K8rse4SZu3CX6wJuUpPCOqXUJQjqql9HSgMdq0Z//34Fv7WZS+CnCa6pVKPJfbLqPe
+        bo+6/AEAAP//AwDRSoPR2AUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "active"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '140'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW8TMRD9K5YvXKLNbtK0wIlKoKqHFiQKB2gVzdrOxoo/Vh47YRXlvzP2bhu4
+        tDf7vTczz89z5EFhMpF/ZMd/jxtAjBATOh8VIb85iKj3ij/NGO/o4BzYkficrB0KbkGbAskMfVJ/
+        wPZGVcLbQhvfaYdbZUbRvNVu3gJuC5m0dMm2KhSuWV3WF3Vdf2ieyXPfgqArwA+kgnzfhbYP2gnd
+        g3lxNtq4/3pzc3tfPXz5/lCkW2+V1EGJ6MMwOsnQ/Ny8e80LTRLgvNPizUkUoggKovYu6km5qBd1
+        fdVcNc1qtWx+FZ1DEMInF40XO1JtwKDKTgHXPX3EwYf8/hjSM7pTQ4T2jFmV7frNugs+9WUQJZEo
+        HeRPJxLswaRsYIqwlCBCpzCLjzwOfaEPEJx2XRZMj+M/qQm94E4jTsxUmsnrb7dsErAxM3YAZLQ1
+        DJWLM7bxgXpKRkvQUxKtNjoOhe8SBHBRKVmxa8RkqTsVhb0K75Dlxvux8YwtqsXyMk8WXuaxzbKu
+        G7pKiFDWdSxbTwXZ2FhyOpVloTdD+Wt+56XeaCVZzoY9jnE8cp4zUiH4/OUuGUPXsnPT+WW3cg+Q
+        ZPW/z84Bn0dfVO8rGv0XAAD//wMAl2Nr51sDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbW/UOBD+K1G+3JftNtk3ClIlVjooiDsKpa0QCK0m9iTrW8fOeZx2l6r/nbGd
+        7baIOz5l/Myrn3niu9wh9drnL7K7x6Yw/Pma/9m37S67InT5t1GWS0Wdhp2BFn/lVkZ5BZqS7ypi
+        DQpLvwq21T8ovNBAye1tlzPcoSNrgmVdA0Z9B6+sAX3AlUHPvqdAH8qGdEtqC0LY3vhw3riqc8oI
+        1YGGfjtAXokN+s5qJXYDygFpouFAtN7XrIH2Jjs+0frM2b47rz/01TvcUcBb7M6dapR5ZbzbJTI6
+        6I36t0cl4/0WMBXTRY1H4mQyOypLhKOTspZH88l8VhSTegGzaUwMI3P7W+skbjvlIgGxxKSYFGVR
+        zstyPp+WX/bRTKHvbqVYg2nwIbB4Vj77KRC33oEEDyHoLl+tKiBczFYrPufL5bvvm4vX9Zc31776
+        rJeXm+dvLgp9/pe+eH1Vflzm99/SRVsw0KDEeNPQTZhTGXY7YqMJ1FCwhiXQSIpTYxvmJlgeycdx
+        mFTywHsz1qehQXh1g0k0bJinKot4C0pHKPZ7iVtoO41jYdvo1pa70Bp1CjqulDnmK66js1fS9G3F
+        ewy+cr4omPbiebl3HupGhBLlD3J9LKSHydIY78/Pzt6+H1+++nQZQ9e2Rakca8kODB0H6PhQvPm/
+        WbiTAGONEr/txCQKh1EgXrX/vXtDwza0FRuOqvknxTAp0GqvNYa96/foBnceqgPW8duA7gblo+wW
+        wxVsvYpLj82D6DmO0msRKAzUHuQRnb9Rxz2n3oDuw3WGhcRmRCw7StL1uy66b8EZZZoQMFCVX3MH
+        5uNvRTR4htQo8g9vsyEgSxvIboEy1mBGLOhRVlvHNWXGkuqY10pp5XfR3/TgwHhEOc6WRH3L1bPI
+        ifuDslD4JhUeZZPxZLoInYWVoW05LYoyEJJ+vbs8pa2GhDBYSrmP/xjXbiEqx/RaBzrQOeuGc3ha
+        5MF+EGWoApKneqKSwOWhy2x8MuYuPwAAAP//AwAaMO+G9QUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[active].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[active].yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:28 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=l9WnK9TmrUPUxxCkxTGK9Agth0pXJUOZkqbML6OvztdeUO1VHNmvy1tGRBwzC3FMK27jL4cu6qPaYYU%2bVN8OsALiJWW%2b0PUmsA6IW7Ztrvhs%2bU1zZJesJ0KQFO8HAU8slsqf%2bpzhvB6kstB%2bIzSjFN8FdfylYcLNqS9u6OPsWKxs%2fKXPkOZIJxjHezhSy0nA;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      - ipa_session=MagBearerToken=l9WnK9TmrUPUxxCkxTGK9Agth0pXJUOZkqbML6OvztdeUO1VHNmvy1tGRBwzC3FMK27jL4cu6qPaYYU%2bVN8OsALiJWW%2b0PUmsA6IW7Ztrvhs%2bU1zZJesJ0KQFO8HAU8slsqf%2bpzhvB6kstB%2bIzSjFN8FdfylYcLNqS9u6OPsWKxs%2fKXPkOZIJxjHezhSy0nA
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:28 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:31Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T12:46:28Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      - ipa_session=MagBearerToken=l9WnK9TmrUPUxxCkxTGK9Agth0pXJUOZkqbML6OvztdeUO1VHNmvy1tGRBwzC3FMK27jL4cu6qPaYYU%2bVN8OsALiJWW%2b0PUmsA6IW7Ztrvhs%2bU1zZJesJ0KQFO8HAU8slsqf%2bpzhvB6kstB%2bIzSjFN8FdfylYcLNqS9u6OPsWKxs%2fKXPkOZIJxjHezhSy0nA
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU207bQBD9FcsvfUmCnRtQCalpS1OECqiEPFBQNN4dO9vYu+5eQtyIf+9enKRI
-        CJ6yPjNzZvbM2WxjicqUOv4Ybf8/Em5/fsVfTVU10Z1CGT92opgyVZfQcKjwtTDjTDMoVYjdeaxA
-        ItRrySL7jUSTElQIa1HHFq5RKsHdScgCOPsLmgkO5QFnHLWNvQSMo3XlQrENECIM1+57JbNaMk5Y
-        DSWYTQtpRlaoa1Ey0rSoTQgTtR9KLXecOajd0QZu1XIqhamv8xuTXWKjHF5hfS1Zwfg517IJYtRg
-        OPtjkFF/vzEMyGCcY5ec9IfdNEXonqQ57Y76o2GS9PMxDAe+0I1s2z8JSXFTM+kF8BT9pJ8kx+lx
-        mo5Gg+R+l20l1PUTJUvgBb6ViBstgYIGl7SNF4sMFI6Hi4X9jieTy2b181tOqtM1/XK6vJ+mdbb6
-        fD1L6Pfbu6GZn89n88nkLH5+DBeugEOBFP2NXVfCz6jbccceCieRcqd2GapDyRkXhdXInTQq7ccq
-        hUXUEsvScxxljB/ZsZY+WAELsOf9hBuo6hJ7RFS7KxHggjMC5d6TIfXqejq9uOrNzm9nPnUpKqRM
-        2v2KdtojBx357L3sO6e8Q2balR6KC0a5qTJrEoeno3Fid5qcpj5o/UMk+jVqVr2yoTRsSIUt71+I
-        eYu0YGvkLx+ix2v7iFGu0U2Y27eI7vKgFjtLWVhLs0NX2GjIDliFrp/IF35/ntr52DKq8AfgRnSD
-        HTbtg+8s+tmWrqE0bthWNd9MKesgFdyom9qHn0ByxguX0F4vntsOVrwfTKk20pZ6395cRG1CFOSK
-        nkBFXOhIWW92olxIy0kj65raLiFjJdONjxcGJHCNSHvRRClTWfbIqyc/qMgRrwNxJ+r3+oOx60wE
-        dW3TQZKkTpDwmrZxKFu0BW6wUPLsn4vlrsAbL55QijRyqkUPQYuH2AuEUgq3am7K0v1/0MN5b0xH
-        ANTO+cKTTt1D32HvpGf7/gMAAP//AwDR9/lA2gUAAA==
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9tKWNC2lTEJatyGGpgES0AcGqk7s09RrYme+9DLEf9+xnVKQ
+        EDzl+DtXf+dzHlONxlU2/Zw8vjSZpM/v9Lur621ya1CnD50k5cI0FWwl1PiWW0hhBVQm+m4DViJT
+        5q1gVfxBZlkFJrqtalKCG9RGSW8pXYIU/8AKJaHa40KiJd9rwPmyPl0ZsQHGlJPWn5e6aLSQTDRQ
+        gdu0kBVsibZRlWDbFqWAOFF7MGaxqzkHszPJcW0WZ1q55nJ+5YqfuDUer7G51KIU8lRavY1kNOCk
+        +OtQ8HC/7AjHRX887DIYH3X7fYRuURSj7mF+OMyyfD6C4SAk+pGp/VppjptG6EBAKJFneZYd5Vk/
+        H47y8d0umii0zZqzBcgS3wvEjdXAwYIPekxnswIMjoazGZ3TyeR8uVxM56w+XvFvx4u7s35TLL9e
+        3mT8x/Xt0E1PpzfTyeQkfXqIF65BQokcw419VyZPuN9xh4zSU2S81S7DdDg7kaokjrxl0dioD8Gl
+        qwui15foH44yYqM/OGqdK5Sv1RbwGkQVoNDvC26gbirsMVUH90LVyIWmZap2tAMPHfDnAu69rq7d
+        2D6cFMA0hkVYUb/LMQOppGBQPY8dZ7y4PDs7v+jdnF7fhFATV/r8HF4K9YPUShGJZoFV5OCgEPKA
+        NrkIzoYeMeoV+ivM6S2i5wPMbCcpgq12O3SJWwvFHqvRk6Lms7C/UN7rmCqa+APwU3uC9psOzg8W
+        /USpK6icv1VLa2hmDCnIRDXabRPca9BSyNIHtDykU+pA1P8SxrSeNjXo9uo8aQOSuNNkDSaRyiaG
+        tNlJ5kpTTZ6QOhpaYSEqYbfBXzrQIC0i7yUTY1xN1ZPAnv5kEl94FQt3kryXD0a+M1Pct+0PSC+e
+        kPiaHtOYNmsT/GAx5Sk8F6pdQ9BiOuEceeJZS+4jF/dpIAi1Vl6P0lWV/3/wvf2sDF8AOM35ShSe
+        3X3fYW/co77/AQAA//8DAAbYCcTaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:28 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=8fe5xr9fLIlJvw%2fUtBjYELe45VSEF2Uzt3rm%2fK2l%2fORm9k5bsDeRIxdCiiN1l09UzyZ4do9BMg1o%2bHATBHHqXUZvO9Iu4%2bgpwHbNHpate36zkqwP9IIQWm0IiQHtyz5fPDPosd%2f%2ffTv0kWSeAUANNZ47AqaqLaQiqNQ%2fsW1AuCuR53SWb4sRoGBUsmqSunA5
+      - ipa_session=MagBearerToken=l9WnK9TmrUPUxxCkxTGK9Agth0pXJUOZkqbML6OvztdeUO1VHNmvy1tGRBwzC3FMK27jL4cu6qPaYYU%2bVN8OsALiJWW%2b0PUmsA6IW7Ztrvhs%2bU1zZJesJ0KQFO8HAU8slsqf%2bpzhvB6kstB%2bIzSjFN8FdfylYcLNqS9u6OPsWKxs%2fKXPkOZIJxjHezhSy0nA
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=iTyL2187tYdr%2bFUK3zUIwnGirrlQQO0Ux%2b1n2sTmTPhy48kBmlBD72nK1TWh3p4SZVSv0Ii6w6w1jYThpcYr%2bFmGycq%2fZqY54Hmj3SMS9ixst9cpkY4dbRzdN5jqjXBt7C%2f7hB02NSLLG6gDvW6L1rRvN4w1MnlbZ27fpNeuEQ6GUOHOpN1VytiMhdRkskop;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      - ipa_session=MagBearerToken=iTyL2187tYdr%2bFUK3zUIwnGirrlQQO0Ux%2b1n2sTmTPhy48kBmlBD72nK1TWh3p4SZVSv0Ii6w6w1jYThpcYr%2bFmGycq%2fZqY54Hmj3SMS9ixst9cpkY4dbRzdN5jqjXBt7C%2f7hB02NSLLG6gDvW6L1rRvN4w1MnlbZ27fpNeuEQ6GUOHOpN1VytiMhdRkskop
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:31 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -399,7 +399,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      - ipa_session=MagBearerToken=iTyL2187tYdr%2bFUK3zUIwnGirrlQQO0Ux%2b1n2sTmTPhy48kBmlBD72nK1TWh3p4SZVSv0Ii6w6w1jYThpcYr%2bFmGycq%2fZqY54Hmj3SMS9ixst9cpkY4dbRzdN5jqjXBt7C%2f7hB02NSLLG6gDvW6L1rRvN4w1MnlbZ27fpNeuEQ6GUOHOpN1VytiMhdRkskop
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -409,20 +409,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU207cMBD9lSgvfdlLsjegElJXKjfRdik3VVRoNbEnWXcdO7Ud2AXx7x07WRYq
-        Wp4yPnP1meM8xgZtLV38MXp8aTJFn5/x57os19GVRRPfdqKYC1tJWCso8S23UMIJkLbxXQWsQKbt
-        W8E6+4XMMQm2cTtdxQRXaKxW3tKmACUewAmtQG5xodCR7zVQ+7I+XVuxAsZ0rZw/L01WGaGYqEBC
-        vWohJ9gSXaWlYOsWpYBmovZg7WJTMwe7MclxYRdHRtfVLD+rs1NcW4+XWM2MKIQ6UM6sGzIqqJX4
-        XaPg4X4TGLLhJMcu2x2MummK0N1Nc94dD8ajJBnkExgNQ6Ifmdrfa8NxVQkTCAglBskgSZN0nKbj
-        8TC92UQTha6652wBqsDnwGQn3fkrEFfOAAcHPugxns8zsDgZzed0jqfT04fl+WF+c3ztsh9yernc
-        Oz5P5OyLPD+8Sr9P46fb5qIlKCiQY7ip78bUPve77ZBReGqst9ol2A5n+0oXxI23HFrX6ELcoXot
-        pICXIGSAQslPuIKykthjugxuqamQXaBsgvqZUH26xSI4a8FVXWa0Ku9Lx5OEmE320o1zWzcgtmH1
-        WZEvtfI8WTPGt9nR0cm33uXBxWUIXegSuTAkF92S0PdQf1u8+N8s1ImB0kqwdzuR+JjBoAEnyn+v
-        V9mWcKnZkqJyeofoJwU738iJYGfqDbrEtYNsi1X0/NHcIX+RXaK/gs7nYa+hudc1xdnmh+Ap9NRu
-        FRCc7wjgiVLvQNb+Ou1CQjNrSVm2UadbV8F9D0YJVfiAlqr4mjoQH1+Fta2nTQ06PjuJ2oCo2UB0
-        DzZS2kWWNNuJcm2oJo9IUhXxmgkp3Dr4ixoMKIfIe9HU2rqk6lHgxHywkS981xTuRIPeYDjxnZnm
-        vm06TJLUE9K8rse4SZu3CX6wJuUpPCOqXUJQjqql9HSgMdq0Z//34Fv7WZS+CnCa6pVKPJfbLqPe
-        bo+6/AEAAP//AwDRSoPR2AUAAA==
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9tJL0pa2TEJapTFA2yjjpokJVSf2aerVsTPbgWaI/75jJ21B
+        QuMpx9+5+juf8xQbtJV08cfo6aXJFH1+xZ+roqijG4smvu9EMRe2lFArKPAtt1DCCZC28d0ELEem
+        7VvBOvuNzDEJtnE7XcYEl2isVt7SJgcl/oITWoHc40KhI99roPJlfbq2YgOM6Uo5f16brDRCMVGC
+        hGrTQk6wNbpSS8HqFqWAZqL2YO1qW3MJdmuS48quToyuyvnyosq+Ym09XmA5NyIX6lg5UzdklFAp
+        8adCwcP9kglOs3Q66jKYTrppitDNsmzcPRgcjJJksBzDaBgS/cjU/lEbjptSmEBAKDFIBkmapNN0
+        MBoPDu+20UShKx85W4HKcReYTCj4dSBunAEODnzQU7xYZGBxPFos6BzPZmdyvbpd3p3euuynnF2v
+        D08vEzn/Ji+/3KQ/ZvHzfXPRAhTkyDHc1Hdj6oj73XbIyD011lvtEmyHsyOlc+LGWw6ta3QhHlC9
+        FlLAK8FVVWREt8fTg3FC7KTDSXDahoedhla6QC4MbU23s/Q91Oe7cgUIGRwB+oQbKEqJPaaL4KbV
+        MoOBYSeKN8ib7sjbyWg3dFPyfH5ycnbeuz6+ut6GMlBaCfZuqNTEil2hbEbsZ0L1aSWrLRH71Jay
+        /1CjbEu41GxNAUt6h+gpArvYyolgZ6otusbaQbbHSnr+aB6Qv8gu0PfTy0XYa+jrdU1xtvkh+IX4
+        UfcKCM53BPBMqQ8gK09Oe8HQzFpSlm3U6eoyuB/BKKFyH9DSGd9SB9rYd2Ft62lTg44vzqI2IGro
+        ih7BRkq7yJJmO9FSG6rJI9JASZvPhBSuDv68AgPKIfJeNLO2Kqh6FDgxH2zkCz80hTvRoDcYjn1n
+        prlvmw5pFZ6Q5nU9xU3aok3wgzUpz+EZUe0CgmRVJaWnA43Rpj37vwff2zvl+SrAaapXSvJc7ruM
+        etMedfkHAAD//wMA4FLvVtgFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,7 +435,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=0D%2fdhBQqfmcaAC5cT0zwh0PvnWrLMPnF4zWfJIabOUj23tOLdiBf31zTG0jfZ%2beS8af%2bZY%2fjxzWS78lgv1pYkunpkuyQvaKHFAWvfzmwCkjtx3CpQuttI95aVi5zqyuMfsbC%2fv2zXBCMpqyRzK9WF1vFYEBEw5fMKMtkNnCXaHV3kxo9YG%2fDn70aK2weEIIg
+      - ipa_session=MagBearerToken=iTyL2187tYdr%2bFUK3zUIwnGirrlQQO0Ux%2b1n2sTmTPhy48kBmlBD72nK1TWh3p4SZVSv0Ii6w6w1jYThpcYr%2bFmGycq%2fZqY54Hmj3SMS9ixst9cpkY4dbRzdN5jqjXBt7C%2f7hB02NSLLG6gDvW6L1rRvN4w1MnlbZ27fpNeuEQ6GUOHOpN1VytiMhdRkskop
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -490,7 +490,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -541,13 +541,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=Pcf8Scbfal3zrWl7qK4axml122T%2f1YQnCG6zS2k%2fq%2bQB%2fBHerLwdoWdpI574oO91nkDLZSRDpLI8K%2beJPIiWfqxwDy3UnkklkU243aHA1e2LkN0%2bfCgcBUKr6bGSstUX0H2bVA%2bzfrZFdYsap%2fW13xbuWIOznh9SjX9WHBF4uC1J3B16VI5VdPHIQ%2fO%2fxznj;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -571,7 +571,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      - ipa_session=MagBearerToken=Pcf8Scbfal3zrWl7qK4axml122T%2f1YQnCG6zS2k%2fq%2bQB%2fBHerLwdoWdpI574oO91nkDLZSRDpLI8K%2beJPIiWfqxwDy3UnkklkU243aHA1e2LkN0%2bfCgcBUKr6bGSstUX0H2bVA%2bzfrZFdYsap%2fW13xbuWIOznh9SjX9WHBF4uC1J3B16VI5VdPHIQ%2fO%2fxznj
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -598,7 +598,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -627,7 +627,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      - ipa_session=MagBearerToken=Pcf8Scbfal3zrWl7qK4axml122T%2f1YQnCG6zS2k%2fq%2bQB%2fBHerLwdoWdpI574oO91nkDLZSRDpLI8K%2beJPIiWfqxwDy3UnkklkU243aHA1e2LkN0%2bfCgcBUKr6bGSstUX0H2bVA%2bzfrZFdYsap%2fW13xbuWIOznh9SjX9WHBF4uC1J3B16VI5VdPHIQ%2fO%2fxznj
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -637,15 +637,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RSTW8TMRD9K5YvXKLNbtK0wIlKoKqHFiQKB2gVzdrOxoo/Vh47YRXlvzP2bhu4
-        tDf7vTczz89z5EFhMpF/ZMd/jxtAjBATOh8VIb85iKj3ij/NGO/o4BzYkficrB0KbkGbAskMfVJ/
-        wPZGVcLbQhvfaYdbZUbRvNVu3gJuC5m0dMm2KhSuWV3WF3Vdf2ieyXPfgqArwA+kgnzfhbYP2gnd
-        g3lxNtq4/3pzc3tfPXz5/lCkW2+V1EGJ6MMwOsnQ/Ny8e80LTRLgvNPizUkUoggKovYu6km5qBd1
-        fdVcNc1qtWx+FZ1DEMInF40XO1JtwKDKTgHXPX3EwYf8/hjSM7pTQ4T2jFmV7frNugs+9WUQJZEo
-        HeRPJxLswaRsYIqwlCBCpzCLjzwOfaEPEJx2XRZMj+M/qQm94E4jTsxUmsnrb7dsErAxM3YAZLQ1
-        DJWLM7bxgXpKRkvQUxKtNjoOhe8SBHBRKVmxa8RkqTsVhb0K75Dlxvux8YwtqsXyMk8WXuaxzbKu
-        G7pKiFDWdSxbTwXZ2FhyOpVloTdD+Wt+56XeaCVZzoY9jnE8cp4zUiH4/OUuGUPXsnPT+WW3cg+Q
-        ZPW/z84Bn0dfVO8rGv0XAAD//wMAl2Nr51sDAAA=
+        H4sIAAAAAAAAA4RSwW7bMAz9FUGXXQLHcbK02GkFNhQ9tBuwboe1RUBLsiNElgxRSmYE+fdRspNs
+        l+0m8T0+ko88cq8wmsA/sOOfz1bvlbXQKfq98E+x6wb+NmM8amljVyuf44v363JVlovlTQbR5uh3
+        JDj9t65TUnslgvNDhuYpNJcXuQ60yUAOfVS/oOuNKoTrMtwAYoAQ0bowdgIiUGdnUHgFQTsb9NRo
+        VVZleVOVi2q1rm5/Zt7O173XVugezGWisd7Tl/v7h6fi+fO35zNVgHVWi/9SjWu1xa0yY//zWtt5
+        Dbg9u3RNzZH2X75ZBCFctME4sSNCAwZV8g9w05MFB+eTXvDxHN2pIUB9jXUqabtm03oX+1yDxo20
+        CORvJyLswcQ0ztRSTkGEVmEiH3kY+gwfwFtt20SYDOA/SIQ8ftSIEzKlJvDu6wObCGwckB0AGe2L
+        obJhxhrnSVMyWmlPu6q10WHIeBvBgw1KyYLdIcaO1CnJ75V/hywJ70fhGauKarlOlYWTqexiSebR
+        V0KAfK5j2mZKSI2NKadTvkuaGfIF8kcndaOVZMkb9jra8cp58kh579J+bDSGvnmH0/tyQEkDJLX6
+        10Ekg6+lV8VtQaV/AwAA//8DANS7CWFbAwAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -658,7 +658,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -686,7 +686,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=WrXDvqw3NeI2%2fHKj35DR%2fm9gtq%2fmT0w3%2fZaQxj86uA7QOeGhm6cyZ67XRwAaXw7slYUxdjiUlNOGJe8eJKvHUsNadohWNrHOTo8F8PCiJLNX%2fxNQVOq0%2bbrhGLXpKvPyuV2X48TL0fm2iMNVqwln7kpZ8PAnQoOYm4U5SSoCu8AiTXUmkO9Jdrd553uYR7cN
+      - ipa_session=MagBearerToken=Pcf8Scbfal3zrWl7qK4axml122T%2f1YQnCG6zS2k%2fq%2bQB%2fBHerLwdoWdpI574oO91nkDLZSRDpLI8K%2beJPIiWfqxwDy3UnkklkU243aHA1e2LkN0%2bfCgcBUKr6bGSstUX0H2bVA%2bzfrZFdYsap%2fW13xbuWIOznh9SjX9WHBF4uC1J3B16VI5VdPHIQ%2fO%2fxznj
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -713,7 +713,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -751,7 +751,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -759,20 +759,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=ui05ck3zj8McNqu5HBFE0f1pZZIDkdEOYV%2bwASyNv%2bWSFfMrGNbCkv1rqoTQdShRKnpaF%2bRvQNkO1ZOAv6CixO%2bUNVb%2fyEQPgjmBbhvFKP1%2brDOeAT6zMv1cX%2fNtNC1bUSoND5elTWOobqFPtIFEXM3NAYB%2bxnTiK0BOjePeGiORcR2dCvfKvbi7aGLNwtuX;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -794,7 +794,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      - ipa_session=MagBearerToken=ui05ck3zj8McNqu5HBFE0f1pZZIDkdEOYV%2bwASyNv%2bWSFfMrGNbCkv1rqoTQdShRKnpaF%2bRvQNkO1ZOAv6CixO%2bUNVb%2fyEQPgjmBbhvFKP1%2brDOeAT6zMv1cX%2fNtNC1bUSoND5elTWOobqFPtIFEXM3NAYB%2bxnTiK0BOjePeGiORcR2dCvfKvbi7aGLNwtuX
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -821,7 +821,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -849,7 +849,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      - ipa_session=MagBearerToken=ui05ck3zj8McNqu5HBFE0f1pZZIDkdEOYV%2bwASyNv%2bWSFfMrGNbCkv1rqoTQdShRKnpaF%2bRvQNkO1ZOAv6CixO%2bUNVb%2fyEQPgjmBbhvFKP1%2brDOeAT6zMv1cX%2fNtNC1bUSoND5elTWOobqFPtIFEXM3NAYB%2bxnTiK0BOjePeGiORcR2dCvfKvbi7aGLNwtuX
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -859,20 +859,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUbW/UOBD+K1G+3JftNtk3ClIlVjooiDsKpa0QCK0m9iTrW8fOeZx2l6r/nbGd
-        7baIOz5l/Myrn3niu9wh9drnL7K7x6Yw/Pma/9m37S67InT5t1GWS0Wdhp2BFn/lVkZ5BZqS7ypi
-        DQpLvwq21T8ovNBAye1tlzPcoSNrgmVdA0Z9B6+sAX3AlUHPvqdAH8qGdEtqC0LY3vhw3riqc8oI
-        1YGGfjtAXokN+s5qJXYDygFpouFAtN7XrIH2Jjs+0frM2b47rz/01TvcUcBb7M6dapR5ZbzbJTI6
-        6I36t0cl4/0WMBXTRY1H4mQyOypLhKOTspZH88l8VhSTegGzaUwMI3P7W+skbjvlIgGxxKSYFGVR
-        zstyPp+WX/bRTKHvbqVYg2nwIbB4Vj77KRC33oEEDyHoLl+tKiBczFYrPufL5bvvm4vX9Zc31776
-        rJeXm+dvLgp9/pe+eH1Vflzm99/SRVsw0KDEeNPQTZhTGXY7YqMJ1FCwhiXQSIpTYxvmJlgeycdx
-        mFTywHsz1qehQXh1g0k0bJinKot4C0pHKPZ7iVtoO41jYdvo1pa70Bp1CjqulDnmK66js1fS9G3F
-        ewy+cr4omPbiebl3HupGhBLlD3J9LKSHydIY78/Pzt6+H1+++nQZQ9e2Rakca8kODB0H6PhQvPm/
-        WbiTAGONEr/txCQKh1EgXrX/vXtDwza0FRuOqvknxTAp0GqvNYa96/foBnceqgPW8duA7gblo+wW
-        wxVsvYpLj82D6DmO0msRKAzUHuQRnb9Rxz2n3oDuw3WGhcRmRCw7StL1uy66b8EZZZoQMFCVX3MH
-        5uNvRTR4htQo8g9vsyEgSxvIboEy1mBGLOhRVlvHNWXGkuqY10pp5XfR3/TgwHhEOc6WRH3L1bPI
-        ifuDslD4JhUeZZPxZLoInYWVoW05LYoyEJJ+vbs8pa2GhDBYSrmP/xjXbiEqx/RaBzrQOeuGc3ha
-        5MF+EGWoApKneqKSwOWhy2x8MuYuPwAAAP//AwAaMO+G9QUAAA==
+        H4sIAAAAAAAAA4RUbW/TMBD+K1G+8KXrkq7rChISlYAx8TJetgkNoepiX1NTxw4+Z2uZ9t8522nL
+        pIl9yvm5Vz/3xHe5Q+q0z19kd/+awvDnR/66a5pNdkno8p+DLJeKWg0bAw0+5lZGeQWaku8yYjUK
+        S48F2+oXCi80UHJ72+YMt+jImmBZV4NRf8Ara0DvcWXQs+8h0IWyId2SWoMQtjM+nFeuap0yQrWg
+        oVv3kFdihb61WolNj3JAmqg/EC23NRdAW5Md32h56mzXni8+d9V73FDAG2zPnaqVeWO82yQyWuiM
+        +t2hkvF+xQlOq3I6PhAwPTkoS4SDqqomB8ej43FRjBYTGB/FxDAyt7+1TuK6VS4SEEuMilFRFuW0
+        HI0no+fX22im0Le3UizB1LgLLE44+GEgrr0DCR5C0F0+n1dAOBnP53zOZ7MzvVpeLa7fXfnqu55d
+        rJ6/+1ro8w/669vL8sssv/+ZLtqAgRolxpuGbsK8lGG3AzbqQA0Fq18CDaR4aWzN3ATLI/mkC3WD
+        5qGQIt4pabqmYroDXh5PCmanPDqJTko87DS0tA1K5Xhrtp/lMECHcleuAaWjI0KvcA1Nq3EobBPd
+        vFrywOox1qdJQHiebOsUDiP9XjWPMDvdMbvT2O5Gqd+n89PTs0/DizffLrahAow1SjwZqi1TRkvU
+        af7DSplD3tdyy9I+tefzP7wZ6rehrVhxwIJ/Ugz8Ac23WmPYu26LrnDjodpjLb8N6G5Q/pPdYOhn
+        F/O49Ng3iJ7jKL0WYVth1L08ovMJddxz6g3oLpDTXzA2I2LZUZKu37TRfQvOKFOHgJ7O/Io78MY+
+        KqLe06dGkX8+y/qALNGV3QJlvP2MWNCDbGEd15QZC6TlzVdKK7+J/roDB8YjymE2I+oarp5FTtwz
+        ykLhm1R4kI2Go6NJ6CysDG3LI15FICT9end5Spv3CWGwlHIf/zGu3UDUs+m0DnSgc9b15/C0yL29
+        U16oApKneqCkwOW+y3g4HXKXvwAAAP//AwCyWR6H9QUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -885,7 +885,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -913,7 +913,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=YPFoWDRXEA7i387pVVXieXFlp8JcnqMtTruFnJ1tFm8oeGGm6r3YndI8Q3X6SqZRn3WIi3%2fUtKlUHoig8vwQ2dUmwf9arwsob2HHYGs90O2O%2f3Ut9%2bMA7tRSrQxy2GDYRocm2nKNzTXeWhKNPkYELJCSNCTw3OeB2HChEoxOsw6%2ftiGBQzX5%2floC64str1IQ
+      - ipa_session=MagBearerToken=ui05ck3zj8McNqu5HBFE0f1pZZIDkdEOYV%2bwASyNv%2bWSFfMrGNbCkv1rqoTQdShRKnpaF%2bRvQNkO1ZOAv6CixO%2bUNVb%2fyEQPgjmBbhvFKP1%2brDOeAT6zMv1cX%2fNtNC1bUSoND5elTWOobqFPtIFEXM3NAYB%2bxnTiK0BOjePeGiORcR2dCvfKvbi7aGLNwtuX
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -940,7 +940,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -978,7 +978,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -986,20 +986,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:32 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=aj%2b%2bzIxGGmRzktU37BHqb9UVu37vJvA%2f%2fYFOEZZ9KSzgGBBl0BHvyEF9UEUbSxPD%2fYys4e7Kwb0zRVccwboATinLB3rc0MEW5FKMW0oXGmatE9TY8gi8SOvBw55b2iUtQlne9IH3NqtiM%2fZTdOniEAdMpcN1VA2leKRBX1g2eVy50fiGXAtG3%2f6oNJc3oudk;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1021,7 +1021,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      - ipa_session=MagBearerToken=aj%2b%2bzIxGGmRzktU37BHqb9UVu37vJvA%2f%2fYFOEZZ9KSzgGBBl0BHvyEF9UEUbSxPD%2fYys4e7Kwb0zRVccwboATinLB3rc0MEW5FKMW0oXGmatE9TY8gi8SOvBw55b2iUtQlne9IH3NqtiM%2fZTdOniEAdMpcN1VA2leKRBX1g2eVy50fiGXAtG3%2f6oNJc3oudk
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1048,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1077,7 +1077,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      - ipa_session=MagBearerToken=aj%2b%2bzIxGGmRzktU37BHqb9UVu37vJvA%2f%2fYFOEZZ9KSzgGBBl0BHvyEF9UEUbSxPD%2fYys4e7Kwb0zRVccwboATinLB3rc0MEW5FKMW0oXGmatE9TY8gi8SOvBw55b2iUtQlne9IH3NqtiM%2fZTdOniEAdMpcN1VA2leKRBX1g2eVy50fiGXAtG3%2f6oNJc3oudk
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1105,7 +1105,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1133,7 +1133,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=tG1zyfjScd9eZ9TDu%2bNMVPlzS5NtT9WfdV%2fwvoWw4WhrwRnycjhT22eIOS3XZE02kRApehEH5ETTFGiw27WD%2bvUGcWDVo0QR9C13He1Tb4DSA7f%2ffHA1jvswE%2fT7UH2pGbtAyrEELUC%2bJ1nY5tO8ncrY8OVinXPqmJ1dv%2fTEP7C59XBjx4zZ%2bk8BuB66bL%2bQ
+      - ipa_session=MagBearerToken=aj%2b%2bzIxGGmRzktU37BHqb9UVu37vJvA%2f%2fYFOEZZ9KSzgGBBl0BHvyEF9UEUbSxPD%2fYys4e7Kwb0zRVccwboATinLB3rc0MEW5FKMW0oXGmatE9TY8gi8SOvBw55b2iUtQlne9IH3NqtiM%2fZTdOniEAdMpcN1VA2leKRBX1g2eVy50fiGXAtG3%2f6oNJc3oudk
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1160,7 +1160,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_denied].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_denied].yaml
@@ -1,0 +1,1179 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:33Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CWE3c2lUAmpaUspQgVULg8UFM3ak42bXXvrS0iK+PeO7Q0B
+        CcFTZs+Mz4zPHOch1WhcbdNPycPzkEn6+Z1+c02zTq4M6vSul6RcmLaGtYQGX0sLKayA2sTcVcAq
+        ZMq8VqzKP8gsq8HEtFVtSnCL2ijpI6UrkOIfWKEk1FtcSLSUewk4T+uPKyNWwJhy0vrvhS5bLSQT
+        LdTgVh1kBVugbVUt2LpDqSBO1H0YM99wzsBsQkpcmPmRVq49m5278gTXxuMNtmdaVEIeSqvXUYwW
+        nBR/HQoe7jcu94Z7RYk7bK8Y7uQ5wg4MyuHOqBgNs6yYjWE4CAf9yNT+XmmOq1boIECgKLIiyz7m
+        H/N8NBoUN5tqktC295zNQVb4ViGurAYOFnzRQzqdlmBwPJxO6TudTE6yxa/vM9bsL/nX/fnNUd6W
+        iy9nlxn/cXE1dNeH15fXk8lB+ngXL9yAhAo5hhv7rkwecL/jHgWVl8j4qFuG6XF2IFVFGvnIorHR
+        H2KJ8qWhAt6AqAMUKD/jCpq2xj5TTUjXiojMHOtYtFsKuUu3mYekE1y6pqSV+Vw+GmekcLZfbJJb
+        3oCYqO6TM5975mmyOMbp2dHR8Wn/8vDiMpTOVYNcaLKN6kTY9dDulrx6axbqxEAqKdi7nciETGPw
+        ghXNK2sexDW39IhRL9FfckZvEf2UYKYbSxFstdugC1xbKLdYg35UNZuG/YUm3sfEaOIfgJfKS7jd
+        dEi+s+hHOrqE2vmxO+FDM2PIQSa60a7bkL4HLYWsfEEnSXpNHejeP4UxXaY7Gnx7fpx0BUlUOrkH
+        k0hlE0Pe7CUzpYmTJ2SdlvQrRS3sOuQrBxqkReT9ZGKMa4g9CerpDybxxMtI3EuKfjEY+85Mcd82
+        H2RZ7gWJr+khjcem3QE/WDzyGJ4LcTcQHJJOOEeeeNWS26jFbRoEQq2Vd4l0de3/P/g2frKjJwBO
+        c77wh1d323fY3+tT3/8AAAD//wMA/WXDfdoFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUyW7bMBD9FUGXXmxHkpc4BQLUQLMhbZxmQ5EiMEbUWGZNkSpJeamRf++Qku2k
+        SJuThm9WvnnUJtRoKmHDj8HmpckkfX6En6uiWAf3BnX41ArCjJtSwFpCgW+5ueSWgzC1795jOTJl
+        3gpW6U9klgkwtduqMiS4RG2UdJbSOUj+GyxXEsQe5xIt+V4DlSvr0pXhK2BMVdK681ynpeaS8RIE
+        VKsGspzN0ZZKcLZuUAqoJ2oOxsy2NadgtiY5bs3sTKuqHE+vq/QS18bhBZZjzXMuT6TV65qMEirJ
+        f1XIM3+/QTrsDZMU22yY9NpxjNCGbtpr95N+L4qS6QB6XZ/oRqb2S6UzXJVcewJ8iSRKojiK+3Hc
+        73e7j9tootCWy4zNQOa4C4wO48O/AnFlNWRgwQVtwskkBYOD3mRC53A0uoznN6fTx/MHm34Xo7v5
+        0flNJMZfxM3pffxtFD4/1RctQEKOGfqbum5MHmduty0yckeNcVazBNPK2LFUOXHjLIvG+nFmqsCM
+        ayJcNWUOHHTgK/mIArjwDg99whUUpcAOU8X2PgykkpyB2AmyDr0an51dXHXuTm7vfGjFM1kVKa3Q
+        xcT9QUSMR0fJju6tQt6pY+o17CRMwmAa/X4sL/5Nff6//jlfoHz9ojwuFFFmZihqEg5SLg9oX7Pt
+        jfZzekSahnCh2Jx8U3qH6HgGM9nKiWCrqy06x7WFdI+V9PxRLzB7kV2gG1tNJ36vvqXTNcWZ+ofg
+        GHHT7BXgne8I4JlSFyAqd+fmDr6ZMaQsU6vTrkvvXoKWXOYuoGEpfKAOxPlXbkzjaVK9jq8vgiYg
+        qFkPlmACqWxgSLOtYKo01cwCElJJu0u54Hbt/XkFGqRFzDrByJiqoOqB50R/MIErvKgLt4Kkk3QH
+        rjNTmWsbd6ModoTUr2sT1mmTJsENVqc8+2dEtQvwupeVEI4O1Frp5uz+Htne3snTVYGMpnqlTMfl
+        vkuvM+xQlz8AAAD//wMAxPKnItgFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_denied"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW/bMAz9K4IuuwSOnTTtttMKbCh6aDdg3Q5di4CWFEeIPgxRShYE+e+jZCfp
+        LttN4nvkIx954EFhMpF/ZIe3z7W3SuqgRPRhT5FffJpDU5ms3fPXCeMWtClACX1Sv8H2RlXC2wJv
+        QivAeacFGAdWvaE+fr27u3+snr58fyrUFSBGiAmdjwMPe7BircRmKZXTShZa0tIl26pQKM3iur6q
+        6/rD7CTXB+2E7v8rh66AP5AqjfIiKIjau6jHzFk9q+ub5qZpFov5/Lnwun/pd3qr3Fn489kl4zvt
+        cK3M4NW01W7aAq5PE136LBGHIIRPLhovNoStwKCi+Bpw2ZNNOx9ySgzpFN2ofYT2ErMqt+hXyy74
+        1Jfy5EmiYZG/HomwBZNyl6NqSUGETmEmH3jc9wXeQXDadZkwzsV/UhFy6UEjjsiYmsHbb/dsJLDB
+        J7YDZLRThsrFCVv5QDUlowvpye1WGx33Be8SBHBRKVmxW8RkqTolha0K75Dlwtuh8ITNqtn8OisL
+        L7NsM6/rhr4SIpTDHdKWY0JubEg5HsvuaWYoB80fvNQrui2WvWEvgx0vnGePVAg+r9klY+hb1jS+
+        z1eWa4CkVv86sGzwRfqqel+R9B8AAAD//wMANe8siWUDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbW/TMBD+K1G+8KXrkvSFgYREJfaCeNkYG0IgVF3sa2rq2MHnbC3T/jtnJ20Z
+        AvYp9t1zb889zl3qkFrt0+fJ3e9HYfjzNX3V1vUmuSZ06bdBkkpFjYaNgRr/5lZGeQWaOt91tFUo
+        LP0NbMvvKLzQQJ3b2yZlc4OOrAkn6yow6id4ZQ3ovV0Z9Ox7aGhD2hBuSa1BCNsaH+4rVzZOGaEa
+        0NCue5NXYoW+sVqJTW9lQNdRfyFabnMugLZHdnyk5amzbXO+uGjLN7ihYK+xOXeqUubYeLfpyGig
+        NepHi0rG+abl0fioKPFAHBXjgzxHOIBROT6YFJNxlhWLKYxHMTC0zOVvrZO4bpSLBMQURVZkeZZP
+        8nwyGY2+bNFMoW9upViCqXAHzJ7mT/8A4to7kOAhgO7S+bwEwul4Pud7Opu9yVeXJ4svZ598+VnP
+        rlbPzi4zff5WX55c5x9m6f23btAaDFQoMU4aqgnzQobdDvhQBWoonPol0ECKF8ZWzE04eSQf21na
+        GqVyTLjt0xwG02HMFBE1KB0d0fQS11A3GofC1tt5BBhrlAC9E2QHfX9+evr6/fDq+ONVhPICyQNr
+        xFjf4aiBWixRrOY8h0IZYa2Spq1L3nSA5JNpxovJnhW7rWyF9Eg56ra1UzqXFw7jGr2q/72h6n/1
+        K3WD5uHDi3ZtmVlaou64OiyVOeS1LrcT7fuMFkP9XrQVK/Yt+LliWAfQfKs6NnvXbq0r3Hgo97aG
+        /xLoblD+Fl1jaNsu5nH9sWSQP+Oo+28ERkI3e6FE5yM6uefQG9BtmLmfIRYjYgFSJ2K/aaL7FpxR
+        pgqAnqX0E1dgzt8pot7Th0a5X7xOekDSsZ7cAiWskIRY2oNkYR3nlAnrreHdlUorv4n+qgUHxiPK
+        YTIjamvOnkRO3BNKQuKbLvEgKYbFaBoqCytD2XyUZXkgpHuEd2kXNu8DQmNdyH18bZy7hvg8TKt1
+        oAOds66/h5+M3J938gxZQHJXD5QZuNxXGQ+PhlzlFwAAAP//AwDAjiWa/wUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_denied].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_denied].yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:30 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=aqJ0k%2fXk2XZGI2zLaXqK4eM4odyXa0RlQpH13s31f1KUAax2W21V%2fJnRXP1Igi%2bJrlVP8xnkUiR6nsjQRZNzp%2bCE4WiQBo39UryKfCgAZpfuc8SQiwBZ%2foBzwkNn9%2fPQbg%2fykrenFXzU5bzsDFEceP3v1Y3803nhZxlDP0Z1XEkdSGFmak15IhHR2W0Dqjsu;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      - ipa_session=MagBearerToken=aqJ0k%2fXk2XZGI2zLaXqK4eM4odyXa0RlQpH13s31f1KUAax2W21V%2fJnRXP1Igi%2bJrlVP8xnkUiR6nsjQRZNzp%2bCE4WiQBo39UryKfCgAZpfuc8SQiwBZ%2foBzwkNn9%2fPQbg%2fykrenFXzU5bzsDFEceP3v1Y3803nhZxlDP0Z1XEkdSGFmak15IhHR2W0Dqjsu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:33Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T12:46:30Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      - ipa_session=MagBearerToken=aqJ0k%2fXk2XZGI2zLaXqK4eM4odyXa0RlQpH13s31f1KUAax2W21V%2fJnRXP1Igi%2bJrlVP8xnkUiR6nsjQRZNzp%2bCE4WiQBo39UryKfCgAZpfuc8SQiwBZ%2foBzwkNn9%2fPQbg%2fykrenFXzU5bzsDFEceP3v1Y3803nhZxlDP0Z1XEkdSGFmak15IhHR2W0Dqjsu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU204bMRD9ldW+9CWE3c2lUAmpaUspQgVULg8UFM3ak42bXXvrS0iK+PeO7Q0B
-        CcFTZs+Mz4zPHOch1WhcbdNPycPzkEn6+Z1+c02zTq4M6vSul6RcmLaGtYQGX0sLKayA2sTcVcAq
-        ZMq8VqzKP8gsq8HEtFVtSnCL2ijpI6UrkOIfWKEk1FtcSLSUewk4T+uPKyNWwJhy0vrvhS5bLSQT
-        LdTgVh1kBVugbVUt2LpDqSBO1H0YM99wzsBsQkpcmPmRVq49m5278gTXxuMNtmdaVEIeSqvXUYwW
-        nBR/HQoe7jcu94Z7RYk7bK8Y7uQ5wg4MyuHOqBgNs6yYjWE4CAf9yNT+XmmOq1boIECgKLIiyz7m
-        H/N8NBoUN5tqktC295zNQVb4ViGurAYOFnzRQzqdlmBwPJxO6TudTE6yxa/vM9bsL/nX/fnNUd6W
-        iy9nlxn/cXE1dNeH15fXk8lB+ngXL9yAhAo5hhv7rkwecL/jHgWVl8j4qFuG6XF2IFVFGvnIorHR
-        H2KJ8qWhAt6AqAMUKD/jCpq2xj5TTUjXiojMHOtYtFsKuUu3mYekE1y6pqSV+Vw+GmekcLZfbJJb
-        3oCYqO6TM5975mmyOMbp2dHR8Wn/8vDiMpTOVYNcaLKN6kTY9dDulrx6axbqxEAqKdi7nciETGPw
-        ghXNK2sexDW39IhRL9FfckZvEf2UYKYbSxFstdugC1xbKLdYg35UNZuG/YUm3sfEaOIfgJfKS7jd
-        dEi+s+hHOrqE2vmxO+FDM2PIQSa60a7bkL4HLYWsfEEnSXpNHejeP4UxXaY7Gnx7fpx0BUlUOrkH
-        k0hlE0Pe7CUzpYmTJ2SdlvQrRS3sOuQrBxqkReT9ZGKMa4g9CerpDybxxMtI3EuKfjEY+85Mcd82
-        H2RZ7gWJr+khjcem3QE/WDzyGJ4LcTcQHJJOOEeeeNWS26jFbRoEQq2Vd4l0de3/P/g2frKjJwBO
-        c77wh1d323fY3+tT3/8AAAD//wMA/WXDfdoFAAA=
+        H4sIAAAAAAAAA4RU227bMAz9FcMve0lTx0nTdkCBZVvRFcOWAm3z0LUIaIlxtNiSp0suC/rvoyQn
+        WYGifTJ1SB5Sh5S3qUbjKpt+TLb/m0zS51f61dX1Jrk3qNOnTpJyYZoKNhJqfM0tpLACKhN99wEr
+        kSnzWrAqfiOzrAIT3VY1KcENaqOkt5QuQYq/YIWSUB1wIdGS7yXgPK1PV0asgTHlpPXnhS4aLSQT
+        DVTg1i1kBVugbVQl2KZFKSB21B6Mme84Z2B2JjluzfxKK9eMZzeu+I4b4/Eam7EWpZCX0upNFKMB
+        J8Ufh4KH+2XnOZwNB4MjBmenR70ewhHkZJ3kJ4Msy2dDGPRDom+Zyq+U5rhuhA4CBIo8y7PsNM96
+        +WDYzx520SShbVaczUGW+FYgrq0GDhZ80DadTgswOBxMp3ROR6PrejGfzFh9vuRfzucPV72mWHwe
+        32X82+39wE0uJ3eT0egifX6KF65BQokcw419VSYvuJ9xh4zSS2S81Q7DdDi7kKokjbxl0di4H2KJ
+        8uVCBdwJLl1dkOwe750MM1Kp1z8LThP12O/SXNXIhabpqbaXYw8d8z1dDaIKjgB9wjXUTYVdpurg
+        phEzjUFpK+o3Rdyv077pSPlzfHV1/bN7d3l7twtlIJUU7N3QSpEqZo5VbPG4EPKYRjPfCXFIbSV7
+        Q5qGHjHqJfqkGb1F9PKAme5WimCr3Q5d4MZCccBq9LxqNg3zC/x+j4nRxB+AF963dJh0cL4z6GdK
+        XULlvAjtRUIxY2iDTNxGu2mCewVaCln6gFa2dEIVaDI/hDGtp00Ne3tznbQBSZQlWYFJpLKJod3s
+        JDOliZMnNOuGJlyISthN8JcONEiLyLvJyBhXE3sS1NMfTOKJl5G4k+TdvD/0lZnivmyvT5J7QeJr
+        2qYxbdom+MZiynN4LsRdQ1jNdMQ58sSrljxGLR7TIBBqrfxIpasq///gB3u/c54AOPX5Yoe8uoe6
+        g+5Zl+r+AwAA//8DAP4ECEnaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=J3UvYh%2bBRakt33PYIgz%2fknfiEEHBWoNnzGi%2fwY6moGOMfM9AxD6UbnBo%2fgcS68nUhH5HLYi3wI88gRIZdu7uNllzLpVFkkCz7vRKs9jNHM4qV8BOmIcp9MtMIHsPdh31kLM19hT9x%2foxz%2feYA8i1HcyQd%2bp%2fbDx4XbcpbHH%2fVVkj3aZF9VxELyX%2fBinGy6RG
+      - ipa_session=MagBearerToken=aqJ0k%2fXk2XZGI2zLaXqK4eM4odyXa0RlQpH13s31f1KUAax2W21V%2fJnRXP1Igi%2bJrlVP8xnkUiR6nsjQRZNzp%2bCE4WiQBo39UryKfCgAZpfuc8SQiwBZ%2foBzwkNn9%2fPQbg%2fykrenFXzU5bzsDFEceP3v1Y3803nhZxlDP0Z1XEkdSGFmak15IhHR2W0Dqjsu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:33 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=iOA5HqkYubjcmzJOv4Q4dSh5j1q4SYV9AXy3nosRgNS2RaUeT7ijOLBup4VcaBtNknoNVduDda7i8qJGG0CaIqqxCYUF5mEGpou%2fNj3H61zH5Nvqobj5%2fTnaTSW49so01ekpES2qUcozy62vPUK9Yx1je5D1IDpsD0SugWSZgPXG8kRJ5rleKW2eOc2wZsqS;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      - ipa_session=MagBearerToken=iOA5HqkYubjcmzJOv4Q4dSh5j1q4SYV9AXy3nosRgNS2RaUeT7ijOLBup4VcaBtNknoNVduDda7i8qJGG0CaIqqxCYUF5mEGpou%2fNj3H61zH5Nvqobj5%2fTnaTSW49so01ekpES2qUcozy62vPUK9Yx1je5D1IDpsD0SugWSZgPXG8kRJ5rleKW2eOc2wZsqS
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -399,7 +399,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      - ipa_session=MagBearerToken=iOA5HqkYubjcmzJOv4Q4dSh5j1q4SYV9AXy3nosRgNS2RaUeT7ijOLBup4VcaBtNknoNVduDda7i8qJGG0CaIqqxCYUF5mEGpou%2fNj3H61zH5Nvqobj5%2fTnaTSW49so01ekpES2qUcozy62vPUK9Yx1je5D1IDpsD0SugWSZgPXG8kRJ5rleKW2eOc2wZsqS
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -409,20 +409,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUyW7bMBD9FUGXXmxHkpc4BQLUQLMhbZxmQ5EiMEbUWGZNkSpJeamRf++Qku2k
-        SJuThm9WvnnUJtRoKmHDj8HmpckkfX6En6uiWAf3BnX41ArCjJtSwFpCgW+5ueSWgzC1795jOTJl
-        3gpW6U9klgkwtduqMiS4RG2UdJbSOUj+GyxXEsQe5xIt+V4DlSvr0pXhK2BMVdK681ynpeaS8RIE
-        VKsGspzN0ZZKcLZuUAqoJ2oOxsy2NadgtiY5bs3sTKuqHE+vq/QS18bhBZZjzXMuT6TV65qMEirJ
-        f1XIM3+/QTrsDZMU22yY9NpxjNCGbtpr95N+L4qS6QB6XZ/oRqb2S6UzXJVcewJ8iSRKojiK+3Hc
-        73e7j9tootCWy4zNQOa4C4wO48O/AnFlNWRgwQVtwskkBYOD3mRC53A0uoznN6fTx/MHm34Xo7v5
-        0flNJMZfxM3pffxtFD4/1RctQEKOGfqbum5MHmduty0yckeNcVazBNPK2LFUOXHjLIvG+nFmqsCM
-        ayJcNWUOHHTgK/mIArjwDg99whUUpcAOU8X2PgykkpyB2AmyDr0an51dXHXuTm7vfGjFM1kVKa3Q
-        xcT9QUSMR0fJju6tQt6pY+o17CRMwmAa/X4sL/5Nff6//jlfoHz9ojwuFFFmZihqEg5SLg9oX7Pt
-        jfZzekSahnCh2Jx8U3qH6HgGM9nKiWCrqy06x7WFdI+V9PxRLzB7kV2gG1tNJ36vvqXTNcWZ+ofg
-        GHHT7BXgne8I4JlSFyAqd+fmDr6ZMaQsU6vTrkvvXoKWXOYuoGEpfKAOxPlXbkzjaVK9jq8vgiYg
-        qFkPlmACqWxgSLOtYKo01cwCElJJu0u54Hbt/XkFGqRFzDrByJiqoOqB50R/MIErvKgLt4Kkk3QH
-        rjNTmWsbd6ModoTUr2sT1mmTJsENVqc8+2dEtQvwupeVEI4O1Frp5uz+Htne3snTVYGMpnqlTMfl
-        vkuvM+xQlz8AAAD//wMAxPKnItgFAAA=
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9lJKkpZSJiGt0higbZRx08SEqhPnNPXq2JkvbTPEf9+xk1KQ
+        0HjK8bn7+z7nMdZonLDxx+jxpckkfX7Fn11VNdGtQR0/9KK44KYW0Eio8K0wl9xyEKaN3QZfiUyZ
+        t5JV/huZZQJMG7aqjsldozZKekvpEiT/C5YrCWLn5xItxV47nG/ry5XhG2BMOWn9eanzWnPJeA0C
+        3KZzWc6WaGslOGs6LyW0G3UHYxbbnnMwW5MC12ZxqpWrp/NLl3/Fxnh/hfVU85LLE2l104JRg5P8
+        j0NehPslRxmMR8PhHoPx4V6aIuxBRtZBdjBMkmw+guEgFPqVafxa6QI3NdcBgNAiS7IkTdJxmg1H
+        g/R+m00Q2npdsAXIEp8Tk0NKfp2IG6uhAAs+6TGezXIwOBrOZnSOJ5NzuVzcze/P7mz+U0xulkdn
+        V4mYfhNXX27TH5P46aG9aAUSSiww3NRPY/K48Nz2yCg9NMZbHQmmV7BjqUrCxlsWjd2uw0AqyRmI
+        Zz2FNp8upqen5xf9m5Prm5C6UBUWXBM3qpu47137IbsVGS+kq3LiyEfTg1FCkKaDcQi6joBd+ktR
+        vDNbKFrcLFCIdnDO5T6htgjBCrh4UYsbqGqBfaaqECbdMI2BPsurN5hJWmZMy+7zy3D/u03JVyhf
+        P8Dgl6YDXCi2pNic3iF68MDMtnIit9Vu611iYyHf+Wp6/qhXWLyortDvoeazwGsY6XVNeab9IfjV
+        /cI7BYTgOwJ4otIVCOcv0fEShhlDyjKtOm1Th/AatOSy9AndteM7mkCgfufGdJGuNOj48jzqEqIW
+        xmgNJpLKRoY024vmSlPPIiKaaiIn54LbJsRLBxqkRSz60cQYV1H3KGCiP5jIN161jXtR1s8GIz+Z
+        qcKPTQdEkQekfV2PcVs26wr8Ym3JU3hG1LuCIGbphPBwoNZKd2f/9yh29rNWfRcoaKtXMvVY7qYM
+        ++M+TfkHAAD//wMAyUijktgFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,7 +435,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=wluv1GD80eTQ9GgtSz%2fsl%2fZm4tFjEso0WZKgj4kfSKXjlVuGtXBaHS26py5fukCBTBqCFwdGHFwvzM9Ljy9MvBW53A1jR9%2bkydBp%2bFYWMr%2bMhhJmI42KRQ1SEBucpZ5Deb%2bQIYdghxdExSBpf72zjS6xlHWrug%2fvOzlx5Sqxy672sjNmDZStL%2boo09YyuAB7
+      - ipa_session=MagBearerToken=iOA5HqkYubjcmzJOv4Q4dSh5j1q4SYV9AXy3nosRgNS2RaUeT7ijOLBup4VcaBtNknoNVduDda7i8qJGG0CaIqqxCYUF5mEGpou%2fNj3H61zH5Nvqobj5%2fTnaTSW49so01ekpES2qUcozy62vPUK9Yx1je5D1IDpsD0SugWSZgPXG8kRJ5rleKW2eOc2wZsqS
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -490,457 +490,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.noggin.test/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '20'
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk;path=/ipa;httponly;secure;
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
-        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
-        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
-        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
-        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
-      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_denied"}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '150'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4RSTW/bMAz9K4IuuwSOnTTtttMKbCh6aDdg3Q5di4CWFEeIPgxRShYE+e+jZCfp
-        LttN4nvkIx954EFhMpF/ZIe3z7W3SuqgRPRhT5FffJpDU5ms3fPXCeMWtClACX1Sv8H2RlXC2wJv
-        QivAeacFGAdWvaE+fr27u3+snr58fyrUFSBGiAmdjwMPe7BircRmKZXTShZa0tIl26pQKM3iur6q
-        6/rD7CTXB+2E7v8rh66AP5AqjfIiKIjau6jHzFk9q+ub5qZpFov5/Lnwun/pd3qr3Fn489kl4zvt
-        cK3M4NW01W7aAq5PE136LBGHIIRPLhovNoStwKCi+Bpw2ZNNOx9ySgzpFN2ofYT2ErMqt+hXyy74
-        1Jfy5EmiYZG/HomwBZNyl6NqSUGETmEmH3jc9wXeQXDadZkwzsV/UhFy6UEjjsiYmsHbb/dsJLDB
-        J7YDZLRThsrFCVv5QDUlowvpye1WGx33Be8SBHBRKVmxW8RkqTolha0K75Dlwtuh8ITNqtn8OisL
-        L7NsM6/rhr4SIpTDHdKWY0JubEg5HsvuaWYoB80fvNQrui2WvWEvgx0vnGePVAg+r9klY+hb1jS+
-        z1eWa4CkVv86sGzwRfqqel+R9B8AAAD//wMANe8siWUDAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=A3fwuuowPIkjoM78eJ9nwjQZfMUB4k5JFd%2fi%2fIetVORcK5ahe7%2btP7CRiOChQQO7ksx3oDQQDmEAWoAULCYbJVXn186fFY7IdAWAlQelqi87Fbp5HOyrW1SOvJZ15SKlrSBi6fXyGY7IKAnyYHY4Eo0%2fPVUzqfGx%2fzRjWIjPRCB93W7qGtOaA0USTD4O9iWk
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
-        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
-        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
-        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
-        fflYKvQPAAD//wMAt/mjK1gBAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.noggin.test/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '20'
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI;path=/ipa;httponly;secure;
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
-        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
-        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
-        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
-        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '75'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4RUbW/TMBD+K1G+8KXrkvSFgYREJfaCeNkYG0IgVF3sa2rq2MHnbC3T/jtnJ20Z
-        AvYp9t1zb889zl3qkFrt0+fJ3e9HYfjzNX3V1vUmuSZ06bdBkkpFjYaNgRr/5lZGeQWaOt91tFUo
-        LP0NbMvvKLzQQJ3b2yZlc4OOrAkn6yow6id4ZQ3ovV0Z9Ox7aGhD2hBuSa1BCNsaH+4rVzZOGaEa
-        0NCue5NXYoW+sVqJTW9lQNdRfyFabnMugLZHdnyk5amzbXO+uGjLN7ihYK+xOXeqUubYeLfpyGig
-        NepHi0rG+abl0fioKPFAHBXjgzxHOIBROT6YFJNxlhWLKYxHMTC0zOVvrZO4bpSLBMQURVZkeZZP
-        8nwyGY2+bNFMoW9upViCqXAHzJ7mT/8A4to7kOAhgO7S+bwEwul4Pud7Opu9yVeXJ4svZ598+VnP
-        rlbPzi4zff5WX55c5x9m6f23btAaDFQoMU4aqgnzQobdDvhQBWoonPol0ECKF8ZWzE04eSQf21na
-        GqVyTLjt0xwG02HMFBE1KB0d0fQS11A3GofC1tt5BBhrlAC9E2QHfX9+evr6/fDq+ONVhPICyQNr
-        xFjf4aiBWixRrOY8h0IZYa2Spq1L3nSA5JNpxovJnhW7rWyF9Eg56ra1UzqXFw7jGr2q/72h6n/1
-        K3WD5uHDi3ZtmVlaou64OiyVOeS1LrcT7fuMFkP9XrQVK/Yt+LliWAfQfKs6NnvXbq0r3Hgo97aG
-        /xLoblD+Fl1jaNsu5nH9sWSQP+Oo+28ERkI3e6FE5yM6uefQG9BtmLmfIRYjYgFSJ2K/aaL7FpxR
-        pgqAnqX0E1dgzt8pot7Th0a5X7xOekDSsZ7cAiWskIRY2oNkYR3nlAnrreHdlUorv4n+qgUHxiPK
-        YTIjamvOnkRO3BNKQuKbLvEgKYbFaBoqCytD2XyUZXkgpHuEd2kXNu8DQmNdyH18bZy7hvg8TKt1
-        oAOds66/h5+M3J938gxZQHJXD5QZuNxXGQ+PhlzlFwAAAP//AwDAjiWa/wUAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=htF1N65lErWbchIxtDzNHopSIedTAtVZ9crcVABsTJyd51YzCQMqx3S5j9ViD82WtZv4taYFGd6zjYG8Em8Fq1rS2EU8g7yOiqzt%2b%2bg3Z%2fEFDFPP7Mj82X47zA%2bVSa%2bcpGPNKw0CTAqeZdABu2FtCvDZ5%2beMwjTMqX8TsRAkRx7D2q2XksDixS7i77R3CRdI
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
-        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
-        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
-        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
-        fflYKvQPAAD//wMAt/mjK1gBAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -991,13 +541,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:34 GMT
+      - Mon, 20 Jul 2020 12:46:31 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=B5xyGgeEracIJxWdzMDStwt%2benKAMJAKsbcqxUsnAFEsOSHIa83gnvN5ux1f6Ei57Lz1bqAMw9g4W1OQ%2fG4erVq27POtdjZN2TNKETJbcTmzFGXGy56irpdxJ5tN12DA4Kptp6HgOMs1JqiN%2fcTjjOtOxwhdl3SCINjKn0GsrQX1wo%2beGUaRW5eesJoi2I2%2f;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -1021,7 +571,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      - ipa_session=MagBearerToken=B5xyGgeEracIJxWdzMDStwt%2benKAMJAKsbcqxUsnAFEsOSHIa83gnvN5ux1f6Ei57Lz1bqAMw9g4W1OQ%2fG4erVq27POtdjZN2TNKETJbcTmzFGXGy56irpdxJ5tN12DA4Kptp6HgOMs1JqiN%2fcTjjOtOxwhdl3SCINjKn0GsrQX1wo%2beGUaRW5eesJoi2I2%2f
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1048,7 +598,458 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "nsaccountlock": true, "fasstatusnote":
+      "spamcheck_denied"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '173'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=B5xyGgeEracIJxWdzMDStwt%2benKAMJAKsbcqxUsnAFEsOSHIa83gnvN5ux1f6Ei57Lz1bqAMw9g4W1OQ%2fG4erVq27POtdjZN2TNKETJbcTmzFGXGy56irpdxJ5tN12DA4Kptp6HgOMs1JqiN%2fcTjjOtOxwhdl3SCINjKn0GsrQX1wo%2beGUaRW5eesJoi2I2%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW8TMRD9K5YvXKLNZhNCxYlKoKqHFiQKB2gVzdrOrhV/rDx2QhTlvzP2Lkk5
+        IG72vDfveZ7nxIPCZCJ/z06vj1tAjBATOh8VVX5yHMCKXondRiqnleQvM8Z3oRXgvNMCjAM7MmWy
+        9vjh8fPd3f1j9fTp61Oh9t4qqYMS0Ydj4c1zaV7YhdFp6ZJtVSjo4u26XtX1YnlTwKTlVfyP9xC0
+        E3r4r7fxnXbYK2NG41a7eQvYF9CCNq961S+wg1GV8LbAlIQICqL2LurJpambun7X1ItmtV7WPwrP
+        IQjhk4vGix2xYkiKyuhKxzeksaY5/j1kp/fKXWb5eBm1B9wM9CMHH+RVOld36hihvdasytp+u+mC
+        T0ORoXwSuSN/ORNhDyZl+SnI0oIIncJMPvF4HAp8gOC06zJhehD/TiKUwoNGnJCpNYO3X+7ZRGDj
+        gOwAyGh9GCoXZ2zrA2lKRrkOlGarjY7HgncJAriolKzYLWKypE5NYa/CG2RZeD8Kz1hTNct1dhZe
+        ZtvFksKjq4QIZW/Hts3UkB82tpzPOUfStlC2jz94qbe0xixnw57HOJ45zxmpEHz+H5eMoWvZvOl8
+        2bisAZKe+tey5YCv1qvqpiLr3wAAAP//AwATCB4zZAMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=B5xyGgeEracIJxWdzMDStwt%2benKAMJAKsbcqxUsnAFEsOSHIa83gnvN5ux1f6Ei57Lz1bqAMw9g4W1OQ%2fG4erVq27POtdjZN2TNKETJbcTmzFGXGy56irpdxJ5tN12DA4Kptp6HgOMs1JqiN%2fcTjjOtOxwhdl3SCINjKn0GsrQX1wo%2beGUaRW5eesJoi2I2%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=CeeZdFhloNBUSqOusixEqClr%2flUglvZR4z2fSAROP0eeI20bjjN6TEYYO%2bcubVB9APgCTxMcMdUOJv37MP1IVZrlVq9p%2bq8AbAJ%2fMyF9j8cL7jPihrlfiE8PsIh0nFFjuFeompBF9ZWseFyucEyRRh8ri5nD2a7osS9SfKvLiswyXbeTHjX7wY95puCvG5yH;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=CeeZdFhloNBUSqOusixEqClr%2flUglvZR4z2fSAROP0eeI20bjjN6TEYYO%2bcubVB9APgCTxMcMdUOJv37MP1IVZrlVq9p%2bq8AbAJ%2fMyF9j8cL7jPihrlfiE8PsIh0nFFjuFeompBF9ZWseFyucEyRRh8ri5nD2a7osS9SfKvLiswyXbeTHjX7wY95puCvG5yH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=CeeZdFhloNBUSqOusixEqClr%2flUglvZR4z2fSAROP0eeI20bjjN6TEYYO%2bcubVB9APgCTxMcMdUOJv37MP1IVZrlVq9p%2bq8AbAJ%2fMyF9j8cL7jPihrlfiE8PsIh0nFFjuFeompBF9ZWseFyucEyRRh8ri5nD2a7osS9SfKvLiswyXbeTHjX7wY95puCvG5yH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU227bOBD9FUEvfXEcSXZcd4ECa6BtGvSSXpJg0aIwRtRYZk2RKodM7Ab59x2S
+        cpwAQfuk4cyZC88c6ja3SF65/J/s9qEpNH++56981+2yS0Kb/xhleSOpV7DT0OFTYamlk6AoxS6j
+        r0Vh6CmwqX+icEIBpbAzfc7uHi0ZHSxjW9DyNzhpNKiDX2p0HHvs8KFsSDcktyCE8dqF88bWvZVa
+        yB4U+O3gclJs0PVGSbEbvAxIEw0HovW+5gpob3LgK61PrfH9+eqTr9/hjoK/w/7cylbq19rZXSKj
+        B6/lL4+yifcrXlQwn02nRwLmz4/KEuEIKrZOqpNpUVSrGUwnMTGMzO1vjG1w20sbCYglqqIqyqKc
+        l9V0Nim/7dFMoetvGrEG3eI9sHjO4MdA3DoLDTgIoNt8uayBcDZdLvmcLxZnerO+Wn17e+Xq/9Ti
+        YvPi7ZdCnb9XX95clp8X+d2PdNEONLTYYLxp6Cb0yybsdsRGG6ihYA1LoFEjXmrTMjfBckgujsOk
+        kgPemzYuDU09dGKNYrPk2hKb/dQCtNFSgLqXXez278fz09Ozj+OL118vInRtOmyk5RWaYbDj4DqO
+        6KRF2Wjf1bzKEC1PZgUzX07mMeiHPR3gD7Xzl97K8P1ojUqlxrXUx0zuOgY7kOpBLm6h6xWOhen2
+        TAiLcctOdk8ssEgL1DRQqozYMMpZj+ympI37d+X/dMlWXqN+/HwTd0DLvegOpYN3gzsH9cHX808C
+        7TUG2IrfOkZRhH5mtYzbj6WD+hlH6bcRRgyDHXQSg3+RyR2nXoPyYdhhLbEZEeuPkobdro/hG7Ba
+        6jYAhuvlV9yBOf0giYbIkBrV/uksGwBZoiu7AcpYjBmxskfZyliu2WS8pZ53U0sl3S7GWw8WtENs
+        xtmCyHdcPYuc2GeUhcLXqfAoq8bVZBY6C9OEtuWEVxEISW/wNk9pyyEhDJZS7uJj49odRC1rr1Sg
+        A601djiHf0xzsO+lGqpAw1M9Umng8tBlOp6Pucv/AAAA//8DAC7iuIf+BQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=CeeZdFhloNBUSqOusixEqClr%2flUglvZR4z2fSAROP0eeI20bjjN6TEYYO%2bcubVB9APgCTxMcMdUOJv37MP1IVZrlVq9p%2bq8AbAJ%2fMyF9j8cL7jPihrlfiE8PsIh0nFFjuFeompBF9ZWseFyucEyRRh8ri5nD2a7osS9SfKvLiswyXbeTHjX7wY95puCvG5yH
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=zHeyJbWk8qFxpJnUFuTl6DuIzV2eEx47RfzJG2zaKsdJypjKqctu7f0%2fCwtDbM4RHHIq1D9pxGv0clX%2flRnfQ6qluNbuEjur8D%2bX60prjtcRoicWMkQnnhasc8JC0WKkXbaK0LnyH0N%2fLfsVd%2fsuOk2ZMa0b3BjUenfr6SACcEvWdESMmmrq4XduI6dnqxnT;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=zHeyJbWk8qFxpJnUFuTl6DuIzV2eEx47RfzJG2zaKsdJypjKqctu7f0%2fCwtDbM4RHHIq1D9pxGv0clX%2flRnfQ6qluNbuEjur8D%2bX60prjtcRoicWMkQnnhasc8JC0WKkXbaK0LnyH0N%2fLfsVd%2fsuOk2ZMa0b3BjUenfr6SACcEvWdESMmmrq4XduI6dnqxnT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:32 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1077,7 +1078,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      - ipa_session=MagBearerToken=zHeyJbWk8qFxpJnUFuTl6DuIzV2eEx47RfzJG2zaKsdJypjKqctu7f0%2fCwtDbM4RHHIq1D9pxGv0clX%2flRnfQ6qluNbuEjur8D%2bX60prjtcRoicWMkQnnhasc8JC0WKkXbaK0LnyH0N%2fLfsVd%2fsuOk2ZMa0b3BjUenfr6SACcEvWdESMmmrq4XduI6dnqxnT
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1105,7 +1106,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:32 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1133,7 +1134,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=PkUq0kS42NBybHEDgNsZ1Gg5zEq%2bmglhmYlq4bwqezvl6YToGCGTCWwDgUr3a7xbTf%2fYKBbuYD%2bgoRUD5lwQOsjVUZg%2foNeP6%2bs4s2EpEJdH8Nl%2bOryl%2b%2f30wQjySJz68rYxcO%2fjvHj7pd5EcX0lCxy5kH5FchRF6TWkSfWdSlwa%2fU6Scs9NV0ZDCsQDbf0J
+      - ipa_session=MagBearerToken=zHeyJbWk8qFxpJnUFuTl6DuIzV2eEx47RfzJG2zaKsdJypjKqctu7f0%2fCwtDbM4RHHIq1D9pxGv0clX%2flRnfQ6qluNbuEjur8D%2bX60prjtcRoicWMkQnnhasc8JC0WKkXbaK0LnyH0N%2fLfsVd%2fsuOk2ZMa0b3BjUenfr6SACcEvWdESMmmrq4XduI6dnqxnT
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1160,7 +1161,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:32 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_manual].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_manual].yaml
@@ -34,13 +34,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:32 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=bCxAKHGVGjvFCn88DPp7tZGajrVzZ2CnWXTsFAu67QeCtVbD2XGYAryxGedbCSKWaKXwQoX7I%2b3SOGftWy6nhiZwMEXphhVqDaNw3t9OrPwCoI8eVFaE430XgSkYH5%2bXsguWeOfv0Uvb7EKsL%2bP86UXRJ85WPMSYaBuvRWgc6rVnXV8Sja%2fILTVu3vY%2f9tPC;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      - ipa_session=MagBearerToken=bCxAKHGVGjvFCn88DPp7tZGajrVzZ2CnWXTsFAu67QeCtVbD2XGYAryxGedbCSKWaKXwQoX7I%2b3SOGftWy6nhiZwMEXphhVqDaNw3t9OrPwCoI8eVFaE430XgSkYH5%2bXsguWeOfv0Uvb7EKsL%2bP86UXRJ85WPMSYaBuvRWgc6rVnXV8Sja%2fILTVu3vY%2f9tPC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:35Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T12:46:32Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      - ipa_session=MagBearerToken=bCxAKHGVGjvFCn88DPp7tZGajrVzZ2CnWXTsFAu67QeCtVbD2XGYAryxGedbCSKWaKXwQoX7I%2b3SOGftWy6nhiZwMEXphhVqDaNw3t9OrPwCoI8eVFaE430XgSkYH5%2bXsguWeOfv0Uvb7EKsL%2bP86UXRJ85WPMSYaBuvRWgc6rVnXV8Sja%2fILTVu3vY%2f9tPC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU2U7bQBT9FcsvfUmC7SyQSkhNW5oiVIJKyAMFRdczN8409ow7S5ZG/HtncUiR
-        EDzl+tz93DPZxxKVKXX8Mdr/bxJuf37FX01V7aI7hTJ+bEUxZaouYcehwtfcjDPNoFTBd+exAolQ
-        rwWL/DcSTUpQwa1FHVu4RqkEd5aQBXD2FzQTHMojzjhq63sJGFfWpQvFtkCIMFy775XMa8k4YTWU
-        YLYNpBlZoa5FyciuQW1AmKj5UGp5qLkAdTCt41Ytx1KYerK4MfkV7pTDK6wnkhWMX3Atd4GMGgxn
-        fwwy6vcbEJrh2TBpk7Os105ThPYQ0kW7n/V7SZItBtDr+kQ3sm2/EZLitmbSE+BLZEmWJKfpaZr2
-        +93e/SHaUqjrDSVL4AW+FYhbLYGCBhe0j+fzHBQOevO5/Y5Ho6ts9fPbglTDNf0yXN6P0zpffZ5M
-        E/r99q5nZhez6Ww0Oo+fHsPCFXAokKLf2HUl/Jy6G7esUTiKlLOaY6gWJedcFJYjZ2lU2o+1FBVS
-        Ji3xoilz4qATX8lHVMBK7/DQJ9xCVZfYIaI67EWAC84IlM/CDKHXk/H48rozvbid+lDDKDdVbk/p
-        YtL+ILHMJ8Mj7QelvFNHhXM8S9kKhEj0d9KseuUE/XCC4q3+BVsjf/myPF4KS5laYhlIOMkZP7F3
-        Wx42Os7pkdo+YpRrdPjCvkV0HIOaHyRlYS3NAV3hTkN+xCp044nF3N/Pl3Y6thVV+ANwm7uux0t7
-        5zuHfrKpayiN262Z1TdTyipIBTXqXe3dG5Cc8cIFNGzEM9vBcvuDKdV4mlSv25vLqAmIArvRBlTE
-        hY6U1WYrWghpa9LICqa2N8pZyfTO+wsDErhGpJ1opJSpbPXIsyc/qMgVXofCrSjrZN2B60wEdW3T
-        bpKkjpDwmvZxSJs3CW6wkPLkn4utXYHXdzyiFGnkWIseAhcPsScIpRROGdyUpfv/oEf7WZiuAFA7
-        5wtNOnaPfXuds47t+w8AAP//AwA6U9zu2gUAAA==
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9lJKml6ASUjrNtShaQMJ6AMDVSf2aerVsTNfSruK/75jJ6Ug
+        MXjK8bn7+z5nmxq0Xrr0Y7J9bjJFn1/pV19Vm+TGoknvO0nKha0lbBRU+FpYKOEESNvEbqKvRKbt
+        a8m6+I3MMQm2CTtdp+Su0VitgqVNCUr8BSe0Arn3C4WOYi8dPrQN5dqKNTCmvXLhvDRFbYRiogYJ
+        ft26nGBLdLWWgm1aLyU0G7UHaxe7nnOwO5MCV3YxMdrXF/NLX3zHjQ3+CusLI0qhzpQzmwaMGrwS
+        fzwKHu+XwRH0smF2wOD46KDXQziAIZ4cDPPhIMvy+QgG/VgYVqbxD9pwXNfCRABiizzLs+woz3r5
+        YNTPb3fZBKGrHzhbgCrxrURcOwMcHISkbTqbFWBxNJjN6JyOx+d6uZjOWXWy4l9OFreTXl0sP19c
+        Z/zb1c3AT8+m19Px+DR9vG8uXIGCEjnGG4epTJ3ywHGHjDJAZIPVkmE7nJ0qXRJGwXJo3W4tBkor
+        wUA+6Sq2+fTzYjI5/9m9Pru6jqkLXSEXhjjS7cTD4DqM2Y3YBFe+KoirEO0NRxlB2+ufxKBvidin
+        PxfHO7OlpsXtAqVsBhdCHRJ6ixisQMhntbiGqpbYZbqKYdIPMxhpdKL6P0O2Yfnphfi3blOKFaqX
+        DzH6a3rEaFYY7jqnt4gBOLCznaTI7YzfeZe4cVDsfRWGeXo+i/zF1kHH1NE2P4CwYlhsz3QMvkP0
+        I5WuQPqwbIt/HGYtKcg2anSbOoYfwCihypDQXi+d0gQC74ewto20pVG3l+dJm5A0cCUPYBOlXWJJ
+        m51krg315AnRURMJhZDCbWK89GBAOUTeTcbW+oq6JxE988EmofGqadxJ8m7eH4XJTPMwttcnKgIg
+        zWvapk3ZrC0IizUlj/G5UO8KomjTMefIk4BactdgcZdGgNAYHahWXsrw/+B7+0mloQFw2vOFQAO6
+        +7mD7nGX5v4DAAD//wMA2TF+UdoFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      - ipa_session=MagBearerToken=bCxAKHGVGjvFCn88DPp7tZGajrVzZ2CnWXTsFAu67QeCtVbD2XGYAryxGedbCSKWaKXwQoX7I%2b3SOGftWy6nhiZwMEXphhVqDaNw3t9OrPwCoI8eVFaE430XgSkYH5%2bXsguWeOfv0Uvb7EKsL%2bP86UXRJ85WPMSYaBuvRWgc6rVnXV8Sja%2fILTVu3vY%2f9tPC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:35 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -314,13 +314,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=YmBRmKVVQdPodJHG1IJzAWXU1gwyacPDRfh9R43RMThgm6Ef1ErYIoCaR7QVKbO%2bJNiTw09EmPcS4lF6bhAT%2fYIfCuoXs8HnPrr%2bNlHQNolWjUW4cMd6bEjn%2f2Gp381vknCqiNJdmljD2NUXMcIeuO3SqWaLmU4Ke%2bbUjblhcE2I3s%2fxNIVBPKmGhPhQWRpE;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      - ipa_session=MagBearerToken=YmBRmKVVQdPodJHG1IJzAWXU1gwyacPDRfh9R43RMThgm6Ef1ErYIoCaR7QVKbO%2bJNiTw09EmPcS4lF6bhAT%2fYIfCuoXs8HnPrr%2bNlHQNolWjUW4cMd6bEjn%2f2Gp381vknCqiNJdmljD2NUXMcIeuO3SqWaLmU4Ke%2bbUjblhcE2I3s%2fxNIVBPKmGhPhQWRpE
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -399,7 +399,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      - ipa_session=MagBearerToken=YmBRmKVVQdPodJHG1IJzAWXU1gwyacPDRfh9R43RMThgm6Ef1ErYIoCaR7QVKbO%2bJNiTw09EmPcS4lF6bhAT%2fYIfCuoXs8HnPrr%2bNlHQNolWjUW4cMd6bEjn%2f2Gp381vknCqiNJdmljD2NUXMcIeuO3SqWaLmU4Ke%2bbUjblhcE2I3s%2fxNIVBPKmGhPhQWRpE
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -409,20 +409,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUbU/bMBD+K1G+7EspSd+ASUirNN7EBow3TUyoutjX1KtjZ7YD7RD/fWc7bWFi
-        41PO937PPZen1KBtpEs/Jk8vRabo8yP93FTVMrmxaNL7TpJyYWsJSwUVvmUWSjgB0kbbTdCVyLR9
-        y1kXP5E5JsFGs9N1SuoajdXKS9qUoMRvcEIrkBu9UOjI9lrR+LQ+XFuxAMZ0o5x/z01RG6GYqEFC
-        s2hVTrA5ulpLwZatlhxiR+3D2tkq5xTsSiTDlZ0dGd3U59OLpjjFpfX6CutzI0qhDpQzywhGDY0S
-        vxoUPMw3YryHu3vZFtvtDbbyHGFrD/Lp1rA3HGRZbzqCQT8E+pap/KM2HBe1MAGAkKKX9bI8y4d5
-        Phz2h3crb4LQ1Y+czUCVuHbMdvKdvxxx4QxwcOCdntLJpACLo8FkQu90PD7tzy8Pp3fHt674LsfX
-        873jy0yef5GXhzf5t3H6fB8HrUBBiRzDpL4aU/vc77ZDQumhsV5ql2A7nO0rXRI2XnJoXWinEVw1
-        VUGw+hT5cJQRCtlehKACIYM+5P2EC6hqiV2mq2C2EY41lWhBzGDAyYnq3xDMdIVcGFqyblvf9qrt
-        UCWy9X9dSU1D2BnK2Nt2IdQ2IThbzbPpeAU4A6WVYCDXFxMHOjs/Ojo5614fXF2vV75i6TuupXhA
-        9foAg17ZFnCp2ZxsU7pD9DODnazoRGpnmpV2jksHxUZX0/mjeUD+IrpCD4aeTsJeQ0nPa/Kz8Yfg
-        N+Fn3zAgGN8hwDOFPoBs/BAtYqGYtcQsG9nplnUwP4JRQpXeoR07vaUKtOuvwtrW0oYGHl+cJK1D
-        EneZPIJNlHaJJc52kqk2lJMnxKaaOFMIKdwy2MsGDCiHyLvJ2NqmouxJwMR8sIlP/BATd5Jet9cf
-        +cpMc18272dZ7gGJ1/WUxrBJG+AbiyHP4YwodwWBg6qR0sOBxmjTvv3fg2/kNTV8FuDU1StWeCw3
-        VQbd3S5V+QMAAP//AwCIsBI12AUAAA==
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9tKWJL0Ak5BWaQzQNsq4aWJC1Ylzmnp17Mx22mYV/33HTtpS
+        CY2nHH/n6u98zibUaCphw4/B5rXJJH1+hZ+roqiDB4M6fO4EYcZNKaCWUOBbbi655SBM43vwWI5M
+        mbeCVfobmWUCTOO2qgwJLlEbJZ2ldA6S/wXLlQSxx7lES75DoHJlXboyfA2MqUpad17otNRcMl6C
+        gGrdQpazBdpSCc7qFqWAZqL2YMx8W3MGZmuS487ML7Sqysnspkq/Ym0cXmA50Tzn8lxaXTdklFBJ
+        /qdCnvn7RXAMcTSMugxOjrtxjNCFIZ52h8lwEEXJbASDvk90I1P7ldIZrkuuPQG+RBIlURzFJ3Ey
+        GPX7T9tootCWq4zNQea4C4yOKfgwENdWQwYWXNAmnE5TMDgaTKd0Dsfjq3Ixf5w9XT7a9KcY3y9O
+        L28jMfkmbr88xD/G4ctzc9ECJOSYob+p68bkWeZ22yEjd9QYZ7VLMJ2MnUmVEzfOsmisH0coQswc
+        hfA1jlIuj2icuXdWPJNVkRLnzhcPRxFRFPdPvXOuCsy4plWpdoAjBx35GXxEAbyp6qFPuIaiFNhj
+        qthW33u33DCQSnIGYifuJvl6cnFxdd27P7+7b/T8v9FIKUyjX5jlxRu7SHa72Kny3X5LlIcPzuOm
+        kcTuOUnTEi4UW5BrRu8QHVtgpls5EWx1tUUXWFtI91hJzx/1ErNX2QW6q6rZ1O/Vd3S6pjjT/BDc
+        FI7QvQK88x0BvFDqEkTlLtWuwTczhpRlGnXauvTuFWjJZe4CWhrCR+pAFH/nxrSeNtXr+OYqaAOC
+        ZlPBCkwglQ0MabYTzJSmmllAcihpVSkX3Nben1egQVrErBeMjakKqh54TvQHE7jCy6ZwJ0h6SX/k
+        OjOVubZxn1TgCGle1yZs0qZtghusSXnxz4hqF+DVKyshHB2otdLt2f09sr29k4qrAhlNdaASx+W+
+        y6B30qMu/wAAAP//AwAtb1QH2AUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -435,7 +435,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -463,7 +463,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      - ipa_session=MagBearerToken=YmBRmKVVQdPodJHG1IJzAWXU1gwyacPDRfh9R43RMThgm6Ef1ErYIoCaR7QVKbO%2bJNiTw09EmPcS4lF6bhAT%2fYIfCuoXs8HnPrr%2bNlHQNolWjUW4cMd6bEjn%2f2Gp381vknCqiNJdmljD2NUXMcIeuO3SqWaLmU4Ke%2bbUjblhcE2I3s%2fxNIVBPKmGhPhQWRpE
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -490,7 +490,231 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
+      - Mon, 20 Jul 2020 12:46:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=RtYQ8kvnUeDEgxRR6f0Azti0QmS3GJSo3tHsTIn2OCADdz8I6FK10uktRXiUI%2bIqjFCQUXFwMEGrZO%2bV5B%2b9msokxj9iKE7X4Cw%2fsPkf5BAEYu98tdVMC2WCjxRy9m%2fpBkXlakLYpymQmzKEg%2fJBMaSY9Z6DGcZ5SaUt5So0Ta3PpffCN6PNfz%2f9Aqsy9nLU;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=RtYQ8kvnUeDEgxRR6f0Azti0QmS3GJSo3tHsTIn2OCADdz8I6FK10uktRXiUI%2bIqjFCQUXFwMEGrZO%2bV5B%2b9msokxj9iKE7X4Cw%2fsPkf5BAEYu98tdVMC2WCjxRy9m%2fpBkXlakLYpymQmzKEg%2fJBMaSY9Z6DGcZ5SaUt5So0Ta3PpffCN6PNfz%2f9Aqsy9nLU
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "nsaccountlock": true, "fasstatusnote":
+      "spamcheck_manual"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '173'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=RtYQ8kvnUeDEgxRR6f0Azti0QmS3GJSo3tHsTIn2OCADdz8I6FK10uktRXiUI%2bIqjFCQUXFwMEGrZO%2bV5B%2b9msokxj9iKE7X4Cw%2fsPkf5BAEYu98tdVMC2WCjxRy9m%2fpBkXlakLYpymQmzKEg%2fJBMaSY9Z6DGcZ5SaUt5So0Ta3PpffCN6PNfz%2f9Aqsy9nLU
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSy24bMQz8FUGXXoz1eu26j1MDtAhySFqgaQ9pAoMr0WvBeiz0sGsY/vdS2o2d
+        XpKbRA6HwyGP3GNIOvLP7PjyqV2nbNig1vT9w6etstMWwoY/TRhfQwgRYgrWRSz50IMRGxTblQGb
+        QBdYUtIm06IvkNn7Zb2o69n8U0lunEGpPIro/GHokUNTmYw5FIQBNTQvoS/4F0yvsRLOPLNfsiWy
+        9a0A66wSoC0YfFF89/36+uauuv/2875AbQAhXLJRO7ElXPQJKdy9ppimFh4hKmejGtmbuqnrD009
+        axbLefPwLKP3ygrVvymjUzu0Z8zX8yTBlsCvQEqKWRBWPZm+d15e1OboFg8R2kvMYJbv1qvOu9QX
+        FtKRiCjwpxMBdqBTbjf6VkpCgA5DBh95PPQlvQdvle0yYBTIfxMJDX+rQhgzY2lOXv24YSOADR6y
+        PQRGF8IC2jhha+eJUzLaX08mtkqreCj5LoEHGxFlxa5CSIbYqcjv0L8LLBPvBuIJa6pmvsydhZO5
+        7WxO+6GvhAjlboey1ViQhQ0lp1PxlWaGcm781km1VihZ9oY9DnY8cp49Qu9dPgGbtKZvObTxfd5s
+        5gBJUv9bajb40npRfayo9T8AAAD//wMA+b5gnmQDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=RtYQ8kvnUeDEgxRR6f0Azti0QmS3GJSo3tHsTIn2OCADdz8I6FK10uktRXiUI%2bIqjFCQUXFwMEGrZO%2bV5B%2b9msokxj9iKE7X4Cw%2fsPkf5BAEYu98tdVMC2WCjxRy9m%2fpBkXlakLYpymQmzKEg%2fJBMaSY9Z6DGcZ5SaUt5So0Ta3PpffCN6PNfz%2f9Aqsy9nLU
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -541,13 +765,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=72mfGKI6Yv49pNq6fC0rA5yT9d6NGhe3WXq5MFEWwM2G77MtWEFTbFOZAWilYP4O%2bkb7%2bF3NgvLDSlpoJKWUBRMQxTlFjdMfC7LeXZsQjp6gZCglzlCWCA38GdmmHI6xmERDMp1QROnbUrLgCAKvzc5aLPPIHpa2OpV8fc%2fKc8DYqjL40G0IhwjEzp%2bYVM0R;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -571,7 +795,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
+      - ipa_session=MagBearerToken=72mfGKI6Yv49pNq6fC0rA5yT9d6NGhe3WXq5MFEWwM2G77MtWEFTbFOZAWilYP4O%2bkb7%2bF3NgvLDSlpoJKWUBRMQxTlFjdMfC7LeXZsQjp6gZCglzlCWCA38GdmmHI6xmERDMp1QROnbUrLgCAKvzc5aLPPIHpa2OpV8fc%2fKc8DYqjL40G0IhwjEzp%2bYVM0R
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -598,230 +822,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
-      Keep-Alive:
-      - timeout=30, max=99
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
-      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_manual"}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '150'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA4RSy27bMBD8FYKXXgxZsuOk7akBWgQ5JC3QtIc2gbGiKJkwHwKXtCsY/vcuKdlu
-        L8mN3JmdnX0cuJcYdeAf2eHfZ1SNjaaWnn6/ebW6Lq/Ksvyw5C8zxg0oneNNNGb4JP+A6bUshDMZ
-        RpvBH0jZ6d8CCi8hKGeDMjKDi3JRljfVTVWtVsvVr8zbOCMb5aUIzg+ZNU+hea6SGd1rrrTrlMWN
-        1KO3ea3svAbcZJD6uTjOka2vBVhnlQBtYbI1NvT49e7u/rF4+vL96dQABggRrQsjD3swYiPFdm3A
-        RtAnxd4rK1T/pmKndtKeOZ/PpiyCEC7aoJ3YEtaCRplGA7juycXe+dRH8PEU3cohQH2JGZnm49p1
-        513sszz5ibQL5C9HIuxAx1R2GkVOQYROYiIfeBj6DO/BW2W7RJiM8p8kQkt8UIgTMqUm8PbbPZsI
-        bFwS2wMyGhlDacOMtc6TZsPoTHo6hlppFYaMdxE82CBlU7BbxGhInZL8Tvp3yJLwbhSesUWxWF6n
-        ysI1qWy1LMuKvg0EyIc7pq2nhGRsTDke82lSz5CPiz+4RrVKNizNhj2P43jmPM1Ieu/SjdmoNX3z
-        7Uzv84aTBjRk9b/lpgFfSl8V7wsq/RcAAP//AwD1GFZWZQMAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
-      Keep-Alive:
-      - timeout=30, max=98
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "session_logout", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '48'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
-        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
-        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
-        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
-        fflYKvQPAAD//wMAt/mjK1gBAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
-      Keep-Alive:
-      - timeout=30, max=97
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: user=admin&password=adminPassw0rd%21
-    headers:
-      Accept:
-      - text/plain
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '36'
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Referer:
-      - https://ipa.noggin.test/ipa/session/login_password
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/login_password
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Length:
-      - '20'
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - text/plain; charset=UTF-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:36 GMT
-      Keep-Alive:
-      - timeout=30, max=100
-      Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
-      Set-Cookie:
-      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY;path=/ipa;httponly;secure;
-      Vary:
-      - Accept-Encoding
-      X-Frame-Options:
-      - DENY
-    status:
-      code: 200
-      message: Success
-- request:
-    body: '{"method": "ping", "params": [[], {}]}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '38'
-      Content-Type:
-      - application/json
-      Cookie:
-      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
-      Referer:
-      - https://ipa.noggin.test/ipa
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://ipa.noggin.test/ipa/session/json
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
-        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
-        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
-        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
-        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
-    headers:
-      Cache-Control:
-      - no-cache, private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - frame-ancestors 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -849,7 +850,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
+      - ipa_session=MagBearerToken=72mfGKI6Yv49pNq6fC0rA5yT9d6NGhe3WXq5MFEWwM2G77MtWEFTbFOZAWilYP4O%2bkb7%2bF3NgvLDSlpoJKWUBRMQxTlFjdMfC7LeXZsQjp6gZCglzlCWCA38GdmmHI6xmERDMp1QROnbUrLgCAKvzc5aLPPIHpa2OpV8fc%2fKc8DYqjL40G0IhwjEzp%2bYVM0R
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -859,20 +860,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU227bOBD9FUEvfXEcybcmCxSogW3Topd006QouiiMETmWuaZIlUMl9gb59x2S
-        kt0senkSeeZ+5lD3uUPqtM//yO6/PwrDn7/zP7um2Wc3hC7/OspyqajVsDfQ4I/MyiivQFOy3USs
-        RmHpR862+geFFxoomb1tc4ZbdGRNOFlXg1H/glfWgD7iyqBn22OgC2lDuCW1AyFsZ3y4b13VOmWE
-        akFDt+shr8QWfWu1EvseZYfUUX8h2gw510DDkQ0faXPhbNderj901RvcU8AbbC+dqpV5YbzbJzJa
-        6Iz61qGScb6FkBM8Oy9OxNlkdlKWCCfnUK5P5pP5rCgm6wXMpjEwtMzl76yTuGuViwTEFJNiUpRF
-        OS/L+Xw6/zJ4M4W+vZNiA6bGg2PxtHz6P0fceQcSPASn+3y1qoBwMVut+J4vl2+m26uX6y+vPvnq
-        s15eb89fXRX68q2+enlT/rXMH76mQRswUKPEOGmoJswzGXY74kMdqKFw6pdAIymeGVszN+HkkXxs
-        p1PSdE3FtIYU5XxRMAvFeaKgAaUjHvM+xx00rcaxsE00U6LjICVekHAYefKq+TkFG9ugVI6XbPvW
-        TwN0Gqsktf6qK215CNqgTr2dVsqcMoObYZ5jxwPhAow1SoA+vJg00PvLi4vX78fXLz5eDwOQBxax
-        sT75UQuN2KDYrpjuDvRBGYOYf5OxVrdoHr/TiBvq96Kt2LJtzc8VAzVAq0F1DHvXDegW9x6qI9by
-        XwLdLcrvohsMnNn1Kq4/lgzyZz9K/42wsEDRUSjR+BudPHDoLeguDNETG4sRsQApidjv22i+A2eU
-        qYNDP3b+iSuwJN4pot7Sh0a5f3id9Q5ZWnl2B5TxAjJiaY+ytXWcU2YsupalVSmt/D7a6w4cGI8o
-        x9mSqGs4exY5cU8oC4lvU+JRNhlPpotQWVgZypbToigDIekR3ucpbNUHhMZSyEN8bZy7gShV02kd
-        6EDnrOvv4Scjj+eDNEIWkNzVI1UELo9VZuOzMVf5DwAA//8DAEAuRiX/BQAA
+        H4sIAAAAAAAAA4RU227bOBD9FUEv++I4km9JChRYA9tNg91tekmCokVhjKixxDVFcjlkYjfIv3dI
+        yfYGCNonDWfO3M/oMXdIQfn8Vfb4f1Fo/nzN/whdt8tuCV3+bZTltSSrYKehw5fMUksvQVFvu026
+        BoWhl8Cm+heFFwqoN3tjc1ZbdGR0lIxrQMvv4KXRoI56qdGz7bkixLDR3ZDcghAmaB/fG1dZJ7WQ
+        FhSE7aDyUmzQW6Ok2A1aBvQVDQ+idh9zDbQX2fCJ2ktngr1evw/VX7ijqO/QXjvZSP1Ge7frh2Eh
+        aPlfQFmn/go4g7KYFycCzs9OyhLhBOZ4cTKfzGdFMVkvYDZNjrFkTv9gXI1bK10aQAoxKSZFWZTn
+        5WS2mE6/7NE8Qm8fatGCbvAALM4Y/ByIW++gBg8R9JivVhUQLmarFb/z5fLKbtq79Ze3d776rJY3
+        m4u3Hwt1/bf6+Odt+WGZP33rG+1AQ4M1pk5jNqFf13G3IxaaOBqK0rAEGtXitTYNzyZKHsmncpRh
+        DbWoVIpxWkl9yuW0ycgTJw+8VG183xFZ6ESLYrPi9AFUggVZ69BVvJoIKeeLgidZTi+SsTUd1tLx
+        Rs1Q52lUnaZSE6ID2SdPqt9xC51VOBam20c/WvcjFKCNlgLU4QZ653fXl5dX78Y3bz7dJKimoX9l
+        xIZx3gWM1/Czirlr4TCt28vuhU1ODps8cPoXZTTyHvXzc0166gl1OMYWaLUn3bHaqN3gzkN11Fn+
+        SaC7xwhb861jIkVsyaxXafspcmQ/46j/bcRscZ5HniTjL2jyxK73oEIsfthCSkbE/KOew35nk/kB
+        nJa6iYCh3fyOM/Ao/5FEg2VwTWx/f5UNgKzfSPYAlDHfMmJmj7K1cRyzzpgNlldSSSX9LtmbAA60
+        R6zH2ZIodBw9SzNxv1EWA9/3gUfZZDyZLmJmYeqYtpzytuNA+ht8zHu31eAQC+tdntKxcewOEnl1
+        UCqOA50zbnjHf0x9lA+UiFGg5qqesSHO8phlNj4fc5YfAAAA//8DADKpvej+BQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -885,7 +886,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -913,7 +914,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
+      - ipa_session=MagBearerToken=72mfGKI6Yv49pNq6fC0rA5yT9d6NGhe3WXq5MFEWwM2G77MtWEFTbFOZAWilYP4O%2bkb7%2bF3NgvLDSlpoJKWUBRMQxTlFjdMfC7LeXZsQjp6gZCglzlCWCA38GdmmHI6xmERDMp1QROnbUrLgCAKvzc5aLPPIHpa2OpV8fc%2fKc8DYqjL40G0IhwjEzp%2bYVM0R
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -940,7 +941,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -978,7 +979,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -986,20 +987,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=3nuonbkEDqdtP%2baw5gIhcd%2b0bcqNZ1OuNY6POyjCtS3uiGG5eUp9cml4Or8%2fxbpJPTlxxGrosOG%2bgZYsNG2vaOVf9il4aKg6dBiahfNuwhKvvo8wpN4v8M3VdwCXz3jUnaAJBdPzLsQMYYpYJS%2fdxgBo8zX8L9mMahLz2tYPfWVV6hW1v%2fsXPXNMEEuTFYWt;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1021,7 +1022,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      - ipa_session=MagBearerToken=3nuonbkEDqdtP%2baw5gIhcd%2b0bcqNZ1OuNY6POyjCtS3uiGG5eUp9cml4Or8%2fxbpJPTlxxGrosOG%2bgZYsNG2vaOVf9il4aKg6dBiahfNuwhKvvo8wpN4v8M3VdwCXz3jUnaAJBdPzLsQMYYpYJS%2fdxgBo8zX8L9mMahLz2tYPfWVV6hW1v%2fsXPXNMEEuTFYWt
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1048,7 +1049,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1077,7 +1078,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      - ipa_session=MagBearerToken=3nuonbkEDqdtP%2baw5gIhcd%2b0bcqNZ1OuNY6POyjCtS3uiGG5eUp9cml4Or8%2fxbpJPTlxxGrosOG%2bgZYsNG2vaOVf9il4aKg6dBiahfNuwhKvvo8wpN4v8M3VdwCXz3jUnaAJBdPzLsQMYYpYJS%2fdxgBo8zX8L9mMahLz2tYPfWVV6hW1v%2fsXPXNMEEuTFYWt
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1105,7 +1106,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:34 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1133,7 +1134,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      - ipa_session=MagBearerToken=3nuonbkEDqdtP%2baw5gIhcd%2b0bcqNZ1OuNY6POyjCtS3uiGG5eUp9cml4Or8%2fxbpJPTlxxGrosOG%2bgZYsNG2vaOVf9il4aKg6dBiahfNuwhKvvo8wpN4v8M3VdwCXz3jUnaAJBdPzLsQMYYpYJS%2fdxgBo8zX8L9mMahLz2tYPfWVV6hW1v%2fsXPXNMEEuTFYWt
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1160,7 +1161,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:55:37 GMT
+      - Mon, 20 Jul 2020 12:46:35 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_manual].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck[spamcheck_manual].yaml
@@ -1,0 +1,1179 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:55:35Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU2U7bQBT9FcsvfUmC7SyQSkhNW5oiVIJKyAMFRdczN8409ow7S5ZG/HtncUiR
+        EDzl+tz93DPZxxKVKXX8Mdr/bxJuf37FX01V7aI7hTJ+bEUxZaouYcehwtfcjDPNoFTBd+exAolQ
+        rwWL/DcSTUpQwa1FHVu4RqkEd5aQBXD2FzQTHMojzjhq63sJGFfWpQvFtkCIMFy775XMa8k4YTWU
+        YLYNpBlZoa5FyciuQW1AmKj5UGp5qLkAdTCt41Ytx1KYerK4MfkV7pTDK6wnkhWMX3Atd4GMGgxn
+        fwwy6vcbEJrh2TBpk7Os105ThPYQ0kW7n/V7SZItBtDr+kQ3sm2/EZLitmbSE+BLZEmWJKfpaZr2
+        +93e/SHaUqjrDSVL4AW+FYhbLYGCBhe0j+fzHBQOevO5/Y5Ho6ts9fPbglTDNf0yXN6P0zpffZ5M
+        E/r99q5nZhez6Ww0Oo+fHsPCFXAokKLf2HUl/Jy6G7esUTiKlLOaY6gWJedcFJYjZ2lU2o+1FBVS
+        Ji3xoilz4qATX8lHVMBK7/DQJ9xCVZfYIaI67EWAC84IlM/CDKHXk/H48rozvbid+lDDKDdVbk/p
+        YtL+ILHMJ8Mj7QelvFNHhXM8S9kKhEj0d9KseuUE/XCC4q3+BVsjf/myPF4KS5laYhlIOMkZP7F3
+        Wx42Os7pkdo+YpRrdPjCvkV0HIOaHyRlYS3NAV3hTkN+xCp044nF3N/Pl3Y6thVV+ANwm7uux0t7
+        5zuHfrKpayiN262Z1TdTyipIBTXqXe3dG5Cc8cIFNGzEM9vBcvuDKdV4mlSv25vLqAmIArvRBlTE
+        hY6U1WYrWghpa9LICqa2N8pZyfTO+wsDErhGpJ1opJSpbPXIsyc/qMgVXofCrSjrZN2B60wEdW3T
+        bpKkjpDwmvZxSJs3CW6wkPLkn4utXYHXdzyiFGnkWIseAhcPsScIpRROGdyUpfv/oEf7WZiuAFA7
+        5wtNOnaPfXuds47t+w8AAP//AwA6U9zu2gUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=OWh9LjV%2fmjaDfeB3oOEWD88cIl%2bJgJkX56A6U%2bdoCLXFl2qoNhK54oN1%2b84qY1SFfPk0P3qpjqqasyK%2bf3Sne3YpRskmIt5GJmfzWTyCrGPAs5qhKQH4o2Z7Mvpcq4weKByV5uyRWJd1ulcWZ%2f3I70Ndqkugf5w2PPTAP5zwQMpqA4B%2fvjAqBEd7O77Dz8dW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:35 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbU/bMBD+K1G+7EspSd+ASUirNN7EBow3TUyoutjX1KtjZ7YD7RD/fWc7bWFi
+        41PO937PPZen1KBtpEs/Jk8vRabo8yP93FTVMrmxaNL7TpJyYWsJSwUVvmUWSjgB0kbbTdCVyLR9
+        y1kXP5E5JsFGs9N1SuoajdXKS9qUoMRvcEIrkBu9UOjI9lrR+LQ+XFuxAMZ0o5x/z01RG6GYqEFC
+        s2hVTrA5ulpLwZatlhxiR+3D2tkq5xTsSiTDlZ0dGd3U59OLpjjFpfX6CutzI0qhDpQzywhGDY0S
+        vxoUPMw3YryHu3vZFtvtDbbyHGFrD/Lp1rA3HGRZbzqCQT8E+pap/KM2HBe1MAGAkKKX9bI8y4d5
+        Phz2h3crb4LQ1Y+czUCVuHbMdvKdvxxx4QxwcOCdntLJpACLo8FkQu90PD7tzy8Pp3fHt674LsfX
+        873jy0yef5GXhzf5t3H6fB8HrUBBiRzDpL4aU/vc77ZDQumhsV5ql2A7nO0rXRI2XnJoXWinEVw1
+        VUGw+hT5cJQRCtlehKACIYM+5P2EC6hqiV2mq2C2EY41lWhBzGDAyYnq3xDMdIVcGFqyblvf9qrt
+        UCWy9X9dSU1D2BnK2Nt2IdQ2IThbzbPpeAU4A6WVYCDXFxMHOjs/Ojo5614fXF2vV75i6TuupXhA
+        9foAg17ZFnCp2ZxsU7pD9DODnazoRGpnmpV2jksHxUZX0/mjeUD+IrpCD4aeTsJeQ0nPa/Kz8Yfg
+        N+Fn3zAgGN8hwDOFPoBs/BAtYqGYtcQsG9nplnUwP4JRQpXeoR07vaUKtOuvwtrW0oYGHl+cJK1D
+        EneZPIJNlHaJJc52kqk2lJMnxKaaOFMIKdwy2MsGDCiHyLvJ2NqmouxJwMR8sIlP/BATd5Jet9cf
+        +cpMc18272dZ7gGJ1/WUxrBJG+AbiyHP4YwodwWBg6qR0sOBxmjTvv3fg2/kNTV8FuDU1StWeCw3
+        VQbd3S5V+QMAAP//AwCIsBI12AUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Pe1HP2W4bS2LFYWXyDZE9hUImYSBHMm0kO3W49ltvlpQvC6SwSmggBcM0GtSjnQfW1sQx6jo1%2bq2f%2fGERuGp7FUdw2NfUyW9yTxVAQkzeLL1nyrQhTlp0tV42IKRIbj5amxeX%2bMt3ZuQ9vSmG7cjTTIgSUG4U5ByNqJNn5DkTnKJ0q%2fPY0O2BiV5T4QSXVpT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_manual"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSy27bMBD8FYKXXgxZsuOk7akBWgQ5JC3QtIc2gbGiKJkwHwKXtCsY/vcuKdlu
+        L8mN3JmdnX0cuJcYdeAf2eHfZ1SNjaaWnn6/ebW6Lq/Ksvyw5C8zxg0oneNNNGb4JP+A6bUshDMZ
+        RpvBH0jZ6d8CCi8hKGeDMjKDi3JRljfVTVWtVsvVr8zbOCMb5aUIzg+ZNU+hea6SGd1rrrTrlMWN
+        1KO3ea3svAbcZJD6uTjOka2vBVhnlQBtYbI1NvT49e7u/rF4+vL96dQABggRrQsjD3swYiPFdm3A
+        RtAnxd4rK1T/pmKndtKeOZ/PpiyCEC7aoJ3YEtaCRplGA7juycXe+dRH8PEU3cohQH2JGZnm49p1
+        513sszz5ibQL5C9HIuxAx1R2GkVOQYROYiIfeBj6DO/BW2W7RJiM8p8kQkt8UIgTMqUm8PbbPZsI
+        bFwS2wMyGhlDacOMtc6TZsPoTHo6hlppFYaMdxE82CBlU7BbxGhInZL8Tvp3yJLwbhSesUWxWF6n
+        ysI1qWy1LMuKvg0EyIc7pq2nhGRsTDke82lSz5CPiz+4RrVKNizNhj2P43jmPM1Ieu/SjdmoNX3z
+        7Uzv84aTBjRk9b/lpgFfSl8V7wsq/RcAAP//AwD1GFZWZQMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=avidneTT0iLVIws3J3qEoy9VlJ8Ft4CIne%2f9QMBo5w8miOpdF%2fTx2QA4%2bT1QGW0IUqWMPL74L2WHrXpNw6utlwS0%2fj3%2bZKKsdUbxOdgsWSijJxoRnJtsrlpIv8y7cfxECuP1p7xwzRoWOs2wJnzK336o26k%2fu0h5dYSqbxoWOO2bcHBxWxNna%2fQrxwTr8tdZ
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"all": true, "raw": false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '75'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU227bOBD9FUEvfXEcybcmCxSogW3Topd006QouiiMETmWuaZIlUMl9gb59x2S
+        kt0senkSeeZ+5lD3uUPqtM//yO6/PwrDn7/zP7um2Wc3hC7/OspyqajVsDfQ4I/MyiivQFOy3USs
+        RmHpR862+geFFxoomb1tc4ZbdGRNOFlXg1H/glfWgD7iyqBn22OgC2lDuCW1AyFsZ3y4b13VOmWE
+        akFDt+shr8QWfWu1EvseZYfUUX8h2gw510DDkQ0faXPhbNderj901RvcU8AbbC+dqpV5YbzbJzJa
+        6Iz61qGScb6FkBM8Oy9OxNlkdlKWCCfnUK5P5pP5rCgm6wXMpjEwtMzl76yTuGuViwTEFJNiUpRF
+        OS/L+Xw6/zJ4M4W+vZNiA6bGg2PxtHz6P0fceQcSPASn+3y1qoBwMVut+J4vl2+m26uX6y+vPvnq
+        s15eb89fXRX68q2+enlT/rXMH76mQRswUKPEOGmoJswzGXY74kMdqKFw6pdAIymeGVszN+HkkXxs
+        p1PSdE3FtIYU5XxRMAvFeaKgAaUjHvM+xx00rcaxsE00U6LjICVekHAYefKq+TkFG9ugVI6XbPvW
+        TwN0Gqsktf6qK215CNqgTr2dVsqcMoObYZ5jxwPhAow1SoA+vJg00PvLi4vX78fXLz5eDwOQBxax
+        sT75UQuN2KDYrpjuDvRBGYOYf5OxVrdoHr/TiBvq96Kt2LJtzc8VAzVAq0F1DHvXDegW9x6qI9by
+        XwLdLcrvohsMnNn1Kq4/lgzyZz9K/42wsEDRUSjR+BudPHDoLeguDNETG4sRsQApidjv22i+A2eU
+        qYNDP3b+iSuwJN4pot7Sh0a5f3id9Q5ZWnl2B5TxAjJiaY+ytXWcU2YsupalVSmt/D7a6w4cGI8o
+        x9mSqGs4exY5cU8oC4lvU+JRNhlPpotQWVgZypbToigDIekR3ucpbNUHhMZSyEN8bZy7gShV02kd
+        6EDnrOvv4Scjj+eDNEIWkNzVI1UELo9VZuOzMVf5DwAA//8DAEAuRiX/BQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=BC%2bkYJEG7HqWrOQSW9yeltCQOmddVx6JySZ5lbvypgjGxx5lGoX5U4Ed%2fpmsTgYSVLYjpScGSmvEXvCfD8ug03WWW6EPecOW4HQHtD5t0iuGU1Om2KL5S4yUhLNzTBDmgoiUFEM36ovEl7cRA%2fh%2fbREUP6vSXwXvJJt3oEyzcxbQgT1BadXdKj4uO8%2bx6vVY
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=76Xn1SoRLmSOhr8TWzGMo0wSq60bPQ6QOPrG%2bR%2fi%2bmLH0FYiZvkxeNqFqY%2bdDg5b5VsGhYBqG2wYcspHzLxZOiHRLwh5Vfi3%2bZII1OmTcr4CkUQ28uKrrBKdK2ROpW3qkqNbrBmpLAKzivff10E%2bdtv0k7K6jaO0FXizZI5O3LZ06hvLNbkXKsLh5Wc2O2cT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:55:37 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload0].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload0].yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:33Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUkmwsJVEJq2lKK2hIkLg8UFM3ak42bXXvrSy6N+PeO7Q0B
+        qYWnzJ4ZnxmfOc421WhcadP3yfZ5yCT9/Ew/u6raJDcGdfrQSlIuTF3CRkKF/0oLKayA0sTcTcAK
+        ZMr8q1jlv5BZVoKJaavqlOAatVHSR0oXIMUfsEJJKPe4kGgp9xJwntYfV0asgTHlpPXfC53XWkgm
+        aijBrRvICrZAW6tSsE2DUkGcqPkwZr7jnIHZhZS4MvMzrVw9mV26/BtujMcrrCdaFEKeSqs3UYwa
+        nBS/HQoe7oec56MZZwfsqJcddLsIB/nx8OjgsHc4yLLebAiDfjjoR6b2K6U5rmuhgwCBopf1smzU
+        HXW7/azfv9tVk4S2XnE2B1nga4W4tho4WPBF23Q6zcHgcDCd0nc6Hn+/E+svM1YdL/mn4/ndWbfO
+        Fx8n1xn/enUzcLent9e34/FJ+vgQL1yBhAI5hhv7rkyecL/jFgWFl8j4qFmGaXF2IlVBGvnIorHR
+        H2KJ8qWhAl6BKAMUKD/gGqq6xDZTVUiXiojMHMtY1MmF7NBt5iHpBJeuymllPtc9HGakcDYa7ZJ7
+        3oCYqO6TM5975mmyOMbF5Ozs/KJ9fXp1HUrnqkIuNNlGNSJ0PNTZkxevzUKdGEglBXuzE5mQaQxe
+        sKL6/5presSol+gvOaO3iH5KMNOdpQi22u3QBW4s5HusQj+qmk3D/kIT72NiNPEPwEvlJdxvOiTf
+        WPQjHV1C6fzYjfChmTHkIBPdaDd1SK9ASyELX9BIkt5SB7r3D2FMk2mOBt9enidNQRKVTlZgEqls
+        YsibrWSmNHHyhKxTk365KIXdhHzhQIO0iLydjI1xFbEnQT39ziSeeBmJW0mv3esPfWemuG9Limdd
+        L0h8Tds0Hps2B/xg8chjeC7EXUFwSDrmHHniVUvuoxb3aRAItVbeJdKVpf//4Pv4yY6eADjN+cIf
+        Xt1930H7qE19/wIAAP//AwCnfF9Q2gUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload0].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload0].yaml
@@ -34,13 +34,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=r4V74rvNdMnND1HAfGqHEZ3L770wZ30tGnt%2bS8jAOe5X63okzo1HEXvu4e%2bdeaZT2CV6WLIiyy7uHqOtdqFBJPDEy78LZ8LiZ6b3ECvyvhD709r7s3N%2bYF1qY6wbtpvd8SlOlz2Z1lR5PdAJ7xmxBJAZYhSg8ZdDgA0ihPyrHhhCX6vfL6Mq%2bwY642Tu%2fv2I;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      - ipa_session=MagBearerToken=r4V74rvNdMnND1HAfGqHEZ3L770wZ30tGnt%2bS8jAOe5X63okzo1HEXvu4e%2bdeaZT2CV6WLIiyy7uHqOtdqFBJPDEy78LZ8LiZ6b3ECvyvhD709r7s3N%2bYF1qY6wbtpvd8SlOlz2Z1lR5PdAJ7xmxBJAZYhSg8ZdDgA0ihPyrHhhCX6vfL6Mq%2bwY642Tu%2fv2I
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:33Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:01Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      - ipa_session=MagBearerToken=r4V74rvNdMnND1HAfGqHEZ3L770wZ30tGnt%2bS8jAOe5X63okzo1HEXvu4e%2bdeaZT2CV6WLIiyy7uHqOtdqFBJPDEy78LZ8LiZ6b3ECvyvhD709r7s3N%2bYF1qY6wbtpvd8SlOlz2Z1lR5PdAJ7xmxBJAZYhSg8ZdDgA0ihPyrHhhCX6vfL6Mq%2bwY642Tu%2fv2I
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUkmwsJVEJq2lKK2hIkLg8UFM3ak42bXXvrSy6N+PeO7Q0B
-        qYWnzJ4ZnxmfOc421WhcadP3yfZ5yCT9/Ew/u6raJDcGdfrQSlIuTF3CRkKF/0oLKayA0sTcTcAK
-        ZMr8q1jlv5BZVoKJaavqlOAatVHSR0oXIMUfsEJJKPe4kGgp9xJwntYfV0asgTHlpPXfC53XWkgm
-        aijBrRvICrZAW6tSsE2DUkGcqPkwZr7jnIHZhZS4MvMzrVw9mV26/BtujMcrrCdaFEKeSqs3UYwa
-        nBS/HQoe7oec56MZZwfsqJcddLsIB/nx8OjgsHc4yLLebAiDfjjoR6b2K6U5rmuhgwCBopf1smzU
-        HXW7/azfv9tVk4S2XnE2B1nga4W4tho4WPBF23Q6zcHgcDCd0nc6Hn+/E+svM1YdL/mn4/ndWbfO
-        Fx8n1xn/enUzcLent9e34/FJ+vgQL1yBhAI5hhv7rkyecL/jFgWFl8j4qFmGaXF2IlVBGvnIorHR
-        H2KJ8qWhAl6BKAMUKD/gGqq6xDZTVUiXiojMHMtY1MmF7NBt5iHpBJeuymllPtc9HGakcDYa7ZJ7
-        3oCYqO6TM5975mmyOMbF5Ozs/KJ9fXp1HUrnqkIuNNlGNSJ0PNTZkxevzUKdGEglBXuzE5mQaQxe
-        sKL6/5presSol+gvOaO3iH5KMNOdpQi22u3QBW4s5HusQj+qmk3D/kIT72NiNPEPwEvlJdxvOiTf
-        WPQjHV1C6fzYjfChmTHkIBPdaDd1SK9ASyELX9BIkt5SB7r3D2FMk2mOBt9enidNQRKVTlZgEqls
-        YsibrWSmNHHyhKxTk365KIXdhHzhQIO0iLydjI1xFbEnQT39ziSeeBmJW0mv3esPfWemuG9Limdd
-        L0h8Tds0Hps2B/xg8chjeC7EXUFwSDrmHHniVUvuoxb3aRAItVbeJdKVpf//4Pv4yY6eADjN+cIf
-        Xt1930H7qE19/wIAAP//AwCnfF9Q2gUAAA==
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBDkmASkhNW0QRaoME5IGCovHuxNnG3nX3kksR/97ZXScB
+        CcGTZ+dyZvbMWT+lGo2rbPo5eXppMkmf3+l3V9eb5M6gTh87ScqFaSrYSKjxrbCQwgqoTIzdBV+J
+        TJm3klXxB5llFZgYtqpJyd2gNkp6S+kSpPgHVigJ1d4vJFqKvXY4D+vLlRFrYEw5af15oYtGC8lE
+        AxW4deuygi3QNqoSbNN6KSFO1B6MmW8xZ2C2JgVuzPxCK9eMZ9euuMKN8f4am7EWpZDn0upNJKMB
+        J8Vfh4KH+x33sizD/OSAwTEe5DnCASDwg0Fv0M+y3mwI/aNQ6Eem9iulOa4boQMBAaKXEQbh5Hl/
+        kGX322yi0DYrzuYgS3wvEddWAwcLPukpnU4LMDjsT6d0Tkejq5NyPZmx+nTJv53O7y/yplh8Hd9m
+        /MfNXd9Nzie3k9HoLH1+jBeuQUKJHMONfVcmz7jfcYeM0lNkvNUuw3Q4O5OqJI68ZdHYqA/BpasL
+        otdD5INhRmzkvUEbXKJ8rbbgr0FUwRX6fcE11E2FXabqEJ6rGrnQtEzVjnboXYd8B+De6+raje3T
+        SQFMY1iEFfUbHOc7jhlIJQWDajd2nPHX+OLi8lf39vzmNqSauNLdc3gp1A9KK0UkmjlWkYPDQshD
+        2uQ8BBt6xKiX6K8wo7eIng8w062kyG2123oXuLFQ7H01elLUbBr2F+C9jgnRxB+An9oTtN90CH6w
+        6GcqXULl/K1aWkMzY0hBJqrRbpoQXoGWQpY+oeUhnVAHov6nMKaNtKVBt9eXSZuQxJ0mKzCJVDYx
+        pM1OMlOaMHlC6mhohYWohN2EeOlAg7SIvJuMjHE1oSeBPf3JJB54GYE7Sa/bOxr6zkxx3zY/Ir14
+        QuJrekpj2bQt8IPFkufwXAi7hqDFdMQ58sSzljxELh7SQBBqrbwepasq///ge3unDA8AnOZ8JQrP
+        7r5vv3vSpb7/AQAA//8DAB+b7tnaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=crGfr%2fPDIjUYK%2fa8UxkotNyKV9j%2bac%2fbyGR%2frS2oPi90khUDHJgrA733dVZOgCOp%2bPKXWAWN9pvjwqulkHyPHIA0YebGK9U%2bWrlx1lBP2p4f1i0%2fb2X9HdRw4oHrCj5YAqCqEcKZcg82VJj9urd%2bvmz7EoLk%2f0DzZ%2bCFZc3vsEHYqhgv0XJlnYwZ6JD1aCYr
+      - ipa_session=MagBearerToken=r4V74rvNdMnND1HAfGqHEZ3L770wZ30tGnt%2bS8jAOe5X63okzo1HEXvu4e%2bdeaZT2CV6WLIiyy7uHqOtdqFBJPDEy78LZ8LiZ6b3ECvyvhD709r7s3N%2bYF1qY6wbtpvd8SlOlz2Z1lR5PdAJ7xmxBJAZYhSg8ZdDgA0ihPyrHhhCX6vfL6Mq%2bwY642Tu%2fv2I
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=2%2fbm6K3Vmbk4v1%2bcs7FTo1BIkr7SDQkawTMGNW0CVUOSnwlly9wJLtuZuOWZsZBtSsWG1hEeZ8zrv2%2bMZZl5h55c5WFtCCkCqVy4Zg1bJD0xGkBnz8SFfKgQP4P%2fXG3Opi7UFYmYWej5frpKZ10vK%2bFr%2fg7Om5o310unlaox%2fxBghzz1qhbh5LeAknZpKInu;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      - ipa_session=MagBearerToken=2%2fbm6K3Vmbk4v1%2bcs7FTo1BIkr7SDQkawTMGNW0CVUOSnwlly9wJLtuZuOWZsZBtSsWG1hEeZ8zrv2%2bMZZl5h55c5WFtCCkCqVy4Zg1bJD0xGkBnz8SFfKgQP4P%2fXG3Opi7UFYmYWej5frpKZ10vK%2bFr%2fg7Om5o310unlaox%2fxBghzz1qhbh5LeAknZpKInu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      - ipa_session=MagBearerToken=2%2fbm6K3Vmbk4v1%2bcs7FTo1BIkr7SDQkawTMGNW0CVUOSnwlly9wJLtuZuOWZsZBtSsWG1hEeZ8zrv2%2bMZZl5h55c5WFtCCkCqVy4Zg1bJD0xGkBnz8SFfKgQP4P%2fXG3Opi7UFYmYWej5frpKZ10vK%2bFr%2fg7Om5o310unlaox%2fxBghzz1qhbh5LeAknZpKInu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=sOJ9bihXKBTqjPSMdi0iTsdvgjymAuRlGrUPxRvxxxiDPBA7cK6oaq9QTzhPabGyj10kqtp59EBo0zQwruRdVdIVRFGIEw8txkpSQVGctxi%2bu%2fnxTJl7rX5Wg9KoGQYhkF1rgKrTv6zeRcl%2b%2fSwWLIl6fwaDV7%2bspgINY8BKJFKf1ZE8Hfg09Vl1IQzQ5wJW
+      - ipa_session=MagBearerToken=2%2fbm6K3Vmbk4v1%2bcs7FTo1BIkr7SDQkawTMGNW0CVUOSnwlly9wJLtuZuOWZsZBtSsWG1hEeZ8zrv2%2bMZZl5h55c5WFtCCkCqVy4Zg1bJD0xGkBnz8SFfKgQP4P%2fXG3Opi7UFYmYWej5frpKZ10vK%2bFr%2fg7Om5o310unlaox%2fxBghzz1qhbh5LeAknZpKInu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:34 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload1].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload1].yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=GTKeQvi%2blC4MPeKgM98tH9y9SDx31lVF%2f%2bv0immGoPllFCMgrqO2w%2bqw4VTvmEhXee45%2bAFDQ6KKQ5ORAbxG4%2fSSaWHD4EovUh8pxgFaUH63e0PKT08xV8nwK16hkZcyClPExhTLPIwbn3oJuLMVe131ps8iV%2biFJXpSIVY0qpGj8vw8pqsM%2bPxOgeaykC3n;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      - ipa_session=MagBearerToken=GTKeQvi%2blC4MPeKgM98tH9y9SDx31lVF%2f%2bv0immGoPllFCMgrqO2w%2bqw4VTvmEhXee45%2bAFDQ6KKQ5ORAbxG4%2fSSaWHD4EovUh8pxgFaUH63e0PKT08xV8nwK16hkZcyClPExhTLPIwbn3oJuLMVe131ps8iV%2biFJXpSIVY0qpGj8vw8pqsM%2bPxOgeaykC3n
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:35Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:02Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      - ipa_session=MagBearerToken=GTKeQvi%2blC4MPeKgM98tH9y9SDx31lVF%2f%2bv0immGoPllFCMgrqO2w%2bqw4VTvmEhXee45%2bAFDQ6KKQ5ORAbxG4%2fSSaWHD4EovUh8pxgFaUH63e0PKT08xV8nwK16hkZcyClPExhTLPIwbn3oJuLMVe131ps8iV%2biFJXpSIVY0qpGj8vw8pqsM%2bPxOgeaykC3n
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBTgKBSkhNW5qitgSJywMFRePdibONvevuJZdG/Htndx1S
-        JFSeMj5zP3M221SjcZVN3yfbf00m6edn+tnV9Sa5NajTx06ScmGaCjYSanzNLaSwAioTfbcBK5Ep
-        81qwKn4hs6wCE91WNSnBDWqjpLeULkGKP2CFklDtcSHRku8l4HxZn66MWANjyknrvxe6aLSQTDRQ
-        gVu3kBVsgbZRlWCbFqWAOFH7Ycx8V3MGZmeS49rMx1q5ZjK7csU33BiP19hMtCiFPJdWbyIZDTgp
-        fjsUPOyHOJzlg352wE562UGeIxycZsPhwVHvaJBlvdkxDPoh0Y9M7VdKc1w3QgcCQole1suyYT7M
-        837WH9zvoolC26w4m4Ms8X+BuLYaOFjwQdt0Oi3A4PFgOqXvdDT6DmL9Zcbq0yX/dDq/H+dNsfg4
-        ucn41+vbgbs7v7u5G43O0qfHuHANEkrkGDb2XZk84/7GHTJKT5HxVnsM0+HsTKqSOPKWRWPDWHNV
-        IxeaiFdtmUMPHYZKIaIGUQVHgD7gGuqmwi5T9W4vBlJJwaB6FmYMvZyMxxeX3Zvz65sQ6gSXri7o
-        lD4mPzrOiPlsePJM+04pb9Qx8RzPUiaBMI3hTlbUr5zgKJ6g/F//UixRvnxZAa8UUWbmWEUSDgsh
-        D+lu891G+zkD0tAjRr1Ej8/oLaLnGMx0JymCrXY7dIEbC8Ueq9GPp2bTcL9Q2uuYKpr4B+A39133
-        lw7ONw79RKlLqJzfrZ01NDOGFGSiGu2mCe4VaClk6QNaNtI76kDc/hDGtJ42Nej26iJpA5LIbrIC
-        k0hlE0Pa7CQzpakmT0gwDd2oEJWwm+AvHWiQFpF3k5ExrqbqSWBPvzOJL7yMhTtJr9vrH/vOTHHf
-        lq6a5Z6Q+Jq2aUybtgl+sJjyFJ4L1a4h6DsdcY488awlD5GLhzQQhForrwzpqsr/f/C9/SxMXwA4
-        zflCk57dfd9B96RLff8CAAD//wMAOBDU9toFAAA=
+        H4sIAAAAAAAAA4RU30/bMBD+V6K87KUtSWjLmIS0bkMMoQ0kSh8YqLrY19QjsTP/KO0Q//vOdtoO
+        CcFTzt/dfXf+7pynVKNxtU0/JU//m0zS51f6zTXNJrkxqNP7XpJyYdoaNhIafM0tpLACahN9NwGr
+        kCnzWrAqfyOzrAYT3Va1KcEtaqOkt5SuQIq/YIWSUO9xIdGS7yXgPK1PV0asgTHlpPXnB122Wkgm
+        WqjBrTvICvaAtlW1YJsOpYDYUXcwZrnlXIDZmuS4NsszrVx7ubhy5QVujMcbbC+1qIQ8lVZvohgt
+        OCn+OBQ83O+oALYYjcZ9BkfYz3OEflmW4/6oGA2zrFiMYXgYEn3LVP5RaY7rVuggQKAosiLLjoos
+        z4ejLL/dRpOEtn3kbAmywrcCcW01cLDgg57S+bwEg+PhfE7ndDK5OK7WswVrjlf86/Hy9ixvy4cv
+        l9OMf7++GbrZ6Ww6m0xO0uf7eOEGJFTIMdzYV2XyhPsZ98iovETGW90wTI+zE6kq0shbFo2N+yFW
+        KF8uVMCd4NI1Jcnu8Xw0zkilvBgHp4l67HZpqRrkQtP0VNfLgYcO+I6uAVEHR4A+4xqatsYBU01w
+        04iZxqC0Fc0rIhY7EXfrtGs6Uv68PDs7/zmYnl5Pt6EMpJKCvRtaK1LFLLGOLR6UQh7QaJZbIfap
+        nWRvSNPSI0a9Qp+0oLeIXh4w8+1KEWy126IPuLFQ7rEGPa9azMP8Ar/fY2I08Qfghfct7ScdnO8M
+        +plSV1A7L0J3kVDMGNogE7fRbtrgfgQthax8QCdbOqMKNJkfwpjO06WGvb06T7qAJMqSPIJJpLKJ
+        od3sJQuliZMnNOuWJlyKWthN8FcONEiLyAfJxBjXEHsS1NMfTOKJV5G4lxSD4nDsKzPFfdn8kCT3
+        gsTX9JTGtHmX4BuLKc/huRB3A2E10wnnyBOvWnIXtbhLg0CotfIjla6u/f+D7+3dznkC4NTnix3y
+        6u7rDgcfB1T3HwAAAP//AwAxYGW42gUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      - ipa_session=MagBearerToken=GTKeQvi%2blC4MPeKgM98tH9y9SDx31lVF%2f%2bv0immGoPllFCMgrqO2w%2bqw4VTvmEhXee45%2bAFDQ6KKQ5ORAbxG4%2fSSaWHD4EovUh8pxgFaUH63e0PKT08xV8nwK16hkZcyClPExhTLPIwbn3oJuLMVe131ps8iV%2biFJXpSIVY0qpGj8vw8pqsM%2bPxOgeaykC3n
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -314,13 +314,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:02 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=uH3Nhnl%2b2zG9ONPFN5NGu7erBlrhlB%2fIyC87Ue85GeB9SxM2n8sXzV%2bmxTKK%2bzYK%2fsOc9OWdheuU6CSKSzy5Mg16bq%2b1Ppk9i93tnOGjVVpYkJR%2fDtxVoXclJl4ew1ZM1DlMwn%2fZHZOxkeCe3bmdLVhTOVv0ZYATrNOTRXVXAZ7Hw4o1Mjkg1N6KSu8BwRzm;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      - ipa_session=MagBearerToken=uH3Nhnl%2b2zG9ONPFN5NGu7erBlrhlB%2fIyC87Ue85GeB9SxM2n8sXzV%2bmxTKK%2bzYK%2fsOc9OWdheuU6CSKSzy5Mg16bq%2b1Ppk9i93tnOGjVVpYkJR%2fDtxVoXclJl4ew1ZM1DlMwn%2fZHZOxkeCe3bmdLVhTOVv0ZYATrNOTRXVXAZ7Hw4o1Mjkg1N6KSu8BwRzm
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      - ipa_session=MagBearerToken=uH3Nhnl%2b2zG9ONPFN5NGu7erBlrhlB%2fIyC87Ue85GeB9SxM2n8sXzV%2bmxTKK%2bzYK%2fsOc9OWdheuU6CSKSzy5Mg16bq%2b1Ppk9i93tnOGjVVpYkJR%2fDtxVoXclJl4ew1ZM1DlMwn%2fZHZOxkeCe3bmdLVhTOVv0ZYATrNOTRXVXAZ7Hw4o1Mjkg1N6KSu8BwRzm
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      - ipa_session=MagBearerToken=uH3Nhnl%2b2zG9ONPFN5NGu7erBlrhlB%2fIyC87Ue85GeB9SxM2n8sXzV%2bmxTKK%2bzYK%2fsOc9OWdheuU6CSKSzy5Mg16bq%2b1Ppk9i93tnOGjVVpYkJR%2fDtxVoXclJl4ew1ZM1DlMwn%2fZHZOxkeCe3bmdLVhTOVv0ZYATrNOTRXVXAZ7Hw4o1Mjkg1N6KSu8BwRzm
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:35 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload1].yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_missing_key[payload1].yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:35Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBTgKBSkhNW5qitgSJywMFRePdibONvevuJZdG/Htndx1S
+        JFSeMj5zP3M221SjcZVN3yfbf00m6edn+tnV9Sa5NajTx06ScmGaCjYSanzNLaSwAioTfbcBK5Ep
+        81qwKn4hs6wCE91WNSnBDWqjpLeULkGKP2CFklDtcSHRku8l4HxZn66MWANjyknrvxe6aLSQTDRQ
+        gVu3kBVsgbZRlWCbFqWAOFH7Ycx8V3MGZmeS49rMx1q5ZjK7csU33BiP19hMtCiFPJdWbyIZDTgp
+        fjsUPOyHOJzlg352wE562UGeIxycZsPhwVHvaJBlvdkxDPoh0Y9M7VdKc1w3QgcCQole1suyYT7M
+        837WH9zvoolC26w4m4Ms8X+BuLYaOFjwQdt0Oi3A4PFgOqXvdDT6DmL9Zcbq0yX/dDq/H+dNsfg4
+        ucn41+vbgbs7v7u5G43O0qfHuHANEkrkGDb2XZk84/7GHTJKT5HxVnsM0+HsTKqSOPKWRWPDWHNV
+        IxeaiFdtmUMPHYZKIaIGUQVHgD7gGuqmwi5T9W4vBlJJwaB6FmYMvZyMxxeX3Zvz65sQ6gSXri7o
+        lD4mPzrOiPlsePJM+04pb9Qx8RzPUiaBMI3hTlbUr5zgKJ6g/F//UixRvnxZAa8UUWbmWEUSDgsh
+        D+lu891G+zkD0tAjRr1Ej8/oLaLnGMx0JymCrXY7dIEbC8Ueq9GPp2bTcL9Q2uuYKpr4B+A39133
+        lw7ONw79RKlLqJzfrZ01NDOGFGSiGu2mCe4VaClk6QNaNtI76kDc/hDGtJ42Nej26iJpA5LIbrIC
+        k0hlE0Pa7CQzpakmT0gwDd2oEJWwm+AvHWiQFpF3k5ExrqbqSWBPvzOJL7yMhTtJr9vrH/vOTHHf
+        lq6a5Z6Q+Jq2aUybtgl+sJjyFJ4L1a4h6DsdcY488awlD5GLhzQQhForrwzpqsr/f/C9/SxMXwA4
+        zflCk57dfd9B96RLff8CAAD//wMAOBDU9toFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ygGErBpzcBG%2fHS2AP5zo44q4CSPuhWoOGOu58qMm0pgZ4K%2f02TjZ8d03PfCLjj3Dl%2f%2bWMvVqpwNKE7wQHRy48InuWgG4dHF0jQi%2fz1PGvQfsG5OZgl9gYIty0QwkVXaB645Y2LIIPtO3cM2uvRCemEUcZMXqkmonyYFqW29NGKRv3gjs5cW2b8UGzi34%2fagP
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=U6LkijFIp6C%2byeKeXinpfIcsYhkj8FMtDWsaUPKCIqWNWURtbwQ3I4f%2frqMa6x8YfXGQb%2baxb%2f1pBTUUXZyRbmUS6F%2fiLhbP3nPNlf7a6%2bWd6dltQEeBebzfXhYpEgWzha%2fd7b14D25Rdf2BVKHAY4DMxRzOkyMyQ2T6AMKhmJuULj9Bncig45PBlXDOm%2buX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:35 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_payload.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_payload.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=BzXhpi%2b7jx1aobsExX1BLUueM%2bt1yeApazBLo61IKbZWU%2bPf6fQSDZpdtIkCHSljrjKRGx9aAkGASC1Yv1jZ%2bjo%2fwa0zefqqfW8XlSFqm9IYpkKxCnNC9axf2p1wEHL5L1WPKBnu0DT0IPDMVKMevUvyGLYrfq690%2bLxJF65i2p%2fJbwURcsqNgMeiycR%2blwB;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      - ipa_session=MagBearerToken=BzXhpi%2b7jx1aobsExX1BLUueM%2bt1yeApazBLo61IKbZWU%2bPf6fQSDZpdtIkCHSljrjKRGx9aAkGASC1Yv1jZ%2bjo%2fwa0zefqqfW8XlSFqm9IYpkKxCnNC9axf2p1wEHL5L1WPKBnu0DT0IPDMVKMevUvyGLYrfq690%2bLxJF65i2p%2fJbwURcsqNgMeiycR%2blwB
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:32Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:00Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      - ipa_session=MagBearerToken=BzXhpi%2b7jx1aobsExX1BLUueM%2bt1yeApazBLo61IKbZWU%2bPf6fQSDZpdtIkCHSljrjKRGx9aAkGASC1Yv1jZ%2bjo%2fwa0zefqqfW8XlSFqm9IYpkKxCnNC9axf2p1wEHL5L1WPKBnu0DT0IPDMVKMevUvyGLYrfq690%2bLxJF65i2p%2fJbwURcsqNgMeiycR%2blwB
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU70/bMBD9V6J82Ze2pGkpMAlp3ca6aRsgAZXGQNXFvqYeie35R2lX8b/v7KR0
-        SAw+1Xl39+787rmb1KD1lUvfJpt/j0zSz8/0o6/rdXJl0aS3nSTlwuoK1hJqfC4spHACKtvEriJW
-        IlP2uWRV/ELmWAW2CTulU4I1GqtkOClTghR/wAklodrhQqKj2FPAB9pQrqxYAWPKSxe+70yhjZBM
-        aKjAr1rICXaHTqtKsHWLUkIzUfth7WLLOQe7PVLgwi4mRnl9Nj/3xVdc24DXqM+MKIU8kc6sGzE0
-        eCl+exQ83g/5ALJ8mHfZYZ51+32EbjHgh939fH+YZfl8BMNBLAwjU/t7ZTiutDBRgEiRZ3mWHfQP
-        +v1BNsivt9kkodP3nC1AlvhSIq6cAQ4OQtImnc0KsDgazmb0nY7H336I1ac5q4+W/MPR4nrS18Xd
-        +7PLjH++uBr66cn0cjoeH6cPt82Fa5BQIsd449CVyWMedtyhQxkksuHULsN2ODuWqiSNwsmhdXGs
-        ShFiF1hVkWOvEHKPxlrEYA2igSPvO1xBrSvsMVVvr8RAKikYVI+ebFJPzyaTL6e9y5OLy5i6UDVy
-        YWi/qp12L0B7MftR9q1TXiHz7Up3xaXg0tcFmSTg/f1RRjvNDkYxSP5hBuManaj/vyHbbPnxhfiX
-        SEuxRPn0IUZc0yNGs8Qw4ZzeIobLg51tLUWwM36L3uHaQbHDagz91HwW9xepg4+J0TZ/AGHEMNhu
-        0zH4yqIfqHQJlQ/DtqrFZtaSg2zjRrfWMXwPRgpZhoT2eumUOpB434W1baQtjb49/5K0CUkjV3IP
-        NpHKJZa82UnmyhAnT8g1mpZQiEq4dYyXHgxIh8h7ydhaXxN7EtUzb2wSiJcNcSfJe/lgFDozxUNb
-        WlvWD4I0r2mTNmWztiAM1pQ8xOdC3DVE46VjzpEnQbXkptHiJo0CoTEqrFr6qgr/H3x3fjRmIABO
-        cz7xZFB313fYO+xR378AAAD//wMAbNPWBdoFAAA=
+        H4sIAAAAAAAAA4RU227bMAz9FcMve0lT23HSdUCBZVvRDcXaAW3zsAsCWmIcrbbk6ZLLgv77KMlJ
+        VmzYniIfkofU4VF2qUbjGpu+Sna/H5mkny/pO9e22+TBoE6/DZKUC9M1sJXQ4t/CQgoroDEx9hCw
+        Gpkyf0tW1XdkljVgYtiqLiW4Q22U9Cela5DiJ1ihJDRHXEi0FHsOOE/ry5URG2BMOWn996OuOi0k
+        Ex004DY9ZAV7RNupRrBtj1JCnKj/MGa551yA2R8pcGeWV1q57nbxyVXXuDUeb7G71aIW8lJavY1i
+        dOCk+OFQ8HC/s3xSjHBRnjA4w5M8RzgBPM9PxsW4zLJiMYFyFAr9yNR+rTTHTSd0ECBQFFmRZWdF
+        ludlOT7/vM8mCW235mwJssZ/JeLGauBgwSft0vm8AoOTcj6n73Q6vT6rN7MFa89X/O358vNV3lWP
+        b27vM/7+7qF0s8vZ/Ww6vUifvsULtyChRo7hxr4rkxfc73hAh9pLZPypX4YZcHYhVU0a+ZNFY8NY
+        jSLELLFpAsdpJeQpjbUMQSe4dG1F2vtYPp5kJFVelCG4VC1yoWllqh/g1EOnYYaQ0YKIrAF6jRto
+        uwaHTLV79mN0rxEDqaRg0BxMHotvbq+uPtwM7y/v7qOv/zUaOYZpDIuzov1jJ+MsO+zk4M7/9luh
+        fP7wAm6iNQ7PqqNHjHqF/moLeovolQIz31uKYKvdHn3ErYXqiLXor6QW87C/wOx9TIwm/gH4bl64
+        46ZD8D+LfqLSFTTOD9/LHZoZQw4y0Y1224XwGrQUsvYJ/XXTGXUgKT8KY/pIXxp8++lD0ickcSPJ
+        GkwilU0MeXOQLJQmTp7Q2jtaSSUaYbchXjvQIC0iHyZTY1xL7ElQT78wiSdeReJBUgyL0cR3Zor7
+        tvmItu0Fia9pl8ayeV/gB4slT+G5EHcLwaXplHPkiVct+Rq1+JoGgVBr5d0kXdP4/w9+PB9M4gmA
+        05zP/OHVPfYthy+H1PcXAAAA//8DAL0qm13aBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      - ipa_session=MagBearerToken=BzXhpi%2b7jx1aobsExX1BLUueM%2bt1yeApazBLo61IKbZWU%2bPf6fQSDZpdtIkCHSljrjKRGx9aAkGASC1Yv1jZ%2bjo%2fwa0zefqqfW8XlSFqm9IYpkKxCnNC9axf2p1wEHL5L1WPKBnu0DT0IPDMVKMevUvyGLYrfq690%2bLxJF65i2p%2fJbwURcsqNgMeiycR%2blwB
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -316,13 +316,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=Fr6a32SE7ck3uTZW1sHfc3h6CmIWx7I1F6eUI45divBVkrkNpm6eRXRgyn9WJqlIbjCAK5J9DOit90t1cWJvbEIakOF2qyNkymjzoyEWFMaZHHm%2fLzmubZtWuV9t2VX5n%2baa4VOV%2bzYgk390jUm3sO4MD%2b0r4q2TKBgQKMevOSK5nT%2b0fmIEGfvpOA%2fWQdhH;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      - ipa_session=MagBearerToken=Fr6a32SE7ck3uTZW1sHfc3h6CmIWx7I1F6eUI45divBVkrkNpm6eRXRgyn9WJqlIbjCAK5J9DOit90t1cWJvbEIakOF2qyNkymjzoyEWFMaZHHm%2fLzmubZtWuV9t2VX5n%2baa4VOV%2bzYgk390jUm3sO4MD%2b0r4q2TKBgQKMevOSK5nT%2b0fmIEGfvpOA%2fWQdhH
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      - ipa_session=MagBearerToken=Fr6a32SE7ck3uTZW1sHfc3h6CmIWx7I1F6eUI45divBVkrkNpm6eRXRgyn9WJqlIbjCAK5J9DOit90t1cWJvbEIakOF2qyNkymjzoyEWFMaZHHm%2fLzmubZtWuV9t2VX5n%2baa4VOV%2bzYgk390jUm3sO4MD%2b0r4q2TKBgQKMevOSK5nT%2b0fmIEGfvpOA%2fWQdhH
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      - ipa_session=MagBearerToken=Fr6a32SE7ck3uTZW1sHfc3h6CmIWx7I1F6eUI45divBVkrkNpm6eRXRgyn9WJqlIbjCAK5J9DOit90t1cWJvbEIakOF2qyNkymjzoyEWFMaZHHm%2fLzmubZtWuV9t2VX5n%2baa4VOV%2bzYgk390jUm3sO4MD%2b0r4q2TKBgQKMevOSK5nT%2b0fmIEGfvpOA%2fWQdhH
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:33 GMT
+      - Mon, 20 Jul 2020 11:45:01 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_payload.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_bad_payload.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:32Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU70/bMBD9V6J82Ze2pGkpMAlp3ca6aRsgAZXGQNXFvqYeie35R2lX8b/v7KR0
+        SAw+1Xl39+787rmb1KD1lUvfJpt/j0zSz8/0o6/rdXJl0aS3nSTlwuoK1hJqfC4spHACKtvEriJW
+        IlP2uWRV/ELmWAW2CTulU4I1GqtkOClTghR/wAklodrhQqKj2FPAB9pQrqxYAWPKSxe+70yhjZBM
+        aKjAr1rICXaHTqtKsHWLUkIzUfth7WLLOQe7PVLgwi4mRnl9Nj/3xVdc24DXqM+MKIU8kc6sGzE0
+        eCl+exQ83g/5ALJ8mHfZYZ51+32EbjHgh939fH+YZfl8BMNBLAwjU/t7ZTiutDBRgEiRZ3mWHfQP
+        +v1BNsivt9kkodP3nC1AlvhSIq6cAQ4OQtImnc0KsDgazmb0nY7H336I1ac5q4+W/MPR4nrS18Xd
+        +7PLjH++uBr66cn0cjoeH6cPt82Fa5BQIsd449CVyWMedtyhQxkksuHULsN2ODuWqiSNwsmhdXGs
+        ShFiF1hVkWOvEHKPxlrEYA2igSPvO1xBrSvsMVVvr8RAKikYVI+ebFJPzyaTL6e9y5OLy5i6UDVy
+        YWi/qp12L0B7MftR9q1TXiHz7Up3xaXg0tcFmSTg/f1RRjvNDkYxSP5hBuManaj/vyHbbPnxhfiX
+        SEuxRPn0IUZc0yNGs8Qw4ZzeIobLg51tLUWwM36L3uHaQbHDagz91HwW9xepg4+J0TZ/AGHEMNhu
+        0zH4yqIfqHQJlQ/DtqrFZtaSg2zjRrfWMXwPRgpZhoT2eumUOpB434W1baQtjb49/5K0CUkjV3IP
+        NpHKJZa82UnmyhAnT8g1mpZQiEq4dYyXHgxIh8h7ydhaXxN7EtUzb2wSiJcNcSfJe/lgFDozxUNb
+        WlvWD4I0r2mTNmWztiAM1pQ8xOdC3DVE46VjzpEnQbXkptHiJo0CoTEqrFr6qgr/H3x3fjRmIABO
+        cz7xZFB313fYO+xR378AAAD//wMAbNPWBdoFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TaacvHFr%2b6CtUZjIln40eFRvN3uSa5YgJybsa89Pcry0p2fdGpaXgnD2jBHNQaJ%2fRlZeMRNVO%2fCppQfFaxUTWUvo9IpNJ7jauUbBcPruhmvXKJN93XitFaZ7kveiA8RuIfzKThyIszcNkXHDfROGhaaydP76952KT6NA2lJHG2aJE4Y3AYzmGCavGZVxM6q9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=gt8FvyZeX06o74llS0d6XJV5AoOZVu4nzYY391rJpGpPYH4Gt3tLTEOxIZQBE0ZmwdPjsOIRHT4tcFMvv2NzxHE2bijDQ4d7aUO1AcPlBi%2f%2be4LjyIr8ykj7WwONmCs3bs4ZEsFRsHOm7dTVTsdvPbnb8TT2SR7S034WtyN83CTTePhTRzslDRJTX7h%2ff%2feb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:33 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_disabled.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_disabled.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:31 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=c6a%2fMucEhRU2rPUKh%2bJyaHUeeo5SB9HPwMkseN2apI2TTjBMNhg6nAsEB0dQCjBB0%2fUcM%2bKe4Spjz0nglRcOJnpfnodnvDWBfH68PUo45KOheh4AJjeIRwX%2fPd1MyGNpt3o%2ff9NYecBmUHFsN4LsEAiydLMEAdyKnroWFxRb1W7OK%2f2POEbo8QBLqGBKSQ7z;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      - ipa_session=MagBearerToken=c6a%2fMucEhRU2rPUKh%2bJyaHUeeo5SB9HPwMkseN2apI2TTjBMNhg6nAsEB0dQCjBB0%2fUcM%2bKe4Spjz0nglRcOJnpfnodnvDWBfH68PUo45KOheh4AJjeIRwX%2fPd1MyGNpt3o%2ff9NYecBmUHFsN4LsEAiydLMEAdyKnroWFxRb1W7OK%2f2POEbo8QBLqGBKSQ7z
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:31 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:31Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:44:59Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      - ipa_session=MagBearerToken=c6a%2fMucEhRU2rPUKh%2bJyaHUeeo5SB9HPwMkseN2apI2TTjBMNhg6nAsEB0dQCjBB0%2fUcM%2bKe4Spjz0nglRcOJnpfnodnvDWBfH68PUo45KOheh4AJjeIRwX%2fPd1MyGNpt3o%2ff9NYecBmUHFsN4LsEAiydLMEAdyKnroWFxRb1W7OK%2f2POEbo8QBLqGBKSQ7z
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBTgKBSkhNW0pRW4JEoBIFRePdibPF3nX3kksR/97ZXScp
-        EoKnjM/cz5zNY6rRuMqm75PH/00m6edX+tnV9Tq5NqjT+06ScmGaCtYSanzJLaSwAioTfdcBK5Ep
-        81KwKn4js6wCE91WNSnBDWqjpLeULkGKv2CFklDtcCHRku854HxZn66MWAFjyknrvx900WghmWig
-        ArdqISvYA9pGVYKtW5QC4kTthzHzTc0ZmI1JjiszP9PKNePZpSu+4dp4vMZmrEUp5Km0eh3JaMBJ
-        8ceh4GE/ZMN+bzY82mNHvWwvzxH2oF8M9g56B4Ms680OYdAPiX5kar9UmuOqEToQEEr0sl6WDfNh
-        nvezfna7iSYKbbPkbA6yxNcCcWU1cLDggx7T6bQAg4eD6ZS+09Ho+0+x+jJj9fGCfzqe357lTfHw
-        cTzJ+Ner64G7Ob2Z3IxGJ+nTfVy4Bgklcgwb+65MnnB/4w4ZpafIeKs9hulwdiJVSRx5y6KxYSwn
-        uHR1QfT6EvnBYUZsZMOD4KxBVAEPdT/gCuqmwi5TdXCbSMtWUnQopjHwZUX9AhV5pGKuauRC07FV
-        O/q+h/ZDl6ja16aqFC1h5ljF2fYLIfeJyflmn93EG+IZSCUFg2r7cuJCF+Ozs/OL7uT0arI9/Uat
-        b4SWYoHy+UMMeEOPGPUC/RQzeovo9wUz3UiKYKvdBn3AtYVih9Xol1azabhfKO11TBVN/APwjPsd
-        d5cOzjcO/USpC6icH7ZlJjQzhhRkohrtugnuJWgpZOkD2vXSG+pAN/0hjGk9bWrQ7eV50gYk8WbJ
-        EkwilU0MabOTzJSmmjwh1TSkjUJUwq6Dv3SgQVpE3k1GxriaqieBPf3OJL7wIhbuJL1ur3/oOzPF
-        fVtSU5Z7QuJrekxj2rRN8IPFlKfwXKh2DUFr6Yhz5IlnLbmLXNylgSDUWnm9SVdV/v+D7+ytKHwB
-        4DTnMz14dnd9B92jLvX9BwAA//8DAN6YrQDaBQAA
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CWEzRICVEJq2iKKUAsSkAcKimbtycbFa299yaWIf+/Y3hCQ
+        EDxldu5zznEec4PWS5d/zh5fmkzRz+/8u2+adXZj0eT3vSznwrYS1goafCsslHACpE2xm+irkWn7
+        VrKu/iBzTIJNYafbnNwtGqtVsLSpQYl/4IRWILd+odBR7LXDh7ahXFuxAsa0Vy58P5iqNUIx0YIE
+        v+pcTrAHdK2Wgq07LyWkjboPa+ebnjOwG5MCV3Z+arRvL2aXvjrHtQ3+BtsLI2qhTpQz6wRGC16J
+        vx4Fj/cdFBVyRNxhcIA7gwHCTjUqZzv75f6wKMrZCIZ7sTCsTOOX2nBctcJEAGKLsiiL4qAsBoPh
+        cP/wdpNNELp2ydkcVI3vJeLKGeDgICQ95tNpBRZHw+mUvvPx+HxUryYz1hwt+Lej+e3poK0evl5c
+        F/zH1c3QT04m15Px+Dh/uk8HN6CgppPixWEqU8c8cNwjow4Q2WB1ZNgeZ8dK14RRsBxat1mLgdJK
+        MJDPuoptvvy6OD09+9W/Prm6jqlz3SAXhjjS3cTd4NqN2UlsgivfVMRViA72RwVBOygTrr4jYpv+
+        UhwfzJaaFrdzlDINroTaJfTmMdiAkC9qcQVNK7HPdBPDpB9mMNLoRPMGQ0eJIZtYfn4h/r1rarFA
+        9fohRn9LjxjNAsOtM3qLGIADO91IitzO+I33AdcOqq2vwTBPz6aRv9g66Jg62vQHEFYMi22ZjsEP
+        iH6i0gVIH5bt8I/DrCUF2aRGt25jeAlGCVWHhO68fEITCLyfwtou0pVG3V6eZV1CluDKlmAzpV1m
+        SZu9bKYN9eQZ0dESCZWQwq1jvPZgQDlE3s/G1vqGumcRPfPJZqHxIjXuZWW/3BuFyUzzMHawR1QE
+        QNJresxT2bQrCIulkqf4XKh3A1G0+Zhz5FlALbtLWNzlESA0RgeqlZcy/H/wrf2s0tAAOO35SqAB
+        3e3cYf+wT3P/AwAA//8DANRXRijaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:31 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      - ipa_session=MagBearerToken=c6a%2fMucEhRU2rPUKh%2bJyaHUeeo5SB9HPwMkseN2apI2TTjBMNhg6nAsEB0dQCjBB0%2fUcM%2bKe4Spjz0nglRcOJnpfnodnvDWBfH68PUo45KOheh4AJjeIRwX%2fPd1MyGNpt3o%2ff9NYecBmUHFsN4LsEAiydLMEAdyKnroWFxRb1W7OK%2f2POEbo8QBLqGBKSQ7z
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=B2%2bfQf8dY7pYR5ITWxqyI5%2fMPPo7AepD%2bhQAM98vDw5%2fwzUmVsIGErQdfEWRvH8jCABveaSFJEirIptdNEGNdYq%2bglycY4yYqM%2fgepk988D%2b3iyfCVsPJzANdO2YwQIEYPBDlUp6HhFwcTf2shDDOKScKr4UeJ8p2yWG70N4hK7DBS97veKqCPJwHL5xRNpY;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      - ipa_session=MagBearerToken=B2%2bfQf8dY7pYR5ITWxqyI5%2fMPPo7AepD%2bhQAM98vDw5%2fwzUmVsIGErQdfEWRvH8jCABveaSFJEirIptdNEGNdYq%2bglycY4yYqM%2fgepk988D%2b3iyfCVsPJzANdO2YwQIEYPBDlUp6HhFwcTf2shDDOKScKr4UeJ8p2yWG70N4hK7DBS97veKqCPJwHL5xRNpY
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      - ipa_session=MagBearerToken=B2%2bfQf8dY7pYR5ITWxqyI5%2fMPPo7AepD%2bhQAM98vDw5%2fwzUmVsIGErQdfEWRvH8jCABveaSFJEirIptdNEGNdYq%2bglycY4yYqM%2fgepk988D%2b3iyfCVsPJzANdO2YwQIEYPBDlUp6HhFwcTf2shDDOKScKr4UeJ8p2yWG70N4hK7DBS97veKqCPJwHL5xRNpY
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:44:59 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      - ipa_session=MagBearerToken=B2%2bfQf8dY7pYR5ITWxqyI5%2fMPPo7AepD%2bhQAM98vDw5%2fwzUmVsIGErQdfEWRvH8jCABveaSFJEirIptdNEGNdYq%2bglycY4yYqM%2fgepk988D%2b3iyfCVsPJzANdO2YwQIEYPBDlUp6HhFwcTf2shDDOKScKr4UeJ8p2yWG70N4hK7DBS97veKqCPJwHL5xRNpY
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:32 GMT
+      - Mon, 20 Jul 2020 11:45:00 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_disabled.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_disabled.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:31 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:31 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:31Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBTgKBSkhNW0pRW4JEoBIFRePdibPF3nX3kksR/97ZXScp
+        EoKnjM/cz5zNY6rRuMqm75PH/00m6edX+tnV9Tq5NqjT+06ScmGaCtYSanzJLaSwAioTfdcBK5Ep
+        81KwKn4js6wCE91WNSnBDWqjpLeULkGKv2CFklDtcCHRku854HxZn66MWAFjyknrvx900WghmWig
+        ArdqISvYA9pGVYKtW5QC4kTthzHzTc0ZmI1JjiszP9PKNePZpSu+4dp4vMZmrEUp5Km0eh3JaMBJ
+        8ceh4GE/ZMN+bzY82mNHvWwvzxH2oF8M9g56B4Ms680OYdAPiX5kar9UmuOqEToQEEr0sl6WDfNh
+        nvezfna7iSYKbbPkbA6yxNcCcWU1cLDggx7T6bQAg4eD6ZS+09Ho+0+x+jJj9fGCfzqe357lTfHw
+        cTzJ+Ner64G7Ob2Z3IxGJ+nTfVy4Bgklcgwb+65MnnB/4w4ZpafIeKs9hulwdiJVSRx5y6KxYSwn
+        uHR1QfT6EvnBYUZsZMOD4KxBVAEPdT/gCuqmwi5TdXCbSMtWUnQopjHwZUX9AhV5pGKuauRC07FV
+        O/q+h/ZDl6ja16aqFC1h5ljF2fYLIfeJyflmn93EG+IZSCUFg2r7cuJCF+Ozs/OL7uT0arI9/Uat
+        b4SWYoHy+UMMeEOPGPUC/RQzeovo9wUz3UiKYKvdBn3AtYVih9Xol1azabhfKO11TBVN/APwjPsd
+        d5cOzjcO/USpC6icH7ZlJjQzhhRkohrtugnuJWgpZOkD2vXSG+pAN/0hjGk9bWrQ7eV50gYk8WbJ
+        EkwilU0MabOTzJSmmjwh1TSkjUJUwq6Dv3SgQVpE3k1GxriaqieBPf3OJL7wIhbuJL1ur3/oOzPF
+        fVtSU5Z7QuJrekxj2rRN8IPFlKfwXKh2DUFr6Yhz5IlnLbmLXNylgSDUWnm9SVdV/v+D7+ytKHwB
+        4DTnMz14dnd9B92jLvX9BwAA//8DAN6YrQDaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:31 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=24Hj7Fv4XxUXnR7onzHXRep3fQe6N5VTzIDryOArG0TtaIXxPFFl5vklBWk5UqIozuYwpZxhdyy8DGzz7WcF%2fnw5XEJvOyqSihAC6GqAEZkKckY%2fgezLG74x366EjRoGez1HMtiiXw0eSmkf8tvQ44aCMAUtWtWswxUoaqoJQ4CaZ%2fkBWY7KjcumflMLJdxI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=7bQ2ytzpSZDkhzL6mAktuwOek5sHlt5QJyEeAZnFFR3l1%2bLa1Wdc0zgaNZQfvjpolJZ7WT68xwIyBX%2f6NqUW7FDBYdszpSTprk%2fs97mbqT5Q5ZzJ9NBHeR%2fHuUYaYd9MrNzbt2As1tJbbNliZ8Z4pFo1K4WO1VmnF8807E6mmxA7GpNWWkEJKFeaaumv8Jod
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:32 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_expired_token.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_expired_token.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:36Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBNiGQSkhNW0pRW0Ai5IGCovHuxNli77p7yaWIf+/srkOK
+        hMpTxmfuZ87mMdVoXG3T98njvyaT9PMz/eyaZpPcGNTpfS9JuTBtDRsJDb7mFlJYAbWJvpuAVciU
+        eS1Ylb+QWVaDiW6r2pTgFrVR0ltKVyDFH7BCSah3uJBoyfcScL6sT1dGrIEx5aT13w+6bLWQTLRQ
+        g1t3kBXsAW2rasE2HUoBcaLuw5jFtuYczNYkx7VZnGnl2sv5lSu/4cZ4vMH2UotKyFNp9SaS0YKT
+        4rdDwcN+OC+Ko9Eo22PHRbaX5wh7Ixjle4fF4SDLivkQBgch0Y9M7VdKc1y3QgcCQokiK7LsKD/K
+        84Ps4PB2G00U2nbF2QJkhf8LxLXVwMGCD3pMZ7MSDA4Hsxl9p+Px91Ksv8xZM1ryT6PF7Vnelg8f
+        LycZ/3p9M3DT0+lkOh6fpE/3ceEGJFTIMWzsuzJ5wv2Ne2RUniLjre4YpsfZiVQVceQti8aGsZzg
+        0jUl0etL5IfDjNjIjkbB2YCoAx7qfsA1NG2Nfaaa4DaRlmdJ0aGYxsCXFc0rVAwjFQvVIBeajq26
+        0fc9tB+6RNX+b6pa0RJmgXWcbb8Ucp+YXGz32U28JZ6BVFIwqJ9fTlzo4vLs7PyiPzm9njyffqvW
+        N0IrsUT58iEGvKVHjHqJfoo5vUX0+4KZbSVFsNVuiz7gxkK5wxr0S6v5LNwvlPY6poom/gF4xv2O
+        u0sH5xuHfqLUJdTOD9sxE5oZQwoyUY120wb3CrQUsvIB3XrplDrQTX8IYzpPlxp0e3WedAFJvFmy
+        ApNIZRND2uwlc6WpJk9INS1poxS1sJvgrxxokBaR95OxMa6h6klgT78ziS+8jIV7SdEvDoa+M1Pc
+        tyU1ZbknJL6mxzSmzboEP1hMeQrPhWo3ELSWjjlHnnjWkrvIxV0aCEKtldebdHXt/z/4zn4WhS8A
+        nOZ8oQfP7q7voH/cp75/AQAA//8DAFCanMHaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:36 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_expired_token.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_expired_token.yaml
@@ -34,13 +34,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=TQmtrEfofuhrCU%2b6p%2bZbbeiQFgS4PKDq49BELi0wgYuMVlYR9b3dAZG16chxdD1KegqGqIIy9%2fj%2bGNWIj2C5LvsGa69t3aj2C6q%2f2P3hRKceECZ%2b4Mr%2f%2bEqDWfXMtwoeAVNtteSXiposL2Lcx0GuwhwRPoY7rvFksPYL8H6Jd0BKnSJPE66AcTJGI1WstUoV;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      - ipa_session=MagBearerToken=TQmtrEfofuhrCU%2b6p%2bZbbeiQFgS4PKDq49BELi0wgYuMVlYR9b3dAZG16chxdD1KegqGqIIy9%2fj%2bGNWIj2C5LvsGa69t3aj2C6q%2f2P3hRKceECZ%2b4Mr%2f%2bEqDWfXMtwoeAVNtteSXiposL2Lcx0GuwhwRPoY7rvFksPYL8H6Jd0BKnSJPE66AcTJGI1WstUoV
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:36Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:03Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      - ipa_session=MagBearerToken=TQmtrEfofuhrCU%2b6p%2bZbbeiQFgS4PKDq49BELi0wgYuMVlYR9b3dAZG16chxdD1KegqGqIIy9%2fj%2bGNWIj2C5LvsGa69t3aj2C6q%2f2P3hRKceECZ%2b4Mr%2f%2bEqDWfXMtwoeAVNtteSXiposL2Lcx0GuwhwRPoY7rvFksPYL8H6Jd0BKnSJPE66AcTJGI1WstUoV
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBNiGQSkhNW0pRW0Ai5IGCovHuxNli77p7yaWIf+/srkOK
-        hMpTxmfuZ87mMdVoXG3T98njvyaT9PMz/eyaZpPcGNTpfS9JuTBtDRsJDb7mFlJYAbWJvpuAVciU
-        eS1Ylb+QWVaDiW6r2pTgFrVR0ltKVyDFH7BCSah3uJBoyfcScL6sT1dGrIEx5aT13w+6bLWQTLRQ
-        g1t3kBXsAW2rasE2HUoBcaLuw5jFtuYczNYkx7VZnGnl2sv5lSu/4cZ4vMH2UotKyFNp9SaS0YKT
-        4rdDwcN+OC+Ko9Eo22PHRbaX5wh7Ixjle4fF4SDLivkQBgch0Y9M7VdKc1y3QgcCQokiK7LsKD/K
-        84Ps4PB2G00U2nbF2QJkhf8LxLXVwMGCD3pMZ7MSDA4Hsxl9p+Px91Ksv8xZM1ryT6PF7Vnelg8f
-        LycZ/3p9M3DT0+lkOh6fpE/3ceEGJFTIMWzsuzJ5wv2Ne2RUniLjre4YpsfZiVQVceQti8aGsZzg
-        0jUl0etL5IfDjNjIjkbB2YCoAx7qfsA1NG2Nfaaa4DaRlmdJ0aGYxsCXFc0rVAwjFQvVIBeajq26
-        0fc9tB+6RNX+b6pa0RJmgXWcbb8Ucp+YXGz32U28JZ6BVFIwqJ9fTlzo4vLs7PyiPzm9njyffqvW
-        N0IrsUT58iEGvKVHjHqJfoo5vUX0+4KZbSVFsNVuiz7gxkK5wxr0S6v5LNwvlPY6poom/gF4xv2O
-        u0sH5xuHfqLUJdTOD9sxE5oZQwoyUY120wb3CrQUsvIB3XrplDrQTX8IYzpPlxp0e3WedAFJvFmy
-        ApNIZRND2uwlc6WpJk9INS1poxS1sJvgrxxokBaR95OxMa6h6klgT78ziS+8jIV7SdEvDoa+M1Pc
-        tyU1ZbknJL6mxzSmzboEP1hMeQrPhWo3ELSWjjlHnnjWkrvIxV0aCEKtldebdHXt/z/4zn4WhS8A
-        nOZ8oQfP7q7voH/cp75/AQAA//8DAFCanMHaBQAA
+        H4sIAAAAAAAAA4RUW2/TMBT+K1FeeKDr0vQyhjSJAtNACIa0rQ8wVJ3YJ6mZYwdfupZp/51jO103
+        aWJPOT53f9/n3OUGrZcuf5vdPTaZos/P/KNv2212ZdHkvwZZzoXtJGwVtPhcWCjhBEibYlfR1yDT
+        9rlkXf1G5pgEm8JOdzm5OzRWq2Bp04ASf8EJrUDu/UKho9hThw9tQ7m2YgOMaa9cON+YqjNCMdGB
+        BL/pXU6wG3SdloJtey8lpI36g7WrXc8a7M6kwIVdnRntu/P6u6++4NYGf4vduRGNUKfKmW0CowOv
+        xB+Pgsf7HY2ns/pNVR4wOMKD0Qjh4BiK+mBaTidFUdYzmIxjYViZxt9qw3HTCRMBiC3KoiyKo7IY
+        jSbTovyxyyYIXXfL2QpUg/9LxI0zwMFBSLrLl8sKLM4myyWd8/n8y+tms6hZe7zmH45XP85GXXXz
+        /vyy4J8uriZ+cbq4XMznJ/n9r3ThFhQ0yDHeOExl6oQHjgdkNAEiG6yeDDvg7ETphjAKlkPrdmsx
+        UFoJBvJBV7HNu2/nZ2efvw0vTy8uY+pKt8iFIY50P/EwuA5jdhKb4Mq3FXEVoqPprCBoR+VRDPqe
+        iH36Y3G8MFtqWtyuUMo0uBLqkNBbxWALQj6qxQ20ncQh020Mk36YwUijE+0zDI0TQzax/PBC/P9u
+        04g1qqcPMfo7esRo1hjuWtNbxAAc2OVOUuR2xu+8N7h1UO19LYZ5ul5G/mLroGPqaNMPIKwYFtsz
+        HYMvEH1PpWuQPizb4x+HWUsKskmNbtvF8C0YJVQTEvrr5QuaQOB9Fdb2kb406vb756xPyBJc2S3Y
+        TGmXWdLmIKu1oZ48Izo6IqESUrhtjDceDCiHyIfZ3FrfUvcsomde2Sw0XqfGg6wcluNZmMw0D2NH
+        Y6IiAJJe012eypZ9QVgsldzH50K9W4iizeecI88Catl1wuI6jwChMTpQrbyU4f/B9/aDSkMD4LTn
+        E4EGdPdzJ8M3Q5r7DwAA//8DAJIcSvvaBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AJ2WzYwcVWGPKmARQ1hsAB%2fcHd1bR4P6Er19X9bBzX2mlazlGBcxrUpKmPpWPAp75xp7q066u0ogscF4TZjzxCZ3pYOO%2ftr3mjmW%2b9oKi1lKPBxHJAA%2f7%2b7hR0sV8nOIq6WBMnwg2c6q1iKPkMWXOvI%2f8w4zpx%2b0ZoleqU1AtSUO7XsJHsSH2Kw9eQmhOcdM
+      - ipa_session=MagBearerToken=TQmtrEfofuhrCU%2b6p%2bZbbeiQFgS4PKDq49BELi0wgYuMVlYR9b3dAZG16chxdD1KegqGqIIy9%2fj%2bGNWIj2C5LvsGa69t3aj2C6q%2f2P3hRKceECZ%2b4Mr%2f%2bEqDWfXMtwoeAVNtteSXiposL2Lcx0GuwhwRPoY7rvFksPYL8H6Jd0BKnSJPE66AcTJGI1WstUoV
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:03 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=q3Ep5AyLrvXwRIoDEzJwm3p3Dp8plX6L3qUDbfi%2b6dykod1V5pACdsWtwDL%2bsi5QuhYgrgWt2a2euovsso%2b5CvGnmH9EksEXUGGdcQ0vjLtRDhLgmkI2axyocLsHxzwrBlHWGoQcw5Y1rErQXuIL2HQyEGJDcVs1itoOtOwnXwMwkRoYN6GgPySneAaW3aGO;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      - ipa_session=MagBearerToken=q3Ep5AyLrvXwRIoDEzJwm3p3Dp8plX6L3qUDbfi%2b6dykod1V5pACdsWtwDL%2bsi5QuhYgrgWt2a2euovsso%2b5CvGnmH9EksEXUGGdcQ0vjLtRDhLgmkI2axyocLsHxzwrBlHWGoQcw5Y1rErQXuIL2HQyEGJDcVs1itoOtOwnXwMwkRoYN6GgPySneAaW3aGO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      - ipa_session=MagBearerToken=q3Ep5AyLrvXwRIoDEzJwm3p3Dp8plX6L3qUDbfi%2b6dykod1V5pACdsWtwDL%2bsi5QuhYgrgWt2a2euovsso%2b5CvGnmH9EksEXUGGdcQ0vjLtRDhLgmkI2axyocLsHxzwrBlHWGoQcw5Y1rErQXuIL2HQyEGJDcVs1itoOtOwnXwMwkRoYN6GgPySneAaW3aGO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:36 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Gz2h%2fww3HaoJygoF9r7erLODloUd5XimSPFoyoAKLvdghXzomTIDIrrP20LNLg0HaTt0E8SUXreFbgqhYD%2fsPb9u6T81n3LVg%2f%2bo5e6ZHLRjhjF12dHz3VhFxrwUB0PMqFP3fDGHt3UO5jPZ0ONqV8IMfhZxNRqF9sSQYV5UgR7aY4mT3XiZgaJfPYNHCURt
+      - ipa_session=MagBearerToken=q3Ep5AyLrvXwRIoDEzJwm3p3Dp8plX6L3qUDbfi%2b6dykod1V5pACdsWtwDL%2bsi5QuhYgrgWt2a2euovsso%2b5CvGnmH9EksEXUGGdcQ0vjLtRDhLgmkI2axyocLsHxzwrBlHWGoQcw5Y1rErQXuIL2HQyEGJDcVs1itoOtOwnXwMwkRoYN6GgPySneAaW3aGO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_invalid_token.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_invalid_token.yaml
@@ -34,13 +34,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=4Olx3sishbUgT%2bPb0ByhZ8kVJqI6roF4dtuA4cviH4Sqk4BQTw4DPLoXJcIhrfcRhYpkKhCITJUgAUw2rHtQzdczVYlRRM796ZasxxUHnRuEXDPmGmcKDCWbnZwxqnIqNV01a36t1nBWIHkW83rmp04lnRwaFRkCn0giJE2mpA7wx0KHZLk1ku1eAYcuxiU2;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      - ipa_session=MagBearerToken=4Olx3sishbUgT%2bPb0ByhZ8kVJqI6roF4dtuA4cviH4Sqk4BQTw4DPLoXJcIhrfcRhYpkKhCITJUgAUw2rHtQzdczVYlRRM796ZasxxUHnRuEXDPmGmcKDCWbnZwxqnIqNV01a36t1nBWIHkW83rmp04lnRwaFRkCn0giJE2mpA7wx0KHZLk1ku1eAYcuxiU2
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:37Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:04Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      - ipa_session=MagBearerToken=4Olx3sishbUgT%2bPb0ByhZ8kVJqI6roF4dtuA4cviH4Sqk4BQTw4DPLoXJcIhrfcRhYpkKhCITJUgAUw2rHtQzdczVYlRRM796ZasxxUHnRuEXDPmGmcKDCWbnZwxqnIqNV01a36t1nBWIHkW83rmp04lnRwaFRkCn0giJE2mpA7wx0KHZLk1ku1eAYcuxiU2
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU70/bMBD9V6J82ZdSklIKTEJatzGGtgESpR8YqLrYl9QjsTP/KO0q/ved7bQd
-        Ehqf6ry7e3d+79x1qtG42qbvk/W/Rybp52f62TXNKrk1qNOHXpJyYdoaVhIafC0spLACahNjtwGr
-        kCnzWrIqfiGzrAYTw1a1KcEtaqOkPyldgRR/wAolod7hQqKl2EvAeVpfroxYAmPKSeu/H3XRaiGZ
-        aKEGt+wgK9gj2lbVgq06lBLiRN2HMfMNZwlmc6TAjZmfa+Xaq/LaFd9wZTzeYHulRSXkmbR6FcVo
-        wUnx26Hg4X5YsiM+Ggz32PEg28tzhL0C4HDvcHA4zLJBOYLhQSj0I1P7J6U5LluhgwCBYpANsuwo
-        P8rzg+xgdLfJJglt+8TZHGSF/0vEpdXAwYJPWqezWQEGR8PZjL7T8fg7E8svJWtOFvzTyfzuPG+L
-        x49Xk4x/vbkduunZdDIdj0/T54d44QYkVMgx3Nh3ZfKUe497dKi8RMafOjNMj7NTqSrSyJ8sGhvG
-        qhUhZo51HTj2CyH3aax5CDYgIhx4P+ASmrbGPlPN5koMpJKCQb3dyZh6eXV+fnHZn5zdTELqXDXI
-        hSZ/VTftvof2Q/ZW9s2mvEHmOkt3xZXg0jUFLYnH88NRRp5mx1kI0v4wjcFGK5pXHDqKDpno8vaF
-        uP+RVmKB8uVDDHhLjxj1Av2EJb1F9JcHM9usFMFWuw36iCsLxQ5r0PdT5Sz4F6j9HhOjiX8AfkQ/
-        2M7pEHzD6GcqXUDt/LCdaqGZMbRBJm6jXbUh/ARaCln5hO566ZQ6kHg/hDFdpCsNe3t9kXQJSZQr
-        eQKTSGUTQ7vZS0qliZMntDUtmVCIWthViFcONEiLyPvJ2BjXEHsS1NPvTOKJF5G4lwz6g4OR78wU
-        923Jtiz3gsTXtE5j2awr8IPFkufwXIi7gbB46Zhz5IlXLbmPWtynQSDUWnmrpatr///Bd+ftYnoC
-        4DTni5306u76DvvHfer7FwAA//8DAKDcCujaBQAA
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUkm03CpRJS0xZRhApIQB4oKJq1Zzcuu/bWl5AU8e8d25uk
+        SAie4j0zc2Z85jjPqUbjapt+Tp7/PzJJP7/S765p1smtQZ0+9JKUC9PWsJbQ4FthIYUVUJsYuw1Y
+        hUyZt5JV8RuZZTWYGLaqTQluURsl/UnpCqT4C1YoCfUOFxItxV4DztP6cmXEChhTTlr//aiLVgvJ
+        RAs1uFUHWcEe0baqFmzdoZQQJ+o+jFlsOEswmyMFrs3iVCvXXpZXrjjHtfF4g+2lFpWQJ9LqdRSj
+        BSfFH4eCh/sdjEqYlHm2x+AA94ZDhD3IDw/2JvlknGV5uQ/jUSj0I1P7J6U5rlqhgwCBIs/yLDvI
+        s+FwPMlGd5tsktC2T5wtQFb4XiKurAYOFnzSczqfF2Bwfzyf03c6nZ4PqtWsZM3Rkn87WtydDtvi
+        8evlTcZ/XN+O3exkdjObTo/Tl4d44QYkVMgx3Nh3ZfKY+x336FB5iYw/dcswPc6OpapII3+yaGwY
+        q1aEmAXWdeAYFEIOaKxFCDrBpWsK0t7HhpP9jKQa5ochuFANcqFpZaobYOChQZghZDQgImuAvuAK
+        mrbGPlPNhn0X3WjEQCopGNRbk8fii8vT07OL/s3J9U309XujkWOYxrA4K5o3djLe7mTrzg/7LVG+
+        fngBN9Ea22fV0iNGvUR/tZLeInqlwMw3liLYardBH3FtodhhDforqXIe9heYvY+J0cQ/AN/NC7fb
+        dAh+sOgXKl1C7fzwndyhmTHkIBPdaNdtCD+BlkJWPqG7bjqjDiTlT2FMF+lKg2+vzpIuIYkbSZ7A
+        JFLZxJA3e0mpNHHyhNbe0koKUQu7DvHKgQZpEXk/mRrjGmJPgnr6k0k88TIS95K8n4/2fWemuG87
+        HNG2vSDxNT2nsWzeFfjBYslLeC7E3UBwaTrlHHniVUvuoxb3aRAItVbeTdLVtf//4Lvz1iSeADjN
+        +cofXt1d33H/sE99/wEAAP//AwBpFGNS2gUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      - ipa_session=MagBearerToken=4Olx3sishbUgT%2bPb0ByhZ8kVJqI6roF4dtuA4cviH4Sqk4BQTw4DPLoXJcIhrfcRhYpkKhCITJUgAUw2rHtQzdczVYlRRM796ZasxxUHnRuEXDPmGmcKDCWbnZwxqnIqNV01a36t1nBWIHkW83rmp04lnRwaFRkCn0giJE2mpA7wx0KHZLk1ku1eAYcuxiU2
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:04 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:37 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=HTWmvQg8QRGQWUUI9FgQlmYSim4kihCZ2UlVncJG2jwvQ8KqJUpzXp7JNzlQWYRQIR883%2btnp%2f4HEPR4ct3ODG7YfVS3RdQlEm%2fQW9kAUt500cYPzUOGbIrxHvWptUgKebZtUlvBlkRI30TVS%2f4WtzMWYtne6pQAbE4QFuk98j6CBl4e57K%2b0APExv3jCIxy;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      - ipa_session=MagBearerToken=HTWmvQg8QRGQWUUI9FgQlmYSim4kihCZ2UlVncJG2jwvQ8KqJUpzXp7JNzlQWYRQIR883%2btnp%2f4HEPR4ct3ODG7YfVS3RdQlEm%2fQW9kAUt500cYPzUOGbIrxHvWptUgKebZtUlvBlkRI30TVS%2f4WtzMWYtne6pQAbE4QFuk98j6CBl4e57K%2b0APExv3jCIxy
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      - ipa_session=MagBearerToken=HTWmvQg8QRGQWUUI9FgQlmYSim4kihCZ2UlVncJG2jwvQ8KqJUpzXp7JNzlQWYRQIR883%2btnp%2f4HEPR4ct3ODG7YfVS3RdQlEm%2fQW9kAUt500cYPzUOGbIrxHvWptUgKebZtUlvBlkRI30TVS%2f4WtzMWYtne6pQAbE4QFuk98j6CBl4e57K%2b0APExv3jCIxy
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      - ipa_session=MagBearerToken=HTWmvQg8QRGQWUUI9FgQlmYSim4kihCZ2UlVncJG2jwvQ8KqJUpzXp7JNzlQWYRQIR883%2btnp%2f4HEPR4ct3ODG7YfVS3RdQlEm%2fQW9kAUt500cYPzUOGbIrxHvWptUgKebZtUlvBlkRI30TVS%2f4WtzMWYtne6pQAbE4QFuk98j6CBl4e57K%2b0APExv3jCIxy
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_invalid_token.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_invalid_token.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:37Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU70/bMBD9V6J82ZdSklIKTEJatzGGtgESpR8YqLrYl9QjsTP/KO0q/ved7bQd
+        Ehqf6ry7e3d+79x1qtG42qbvk/W/Rybp52f62TXNKrk1qNOHXpJyYdoaVhIafC0spLACahNjtwGr
+        kCnzWrIqfiGzrAYTw1a1KcEtaqOkPyldgRR/wAolod7hQqKl2EvAeVpfroxYAmPKSeu/H3XRaiGZ
+        aKEGt+wgK9gj2lbVgq06lBLiRN2HMfMNZwlmc6TAjZmfa+Xaq/LaFd9wZTzeYHulRSXkmbR6FcVo
+        wUnx26Hg4X5YsiM+Ggz32PEg28tzhL0C4HDvcHA4zLJBOYLhQSj0I1P7J6U5LluhgwCBYpANsuwo
+        P8rzg+xgdLfJJglt+8TZHGSF/0vEpdXAwYJPWqezWQEGR8PZjL7T8fg7E8svJWtOFvzTyfzuPG+L
+        x49Xk4x/vbkduunZdDIdj0/T54d44QYkVMgx3Nh3ZfKUe497dKi8RMafOjNMj7NTqSrSyJ8sGhvG
+        qhUhZo51HTj2CyH3aax5CDYgIhx4P+ASmrbGPlPN5koMpJKCQb3dyZh6eXV+fnHZn5zdTELqXDXI
+        hSZ/VTftvof2Q/ZW9s2mvEHmOkt3xZXg0jUFLYnH88NRRp5mx1kI0v4wjcFGK5pXHDqKDpno8vaF
+        uP+RVmKB8uVDDHhLjxj1Av2EJb1F9JcHM9usFMFWuw36iCsLxQ5r0PdT5Sz4F6j9HhOjiX8AfkQ/
+        2M7pEHzD6GcqXUDt/LCdaqGZMbRBJm6jXbUh/ARaCln5hO566ZQ6kHg/hDFdpCsNe3t9kXQJSZQr
+        eQKTSGUTQ7vZS0qliZMntDUtmVCIWthViFcONEiLyPvJ2BjXEHsS1NPvTOKJF5G4lwz6g4OR78wU
+        923Jtiz3gsTXtE5j2awr8IPFkufwXIi7gbB46Zhz5IlXLbmPWtynQSDUWnmrpatr///Bd+ftYnoC
+        4DTni5306u76DvvHfer7FwAA//8DAKDcCujaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=dKV35rxHF7zEMeNi1nIBt9fu9FpmvTx2CasZwlUD2ZRdFVG7%2ba7yPWNS5jJP54n3PHMy0y9Ioywpz5PqzXcpk1o1kOLtw29K9clqo1qfjs%2fKdMX3ckaj0zOOjfcoDod9PA7uI5GSmOqZBXqCSxLy5i01R5KwsJn10BebH81Q%2fp%2bmN7Cmkk7DLoz0ybtr4PV9
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:37 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=b2dV4iBJAin0d1zp%2fpgOPZtEiHHVelJNCkvPJBKoSVA5tyMRn9WJS66xMgQm8ZA4EAqy%2fu3pyCQI0iBFrXLB8T0ixWuQyCgvxTLmElZStMKRHseW2VrOQlVWGereINTH6dkaE9h5H%2fFxnMXNIwzQMXb60l%2fI2q50rjD4g5AayC0XokEKWCtOsuSRAEoAyzVn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_wrong_status.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_wrong_status.yaml
@@ -1,0 +1,502 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:38Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUkuyEkoRJS05amqC0gcXmgoGjWnmzc7NpbX0JSxL93bG8I
+        SAieMntmfGZ85jgPqUbjKpt+TB6eh0zSz+/0q6vrTXJlUKd3nSTlwjQVbCTU+FpaSGEFVCbmrgJW
+        IlPmtWJV/EFmWQUmpq1qUoIb1EZJHyldghT/wAolodrhQqKl3EvAeVp/XBmxBsaUk9Z/L3XRaCGZ
+        aKACt24hK9gSbaMqwTYtSgVxovbDmMWWcw5mG1LiwiymWrnmbH7uih+4MR6vsTnTohTyWFq9iWI0
+        4KT461DwcL95NsqLwwL32Lif7eU5wt5hNhrtHfQPBlnWnw9hsB8O+pGp/b3SHNeN0EGAQNHP+hmx
+        jPJ8P9sf3WyrSULb3HO2AFniW4W4tho4WPBFD+lsVoDB4WA2o+90MvnJxfrbnNWHK/7lcHEzzZti
+        +fnsMuPfL64G7vr4+vJ6MjlKH+/ihWuQUCLHcGPflckj7nfcoaD0EhkftcswHc6OpCpJIx9ZNDb6
+        Q6xQvjRUwGsQVYAC5SdcQ91U2GWqDulKEZFZYBWLeoWQPbrNIiSd4NLVBa3M5/KDYUYKZ+N8m9zx
+        BsREdZ+c+dwzT5PFMU7PptOT0+7l8cVlKF2oGrnQZBvVitDzUG9HXr41C3ViIJUU7N1OZEKmMXjB
+        ivqVNY/jmht6xKhX6C85p7eIfkows62lCLbabdElbiwUO6xGP6qaz8L+QhPvY2I08Q/AS+Ul3G06
+        JN9Z9CMdXUHl/Nit8KGZMeQgE91oN01I34OWQpa+oJUkvaYOdO9fwpg20x4Nvj0/SdqCJCqd3INJ
+        pLKJIW92krnSxMkTsk5D+hWiEnYT8qUDDdIi8m4yMcbVxJ4E9fQHk3jiVSTuJP1uf3/oOzPFfVtS
+        PMu9IPE1PaTx2Kw94AeLRx7DcyHuGoJD0gnnyBOvWnIbtbhNg0CotfIuka6q/P8H38VPdvQEwGnO
+        F/7w6u76DrrjLvX9DwAA//8DAGY7BanaBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:38 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:39 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:39 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:30:39 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_wrong_status.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_registration/test_spamcheck_wrong_status.yaml
@@ -21,7 +21,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=haj8m%2fAJr1gJC6MVMOjNh6RpHoWwCS1Ibm4sLBqklqj8dnRWkRBZftSU8UbOakzJ49cN1OYjm04nCug5S%2bqcXCFEL98LfX9KABwpuyZtpZi8KYMFEIIc%2f%2byicX4t%2b4XkVy5buujGY%2fNmD4rrQwRM18vAnZeWQpb7dw%2bD87qLD0o0ansi4JHaQJemHrXZ5O6W;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      - ipa_session=MagBearerToken=haj8m%2fAJr1gJC6MVMOjNh6RpHoWwCS1Ibm4sLBqklqj8dnRWkRBZftSU8UbOakzJ49cN1OYjm04nCug5S%2bqcXCFEL98LfX9KABwpuyZtpZi8KYMFEIIc%2f%2byicX4t%2b4XkVy5buujGY%2fNmD4rrQwRM18vAnZeWQpb7dw%2bD87qLD0o0ansi4JHaQJemHrXZ5O6W
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -108,7 +108,7 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
       "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
-      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:30:38Z"}]}'
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-20T11:45:05Z"}]}'
     headers:
       Accept:
       - application/json
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      - ipa_session=MagBearerToken=haj8m%2fAJr1gJC6MVMOjNh6RpHoWwCS1Ibm4sLBqklqj8dnRWkRBZftSU8UbOakzJ49cN1OYjm04nCug5S%2bqcXCFEL98LfX9KABwpuyZtpZi8KYMFEIIc%2f%2byicX4t%2b4XkVy5buujGY%2fNmD4rrQwRM18vAnZeWQpb7dw%2bD87qLD0o0ansi4JHaQJemHrXZ5O6W
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,20 +131,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU204bMRD9ldW+9CUkuyEkoRJS05amqC0gcXmgoGjWnmzc7NpbX0JSxL93bG8I
-        SAieMntmfGZ85jgPqUbjKpt+TB6eh0zSz+/0q6vrTXJlUKd3nSTlwjQVbCTU+FpaSGEFVCbmrgJW
-        IlPmtWJV/EFmWQUmpq1qUoIb1EZJHyldghT/wAolodrhQqKl3EvAeVp/XBmxBsaUk9Z/L3XRaCGZ
-        aKACt24hK9gSbaMqwTYtSgVxovbDmMWWcw5mG1LiwiymWrnmbH7uih+4MR6vsTnTohTyWFq9iWI0
-        4KT461DwcL95NsqLwwL32Lif7eU5wt5hNhrtHfQPBlnWnw9hsB8O+pGp/b3SHNeN0EGAQNHP+hmx
-        jPJ8P9sf3WyrSULb3HO2AFniW4W4tho4WPBFD+lsVoDB4WA2o+90MvnJxfrbnNWHK/7lcHEzzZti
-        +fnsMuPfL64G7vr4+vJ6MjlKH+/ihWuQUCLHcGPflckj7nfcoaD0EhkftcswHc6OpCpJIx9ZNDb6
-        Q6xQvjRUwGsQVYAC5SdcQ91U2GWqDulKEZFZYBWLeoWQPbrNIiSd4NLVBa3M5/KDYUYKZ+N8m9zx
-        BsREdZ+c+dwzT5PFMU7PptOT0+7l8cVlKF2oGrnQZBvVitDzUG9HXr41C3ViIJUU7N1OZEKmMXjB
-        ivqVNY/jmht6xKhX6C85p7eIfkows62lCLbabdElbiwUO6xGP6qaz8L+QhPvY2I08Q/AS+Ul3G06
-        JN9Z9CMdXUHl/Nit8KGZMeQgE91oN01I34OWQpa+oJUkvaYOdO9fwpg20x4Nvj0/SdqCJCqd3INJ
-        pLKJIW92krnSxMkTsk5D+hWiEnYT8qUDDdIi8m4yMcbVxJ4E9fQHk3jiVSTuJP1uf3/oOzPFfVtS
-        PMu9IPE1PaTx2Kw94AeLRx7DcyHuGoJD0gnnyBOvWnIbtbhNg0CotfIuka6q/P8H38VPdvQEwGnO
-        F/7w6u76DrrjLvX9DwAA//8DAGY7BanaBQAA
+        H4sIAAAAAAAAA4RUW0/bMBT+K1Fe9tKWtE3LmIS0bkMMbQMkoA8MVJ3Yp6lHYme+9DLEf9+xnbYg
+        IXjK8Xeu/s7nPKYajats+il5fG4ySZ/f6TdX15vkxqBO7ztJyoVpKthIqPE1t5DCCqhM9N0ErESm
+        zGvBqviDzLIKTHRb1aQEN6iNkt5SugQp/oEVSkK1x4VES76XgPNlfboyYg2MKSetPz/ootFCMtFA
+        BW7dQlawB7SNqgTbtCgFxInagzGLbc05mK1JjiuzONXKNRfzS1f8wI3xeI3NhRalkCfS6k0kowEn
+        xV+Hgof7HeZH+XyI4y6DQ+z2+whdQODd0WCUZ9lgPoZ8GBL9yNR+pTTHdSN0ICCUGGSDLDscZP1+
+        Psry2200UWibFWcLkCW+FYhrq4GDBR/0mM5mBRgc57MZndPJ5OekXE/nrD5a8q9Hi9vTflM8fLm4
+        zvj3q5vcTU+m19PJ5Dh9uo8XrkFCiRzDjX1XJo+533GHjNJTZLzVLsN0ODuWqiSOvGXR2KgPwaWr
+        C6LXl+iPxhmx0R8ctc4lypdqC3gNogpQ6PcZ11A3FfaYqoN7oWrkQtMyVTvagYcO+K6Ae6uraze2
+        DycFMI1hEVbUr3A82nHMQCopGFS7seOM5xenp2fnveuTq+sQauJKd8/huVDfSa0UkWgWWEUODgoh
+        D2iTi+Bs6BGjXqK/wpzeIno+wMy2kiLYardFH3BjodhjNXpS1HwW9hfKex1TRRN/AH5qT9B+08H5
+        zqKfKHUJlfO3amkNzYwhBZmoRrtpgnsFWgpZ+oCWh3RKHYj6X8KY1tOmBt1eniVtQBJ3mqzAJFLZ
+        xJA2O8lcaarJE1JHQyssRCXsJvhLBxqkReS9ZGKMq6l6EtjTH0ziCy9j4U4y6A2GY9+ZKe7b9oek
+        F09IfE2PaUybtQl+sJjyFJ4L1a4haDGdcI488awld5GLuzQQhForr0fpqsr/P/je3inDFwBOc74Q
+        hWd33zfvfexR3/8AAAD//wMA9/jk+toFAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -157,7 +157,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=AP1tczlnN9vt3RMWW58J0PDF4BS1nEBQu2W5e9GPWRB64oTEIQViSzq3P%2b86fqYhZ9nfk3PKmspK7Tw4STM34r%2fCxomyaJhta2p6TPeyJnmAm87ns5RRmWBA4kGP%2b8XSkEr%2bSFFzP3orJNDSUVVXpz8Juov%2b6uKpd6y3QGZOwITa1HZygwhD71XlzuPHmTSu
+      - ipa_session=MagBearerToken=haj8m%2fAJr1gJC6MVMOjNh6RpHoWwCS1Ibm4sLBqklqj8dnRWkRBZftSU8UbOakzJ49cN1OYjm04nCug5S%2bqcXCFEL98LfX9KABwpuyZtpZi8KYMFEIIc%2f%2byicX4t%2b4XkVy5buujGY%2fNmD4rrQwRM18vAnZeWQpb7dw%2bD87qLD0o0ansi4JHaQJemHrXZ5O6W
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -212,7 +212,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:05 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -263,7 +263,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:06 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -301,7 +301,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -309,20 +309,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Fri, 17 Jul 2020 11:30:38 GMT
+      - Mon, 20 Jul 2020 11:45:06 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
       Set-Cookie:
-      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=KWb9q1f874Zvyz9Jlu5WBBFyq7XT6MRjxzTo1McqsNw0L1yRnUdDaIPBWc2b2fFp7rmKlRwau0u%2fKuer%2bEdtv1kff1%2fUyaksCnGON2MaGbRkr2%2fgGPaxzgG3s5vrMtDJP09e2DTKJ%2b5MFvka%2bLUiwsbWvcQPXSRn1SANgK6bPwIhi1PorXonW%2bBHzsn1aWWR;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -344,7 +344,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      - ipa_session=MagBearerToken=KWb9q1f874Zvyz9Jlu5WBBFyq7XT6MRjxzTo1McqsNw0L1yRnUdDaIPBWc2b2fFp7rmKlRwau0u%2fKuer%2bEdtv1kff1%2fUyaksCnGON2MaGbRkr2%2fgGPaxzgG3s5vrMtDJP09e2DTKJ%2b5MFvka%2bLUiwsbWvcQPXSRn1SANgK6bPwIhi1PorXonW%2bBHzsn1aWWR
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -371,7 +371,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:39 GMT
+      - Mon, 20 Jul 2020 11:45:06 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -400,7 +400,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      - ipa_session=MagBearerToken=KWb9q1f874Zvyz9Jlu5WBBFyq7XT6MRjxzTo1McqsNw0L1yRnUdDaIPBWc2b2fFp7rmKlRwau0u%2fKuer%2bEdtv1kff1%2fUyaksCnGON2MaGbRkr2%2fgGPaxzgG3s5vrMtDJP09e2DTKJ%2b5MFvka%2bLUiwsbWvcQPXSRn1SANgK6bPwIhi1PorXonW%2bBHzsn1aWWR
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -428,7 +428,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:39 GMT
+      - Mon, 20 Jul 2020 11:45:06 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -456,7 +456,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=Q7trWCCp%2bkPpIuyy7lcf4AakOx%2baZao7U%2fXyQUomc5qacSYFFvDAGdBN%2bEtuHCp0ACDJ%2baxTHcGGEcZiJWJuQgtdCMZmzapdTVb%2bXQ0tJRf6JnCQBCWMbfZ4SKZ0M5cA5OGTz41advEUGsUFwd1junmGQhPFCYT3IFhixorXesKVLZ%2f32DQPzc9rr1BYAt%2fj
+      - ipa_session=MagBearerToken=KWb9q1f874Zvyz9Jlu5WBBFyq7XT6MRjxzTo1McqsNw0L1yRnUdDaIPBWc2b2fFp7rmKlRwau0u%2fKuer%2bEdtv1kff1%2fUyaksCnGON2MaGbRkr2%2fgGPaxzgG3s5vrMtDJP09e2DTKJ%2b5MFvka%2bLUiwsbWvcQPXSRn1SANgK6bPwIhi1PorXonW%2bBHzsn1aWWR
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -483,7 +483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 17 Jul 2020 11:30:39 GMT
+      - Mon, 20 Jul 2020 11:45:06 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -524,6 +524,7 @@ def test_spamcheck(client, dummy_user, mocker, spamcheck_status):
     # Check that the status was changed
     user = User(ipa_admin.user_show("dummy"))
     assert user.status_note == spamcheck_status
+    assert user.locked == (spamcheck_status != "active")
 
 
 @pytest.mark.vcr()
@@ -582,9 +583,4 @@ def test_spamcheck_wrong_status(client, dummy_user, mocker):
         "/register/spamcheck-hook", json={"token": token, "status": "this-is-wrong"},
     )
     assert response.status_code == 400
-    assert response.json == {
-        "error": (
-            "Invalid status: this-is-wrong. Must be one of spamcheck_denied, "
-            "spamcheck_manual, active."
-        )
-    }
+    assert response.json == {"error": "Invalid status: this-is-wrong."}

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -114,7 +114,7 @@ def test_step_3(client, post_data_step_3, token_for_dummy_user, cleanup_dummy_us
     assert_redirects_with_flash(
         result,
         "/",
-        "Congratulations, your account is now active! Welcome, Dummy User.",
+        "Congratulations, your account has been created! Welcome, Dummy User.",
         "success",
     )
 
@@ -279,7 +279,7 @@ def test_short_password_policy(
         result,
         expected_url="/",
         expected_message=(
-            'Your account has been activated, but the password you chose does not comply '
+            'Your account has been created, but the password you chose does not comply '
             'with the policy (Constraint violation: Password is too short) and has thus '
             'been set as expired. You will be asked to change it after logging in.'
         ),
@@ -446,7 +446,7 @@ def test_generic_activate_error(
         )
     assert_form_generic_error(
         result,
-        'Something went wrong while activating your account, please try again later.',
+        'Something went wrong while creating your account, please try again later.',
     )
 
 
@@ -473,7 +473,7 @@ def test_generic_pwchange_error(
         result,
         expected_url="/",
         expected_message=(
-            'Your account has been activated, but an error occurred while setting your '
+            'Your account has been created, but an error occurred while setting your '
             'password (something went wrong). You may need to change it after logging in.'
         ),
         expected_category="warning",
@@ -501,7 +501,7 @@ def test_no_direct_login(
         result,
         expected_url="/",
         expected_message=(
-            "Congratulations, your account is now active! Go ahead and sign in to proceed."
+            "Congratulations, your account has been created! Go ahead and sign in to proceed."
         ),
         expected_category="success",
     )

--- a/noggin/tests/unit/test_signals.py
+++ b/noggin/tests/unit/test_signals.py
@@ -1,0 +1,61 @@
+from io import BytesIO
+
+import pytest
+import requests
+from flask import current_app
+
+from noggin import ipa_admin
+from noggin.app import app
+from noggin.representation.user import User
+from noggin.signals import request_basset_check
+from noggin.utility.token import Audience, read_token
+
+
+@pytest.mark.vcr()
+def test_signal_basset(client, mocker, dummy_user):
+    mocked_requests = mocker.patch("noggin.signals.requests")
+    mocker.patch.dict(current_app.config, {"BASSET_URL": "http://basset.test"})
+    user = User(ipa_admin.user_show("dummy"))
+    with current_app.test_request_context('/'):
+        request_basset_check(user)
+    call_args = mocked_requests.post.call_args_list[0]
+    assert list(call_args[0]) == ["http://basset.test"]
+    json_data = call_args[1]["json"]
+    assert json_data["action"] == "fedora.noggin.registration"
+    expected_dict = user.as_dict()
+    expected_dict["human_name"] = user.commonname
+    expected_dict["email"] = user.mail
+    assert json_data["data"]["user"] == expected_dict
+    assert json_data["data"]["request_headers"] == {"Host": "localhost"}
+    assert json_data["data"]["callback"] == "http://localhost/register/spamcheck-hook"
+    token = json_data["data"]["token"]
+    token_data = read_token(token, audience=Audience.spam_check)
+    assert token_data["sub"] == "dummy"
+
+
+@pytest.mark.vcr()
+def test_signal_basset_disabled(client, mocker, dummy_user):
+    mocked_requests = mocker.patch("noggin.signals.requests")
+    user = User(ipa_admin.user_show("dummy"))
+    with current_app.test_request_context('/'):
+        request_basset_check(user)
+    mocked_requests.post.assert_not_called()
+
+
+@pytest.mark.vcr()
+def test_signal_basset_failed(client, mocker, dummy_user):
+    mocked_requests = mocker.patch("noggin.signals.requests")
+    failure = requests.Response()
+    failure.status_code = 500
+    failure.reason = "Server Error"
+    failure.raw = BytesIO(b"nope.")
+    mocked_requests.post.return_value = failure
+    mocker.patch.dict(current_app.config, {"BASSET_URL": "http://basset.test"})
+    logger = mocker.patch.object(app, "logger")
+    user = User(ipa_admin.user_show("dummy"))
+    with current_app.test_request_context('/'):
+        request_basset_check(user)
+    mocked_requests.post.assert_called()
+    logger.warning.assert_called_with(
+        "Error requesting a Basset check: 500 Server Error: nope."
+    )

--- a/noggin/tests/unit/utilities.py
+++ b/noggin/tests/unit/utilities.py
@@ -1,9 +1,10 @@
 import hashlib
+from contextlib import contextmanager
 from urllib import parse
 
 import pyotp
 from bs4 import BeautifulSoup
-from flask import get_flashed_messages
+from flask import get_flashed_messages, template_rendered
 
 
 def assert_redirects_with_flash(
@@ -61,3 +62,18 @@ def get_otp(secret):
     """
     totp = pyotp.TOTP(secret, 6, hashlib.sha512)
     return totp.now()
+
+
+# https://flask.palletsprojects.com/en/1.1.x/signals/#subscribing-to-signals
+@contextmanager
+def captured_templates(app):
+    recorded = []
+
+    def record(sender, template, context, **extra):
+        recorded.append((template, context))
+
+    template_rendered.connect(record)
+    try:
+        yield recorded
+    finally:
+        template_rendered.disconnect(record, app)

--- a/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_awaiting].yaml
+++ b/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_awaiting].yaml
@@ -1,0 +1,895 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:12 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=SZNBHDUsZi4IEH%2faMof%2fjJOs%2bcAGFSd5ULJov341KeHHec0xcHn7x9KqOp%2fABFoNczb9Ep%2b%2f4jk3srbzqA7B0tmdXC1fU6Xp5QjtTGpjjelUWhcSJmTjlY93ewzW9xF2aV%2fB%2b488ttfe%2bC%2bOQEE1EjVpdZSUib46ZrJ1NUnGPaZHoT4NXcOWOXTTn%2f%2fbqcCT;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SZNBHDUsZi4IEH%2faMof%2fjJOs%2bcAGFSd5ULJov341KeHHec0xcHn7x9KqOp%2fABFoNczb9Ep%2b%2f4jk3srbzqA7B0tmdXC1fU6Xp5QjtTGpjjelUWhcSJmTjlY93ewzW9xF2aV%2fB%2b488ttfe%2bC%2bOQEE1EjVpdZSUib46ZrJ1NUnGPaZHoT4NXcOWOXTTn%2f%2fbqcCT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:52:12Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SZNBHDUsZi4IEH%2faMof%2fjJOs%2bcAGFSd5ULJov341KeHHec0xcHn7x9KqOp%2fABFoNczb9Ep%2b%2f4jk3srbzqA7B0tmdXC1fU6Xp5QjtTGpjjelUWhcSJmTjlY93ewzW9xF2aV%2fB%2b488ttfe%2bC%2bOQEE1EjVpdZSUib46ZrJ1NUnGPaZHoT4NXcOWOXTTn%2f%2fbqcCT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUyW7bMBD9FUGXXrxI8hKnQIA6beoGbeMAcXxIExgjciSzlkiVi5ca+feSlGw3
+        QJucTL2ZeTN88+h9KFGZQofvg/3fR8Ltz4/wkynLXXCvUIZPrSCkTFUF7DiU+K8w40wzKFQdu/dY
+        jkSofyWL9CcSTQpQdViLKrRwhVIJ7k5C5sDZb9BMcChOOOOobewlYBytKxeKbYEQYbh23yuZVpJx
+        wioowGwbSDOyQl2JgpFdg9qEeqLmQ6nlgTMDdTjawJ1aTqQw1TS7NelX3CmHl1hNJcsZv+Ja7mox
+        KjCc/TLIqL9f1o9IFlNok1HSa8cxQjuNhtAeJIN+FCXZEPo9X+hGtu03QlLcVkx6ATxFEiVRdBaf
+        xfEgiZOHQ7aVUFcbSpbAc3wtEbdaAgUNLmkfLhYpKBz2Fwv7HY7H39Tq8nNGyvM1/Xi+fJjEVbq6
+        nM4i+uXuvm/mV/PZfDy+CJ+f6guXwCFHiv7GrivhF9TtuGUPuZNIuVOzDNWi5IKL3GrkThqV9mMV
+        wiJqiUXhObop41071tIHS2A17Hk/4BbKqsAOEeXhSgS44IxAcfRknXoznUyubzqzq7uZT12KEimT
+        dr+imbbroK7PPsp+cMobZKZZ6ak4Z5SbMrUmcXg8GEZ2p9Fo5IPWP0SiX6Nm5f83pOotH1+IeY00
+        Z2vkLx+ixyv7iFGu0U2Y2beI7vKgFgdLWVhLc0BXuNOQnrASXT+RLfz+PLXzsWVU9R+AG9ENdtq0
+        D76x6GdbuobCuGEb1XwzpayDVO1Gvat8eAOSM567hOZ64dx2sOJ9Z0o1kabU+/b2OmgSglquYAMq
+        4EIHynqzFWRCWk4aWNdUdgkpK5je+XhuQALXiLQTjJUypWUPvHrynQoc8bombgVJJ+kNXWciqGsb
+        96IodoLUr2kf1mWLpsANVpc8++diuUvwxgvHlCINnGrBY63FY+gFQimFWzU3ReH+P+jpfDSmIwBq
+        53zhSafuqW+/M+rYvn8AAAD//wMA38ZtWNoFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SZNBHDUsZi4IEH%2faMof%2fjJOs%2bcAGFSd5ULJov341KeHHec0xcHn7x9KqOp%2fABFoNczb9Ep%2b%2f4jk3srbzqA7B0tmdXC1fU6Xp5QjtTGpjjelUWhcSJmTjlY93ewzW9xF2aV%2fB%2b488ttfe%2bC%2bOQEE1EjVpdZSUib46ZrJ1NUnGPaZHoT4NXcOWOXTTn%2f%2fbqcCT
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=rkuNXALcBgQ7RKY7Sl%2f7gXrmzfEbUmqCHhW79zVCuQ%2bj4onJc%2bPDS%2bJzL%2bU2V8fEJ87UYQXhmf6zi8pHrheuDZfeNd5y0VnpUVfDJOhBTioEbXUiwed2ZsJ%2beDdg1qhGezjYS9JLO3xy8Q2NSSIHvs5Bl8fi12%2f7jzr4AGs9%2bH8DY2eku3uYkZOYI%2fTKLIIN;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rkuNXALcBgQ7RKY7Sl%2f7gXrmzfEbUmqCHhW79zVCuQ%2bj4onJc%2bPDS%2bJzL%2bU2V8fEJ87UYQXhmf6zi8pHrheuDZfeNd5y0VnpUVfDJOhBTioEbXUiwed2ZsJ%2beDdg1qhGezjYS9JLO3xy8Q2NSSIHvs5Bl8fi12%2f7jzr4AGs9%2bH8DY2eku3uYkZOYI%2fTKLIIN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_awaiting"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '152'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rkuNXALcBgQ7RKY7Sl%2f7gXrmzfEbUmqCHhW79zVCuQ%2bj4onJc%2bPDS%2bJzL%2bU2V8fEJ87UYQXhmf6zi8pHrheuDZfeNd5y0VnpUVfDJOhBTioEbXUiwed2ZsJ%2beDdg1qhGezjYS9JLO3xy8Q2NSSIHvs5Bl8fi12%2f7jzr4AGs9%2bH8DY2eku3uYkZOYI%2fTKLIIN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW/bMAz9K4IuuwSO7X4FO63AhqKHdgPW7bC1CGhJcYTowxClZEaQ/z5Kdpvt
+        st2kx0fy8ZFHHhQmE/l7dvzzuQHECDGh81ER8pPjAFZsldit4QA6atfzlwXjvd4r58BOpI/J2rHg
+        FrQpkMzQB/UL7GBUJbwtYeN77XCrzERadtotO8BtCSYtXbKdCiXWXF3Xl3Vdr1avwXPdgqArwDek
+        hPzfhW4I2gk9gHlTNsl4/Hx3d/9YPX36+lSoW2+V1EGJ6MM4KcnQ8ly8/5cW6iTAeafFfzuRoSIo
+        iNq7qGdmW7d1fdPcNM1V27Q/Cs8hCOGTi8aLHbE2YFBlpYDrgZZy8CHPH0N6RXdqjNCdMauyXL9Z
+        98GnoTQiJxK5g/zlRIQ9mJQFzBaWFEToFWbykcdxKOEDBJfXnFVNw/HvVIQmeNCIc2ROzcHbL/ds
+        JrDJM3YAZHRBDJWLC7bxgWpKRkcwkBOdNjqOJd4nCOCiUrJit4jJUnVKCnsV3iHLhfdT4QVrq/bi
+        OncWXua2zUVdN/SVEKGc7pS2nhOysCnldCrHQjND2TV/8FJvtJIse8OeJzueOc8eqRB8XrlLxtC3
+        3Nz8frutXAMkSf1r2dngc+vLalVR698AAAD//wMAwHqOF2cDAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rkuNXALcBgQ7RKY7Sl%2f7gXrmzfEbUmqCHhW79zVCuQ%2bj4onJc%2bPDS%2bJzL%2bU2V8fEJ87UYQXhmf6zi8pHrheuDZfeNd5y0VnpUVfDJOhBTioEbXUiwed2ZsJ%2beDdg1qhGezjYS9JLO3xy8Q2NSSIHvs5Bl8fi12%2f7jzr4AGs9%2bH8DY2eku3uYkZOYI%2fTKLIIN
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:13 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=iWDqrVtcemVL9A%2bHIjqsn5%2fZB%2fP3r3uhxewvGWiE1lD4mOEFzJdkGFQOfzmUDiomW33%2f%2bkf7ISa6xtghtPVKnfZC%2f7MdiGUEXHZeYg8gXyWxm8Cncv2g9XX5OexP1ANSrqu06RPLM6VmOmiScM6nQlKMpVntwRgp3N4%2bu015%2bGuCxGkOJ4pl0fUArUY%2b1C0v;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=iWDqrVtcemVL9A%2bHIjqsn5%2fZB%2fP3r3uhxewvGWiE1lD4mOEFzJdkGFQOfzmUDiomW33%2f%2bkf7ISa6xtghtPVKnfZC%2f7MdiGUEXHZeYg8gXyWxm8Cncv2g9XX5OexP1ANSrqu06RPLM6VmOmiScM6nQlKMpVntwRgp3N4%2bu015%2bGuCxGkOJ4pl0fUArUY%2b1C0v
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSpPma/evxdDiUR3XZv1/SzAfR6Z5y/AMAAP//AwC9Ji2lggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=iWDqrVtcemVL9A%2bHIjqsn5%2fZB%2fP3r3uhxewvGWiE1lD4mOEFzJdkGFQOfzmUDiomW33%2f%2bkf7ISa6xtghtPVKnfZC%2f7MdiGUEXHZeYg8gXyWxm8Cncv2g9XX5OexP1ANSrqu06RPLM6VmOmiScM6nQlKMpVntwRgp3N4%2bu015%2bGuCxGkOJ4pl0fUArUY%2b1C0v
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU227bMAz9FcEve0lS27k0KFBgBVYUxbC2QNs9dBgKWpIdLbLkiXKTLOi/j5Kd
+        S7cOewpDHt4Oj7xNnMRW++SMbQ/mt23CTfhNPrV1vWGPKF3yfcASobDRsDFQy/fCyiivQGMXe4y+
+        SnKL74FLQO4keGWNV329PM3T9DQ7zbJpnuVPEWeLH5J7rgG7Mt42Cbkb6dCaYFlXgVG/YiXQB78y
+        0lPsraMN7UO6RbUGzm1rfPi/dEXjlOGqAQ3tund5xZfSN1Yrvum9BOgm6v8gLnY1aaOdSYF7XFw5
+        2za35V1bfJYbDP5aNrdOVcpcGu82HWkNtEb9bKUScb9ykvIyEzDk83w8zDIJwyKdwXCaTydpmpcz
+        mIxjYhiZ2q+sE3LdKBcJ2NOYpdk00jh+2qGJQt+sBF+Aqd7huwfSFuiBiDLWdyhsoOYLyZfPsAK6
+        sKkisO0HFuGu3a2VMG1dEAXBn01nKU2czue7ATgYaxQHvRdQzP14c3t1dX0zeri8f4hQbYkhXEit
+        I+ikUOakAFz0TV6keavA3Tj/bl6D0kcN5RrqRssRt3UMY8fbXpvHavjPrAtbS6EcCcLSQeO4wXVy
+        YMVgrzNt+ZIQJb0QGSRI7026FymOfLUMG9jyuQrSieWCPgiH3QMMg4ZVz2P9ATfnMRiMvgsOBD83
+        tiIKg+Ul+uQ15HZaP2MZ2d61hoP/ozciVBK7D4DfNGHtZAXOhIuHRTomkq/UkKT2RSH2kT41BC/u
+        rlkPYN092AqQkZgYSuMHrLSOagpG3Dck2UJp5TcxXrXgwHgpxYhdILY1VWeRIvcBWSj80hUesHyU
+        j2dJXEqEttk4TcNeAjzEb1mX9twnhMG6lNdIBdWuIZ4ryVggkNXgSeIieaWodM4GFZlW6/BAxcHe
+        qyKk/i0IQhx1nIzmI+r4GwAA//8DAAI+84lkBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Dlx1yRBA1VIec%2fmdKFI6yCgpO5UBlILZnYuYGlbJ5uy3nipaQ%2br3MXwTn84PbTnQuzpWb8YLOUrN8tw6QCAynDIBzzbhp4a7ZldnuoQqCp1618z2Hw1jg8pvL5SYc6nWpXtvdTsL8OvbuYWRyuGdooTVJOPA%2fXBZXL4wSAnOgKdfOah%2bLVc5jMhJC6eJn5nl;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Dlx1yRBA1VIec%2fmdKFI6yCgpO5UBlILZnYuYGlbJ5uy3nipaQ%2br3MXwTn84PbTnQuzpWb8YLOUrN8tw6QCAynDIBzzbhp4a7ZldnuoQqCp1618z2Hw1jg8pvL5SYc6nWpXtvdTsL8OvbuYWRyuGdooTVJOPA%2fXBZXL4wSAnOgKdfOah%2bLVc5jMhJC6eJn5nl
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Dlx1yRBA1VIec%2fmdKFI6yCgpO5UBlILZnYuYGlbJ5uy3nipaQ%2br3MXwTn84PbTnQuzpWb8YLOUrN8tw6QCAynDIBzzbhp4a7ZldnuoQqCp1618z2Hw1jg8pvL5SYc6nWpXtvdTsL8OvbuYWRyuGdooTVJOPA%2fXBZXL4wSAnOgKdfOah%2bLVc5jMhJC6eJn5nl
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Dlx1yRBA1VIec%2fmdKFI6yCgpO5UBlILZnYuYGlbJ5uy3nipaQ%2br3MXwTn84PbTnQuzpWb8YLOUrN8tw6QCAynDIBzzbhp4a7ZldnuoQqCp1618z2Hw1jg8pvL5SYc6nWpXtvdTsL8OvbuYWRyuGdooTVJOPA%2fXBZXL4wSAnOgKdfOah%2bLVc5jMhJC6eJn5nl
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_denied].yaml
+++ b/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_denied].yaml
@@ -1,0 +1,895 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=wWQ20QwAHJAi1Nx92%2fhY1U4bSU%2bObnIdztp1%2boS24yfMRIKk0Hwr6T0ufG%2f1F4vKnqObOT1dnELI2sCGorynEdsoRxXrnXxFYeLiEyn1N2UWXFabFGOoO6D2tddaJ%2bNnfDst9Zj2pJnL0FdIEnPK32YFwPHRVXg7UkANdRORZvUXDJT9jP%2bj%2buQja8ANxPVM;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wWQ20QwAHJAi1Nx92%2fhY1U4bSU%2bObnIdztp1%2boS24yfMRIKk0Hwr6T0ufG%2f1F4vKnqObOT1dnELI2sCGorynEdsoRxXrnXxFYeLiEyn1N2UWXFabFGOoO6D2tddaJ%2bNnfDst9Zj2pJnL0FdIEnPK32YFwPHRVXg7UkANdRORZvUXDJT9jP%2bj%2buQja8ANxPVM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:52:14Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wWQ20QwAHJAi1Nx92%2fhY1U4bSU%2bObnIdztp1%2boS24yfMRIKk0Hwr6T0ufG%2f1F4vKnqObOT1dnELI2sCGorynEdsoRxXrnXxFYeLiEyn1N2UWXFabFGOoO6D2tddaJ%2bNnfDst9Zj2pJnL0FdIEnPK32YFwPHRVXg7UkANdRORZvUXDJT9jP%2bj%2buQja8ANxPVM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU204bMRD9FWtf+hLC7iaBUAmpoaUUtQUkQh4oKJq1Jxs3u/bWl5A04t/ryyYp
+        EoKneM/MnBmfOc4mUahtZZKPZPP/kQr38yv5Yut6Te40quSxQxLGdVPBWkCNr4W54IZDpWPsLmAl
+        UqlfS5bFb6SGVqBj2MgmcXCDSkvhT1KVIPhfMFwKqPY4F2hc7CVgPa0vl5qvgFJphfHfC1U0igvK
+        G6jArlrIcLpA08iK03WLuoQ4Ufuh9XzLOQO9PbrArZ5fKGmb69mNLb7jWnu8xuZa8ZKLc2HUOorR
+        gBX8j0XOwv1mgywHZHBAh3nvIMsQDooeGx4M8kE/TfPZEfR7odCP7No/ScVw1XAVBAgUeZqn6XF2
+        nGWDPOvdb7OdhKZ5YnQOosS3EnFlFDAw4JM2yXRagMaj/nTqvpPR6IdZnH2d0fpkyT6fzO8vsqZY
+        nF2PU/bt9q5vJ+eT8WQ0Ok2eH+OFaxBQIsNwY9+VilPmd9xxh9JLpP2pXYbuMHoqZOk08ieD2oSx
+        KukQPceqChyHBReHbqx5CNbAIxx4P+EK6qbCLpX19koUhBScQrXzZEy9ur64uLzqjs9vxyF1Lmtk
+        XLn9ynbaQw8dhuyd7FunvENm25Xui0vOhK0LZxKPZ4Oj1O00HZ6EoPMPVRjWaHj9yob6cUM6bnn3
+        QuxbpCVfonj5EAPeuEeMaol+wpl7i+gvD3q6tZSDjbJbdIFrA8Ueq9H3k7Np2F+g9j52jDr+AfgR
+        /WD7TYfgO4t+dqVLqKwftlUtNNPaOUhHN5p1E8JPoAQXpU9or5dMXAcn3k+udRtpS4Nvby5Jm0Ci
+        XOQJNBHSEO282SEzqRwnI841jVtCwStu1iFeWlAgDCLrkpHWtnbsJKinPmjiiZeRuEPybt478p2p
+        ZL5t1kvTzAsSX9MmiWXTtsAPFkuew3Nx3DUE4yUjxpARrxp5iFo8JEEgVEr6VQtbVf7/g+3PO2N6
+        AmBuzhee9Oru+/a7w67r+w8AAP//AwARRcOd2gUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:14 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wWQ20QwAHJAi1Nx92%2fhY1U4bSU%2bObnIdztp1%2boS24yfMRIKk0Hwr6T0ufG%2f1F4vKnqObOT1dnELI2sCGorynEdsoRxXrnXxFYeLiEyn1N2UWXFabFGOoO6D2tddaJ%2bNnfDst9Zj2pJnL0FdIEnPK32YFwPHRVXg7UkANdRORZvUXDJT9jP%2bj%2buQja8ANxPVM
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=1Dy5ZQ8jJVfMWiDI84otwMSgNtmtCDl2L1ztKZ70uK25Q2ljRawZ0sL9kHmopf24gWmpV47nwNfEe3VTtnemaq%2bq%2fgy4DF6MrwYQ46Cxfmb%2buWLcJ4K%2f5otSCRUdqcQ2XMDbeyZtUectsVvAT8yW%2boPBT0869DXp188SMluKfxBrlajr07q8qr%2f1sG9hPu6V;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=1Dy5ZQ8jJVfMWiDI84otwMSgNtmtCDl2L1ztKZ70uK25Q2ljRawZ0sL9kHmopf24gWmpV47nwNfEe3VTtnemaq%2bq%2fgy4DF6MrwYQ46Cxfmb%2buWLcJ4K%2f5otSCRUdqcQ2XMDbeyZtUectsVvAT8yW%2boPBT0869DXp188SMluKfxBrlajr07q8qr%2f1sG9hPu6V
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_denied"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=1Dy5ZQ8jJVfMWiDI84otwMSgNtmtCDl2L1ztKZ70uK25Q2ljRawZ0sL9kHmopf24gWmpV47nwNfEe3VTtnemaq%2bq%2fgy4DF6MrwYQ46Cxfmb%2buWLcJ4K%2f5otSCRUdqcQ2XMDbeyZtUectsVvAT8yW%2boPBT0869DXp188SMluKfxBrlajr07q8qr%2f1sG9hPu6V
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW/bMAz9K4IuuwSOnaYf22kFNhQ9tBuwboeuRUBLjCNElgxRShYE/e+jZLfZ
+        LttNenwkHx95lAEp2Sg/iOOfzzUQRYiJnI/IyE9JA/Rqg2q70ugMavk8E7IzO3QO+pHyKfX9oeA9
+        GFsgnaGP+Av6wWKlfF/C1nfG0QbtSJq3xs1boE0JJqNd6lsMJdacX9TLuq6v3r8GT3ULQq4A34kT
+        8n8b2iEYp8wA9k3ZKOP+y83N7X318PnbQ6FufI/aBFTRh8OoJEPzU/HuX1q4kwLnnVH/7cR2qoAQ
+        jXfRTMxFvajry+ayac4XzfKx8ByBUj65aL3aMmsNljArBVoNvJK9D3n+GNIrusVDhPaE9Zjl+vWq
+        Cz4NpRE7kdgdks8vTNiBTVnAZGFJIYIOKZOPMh6GEt5DcMZ1mTANJ39wEZ7gzhBNkSk1B6+/3oqJ
+        IEbPxB5I8P0IQhdnYu0D19SCj2BgJ1pjTTyUeJcggIuIuhLXRKnn6pwUdhjekciFd2PhmVhUi7OL
+        3Fl5nds2Z3Xd8FdDhHK4Y9pqSsjCxpSXl3IsPDOUXcs7r82a71hkb8TTaMeTlNkjDMHnlbtkLX/L
+        zU3vt9vKNUCz1L+WnQ0+tV5WVxW3/g0AAP//AwD9DfPuZQMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=1Dy5ZQ8jJVfMWiDI84otwMSgNtmtCDl2L1ztKZ70uK25Q2ljRawZ0sL9kHmopf24gWmpV47nwNfEe3VTtnemaq%2bq%2fgy4DF6MrwYQ46Cxfmb%2buWLcJ4K%2f5otSCRUdqcQ2XMDbeyZtUectsVvAT8yW%2boPBT0869DXp188SMluKfxBrlajr07q8qr%2f1sG9hPu6V
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=tD7yXhhXURLe9eWh4BYl3rgc0XkTLyvUWWqfYQOPScZbiEsMJCzVaDnIoZlfFY999ePO5m%2bk9Me6CGv5FeiOkOeedfix%2bWbCfV9Qu3%2fvHuf0UyYWjFQrM%2bM7dq2TuBGPjuqfabvc0JdXuiJ%2fKp1ln4yGudzw7QKmXSXpTTsRFa012EO8HKzer0JNGZiRoWC%2f;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tD7yXhhXURLe9eWh4BYl3rgc0XkTLyvUWWqfYQOPScZbiEsMJCzVaDnIoZlfFY999ePO5m%2bk9Me6CGv5FeiOkOeedfix%2bWbCfV9Qu3%2fvHuf0UyYWjFQrM%2bM7dq2TuBGPjuqfabvc0JdXuiJ%2fKp1ln4yGudzw7QKmXSXpTTsRFa012EO8HKzer0JNGZiRoWC%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSpPma/evxdDiUR3XZv1/SzAfR6Z5y/AMAAP//AwC9Ji2lggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tD7yXhhXURLe9eWh4BYl3rgc0XkTLyvUWWqfYQOPScZbiEsMJCzVaDnIoZlfFY999ePO5m%2bk9Me6CGv5FeiOkOeedfix%2bWbCfV9Qu3%2fvHuf0UyYWjFQrM%2bM7dq2TuBGPjuqfabvc0JdXuiJ%2fKp1ln4yGudzw7QKmXSXpTTsRFa012EO8HKzer0JNGZiRoWC%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU30/bMBD+V6y87KUtSdqyDglpSEMITQMkYA9ME7ra19TDsTOfQ9sh/vednZSW
+        jWlPvdx99+u7z33KPFJrQnYknnbmt6dM2vibfWrreiNuCX32fSAypakxsLFQ41thbXXQYKiL3SZf
+        hdLRW+AFkPQIQTsbdF+vzMs8f1+8L4ppWUzuEs7Nf6AM0gB1ZYJrMnY36MnZaDlfgdW/UiUwO7+2
+        GDj22tHG9jHdkV6DlK61IX4/+HnjtZW6AQPtuncFLR8wNM5ouem9DOgm6j+IltuavNHW5MA1Lc+8
+        a5vLxVU7/4wbiv4am0uvK21PbfCbjrQGWqt/tqhV2m8xLUpABUM5K8fDokAYzsdqNpyW00mel4tD
+        mIxTYhyZ26+cV7hutE8EvNBY5MU00Ti926KZwtCslFyCrd7guwfyFhSAibIudChqoJZLlA/3Cq1G
+        lWBtP66KV+0urZVt6zkTEP3F9DDnefPZh217CdZZLcG8yCflfry4PDs7vxjdnF7fJKhxzA8t0ZgE
+        OphrezAHWvZNHtG+1t92nH83r0GbvYa4hroxOJKuTmHqWHtR5r4W/jPr0tWotGc5OD5nGje6Dnas
+        WOpVZpx8YMSC3wdGAfJrQ/+Ias9XY9zALe6rKJxULqqDcdQ9vzhoXPU41R9Ie5yC0ei70EDJY+sq
+        pjBaASlkzzG3U/qRKNgOvrUSwh+9iaBC6p5/2DRx7WwF3mpbRen2TGRfuSEL7Ysm6iN9agyeXJ2L
+        HiC6e4gVkGApCUIbBmLhPNdUgrlvWLBzbXTYpHjVggcbENVInBC1NVcXiSL/jkQs/NgVHohyVI4P
+        s7SUim2LcZ7HvRQESP9kXdp9nxAH61KeExVcu4Z0rqwQkUBRQ2CBq+yZo+i9iyqyrTHxeaqd/aKK
+        mPq3IBix13Eymo24428AAAD//wMA/XPct2IFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:15 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=8EJHngp9fUTgOFCFYiPxzLVYBvOaeXcv0rFL99YT97FQ11UyJTzgHzFeBW4%2b2%2boxfP2r%2byRvmImpE9MwiWcLNx4H87vzWybEDbYQ1z9f9W7gDuiwnY9riY5q9ijY4jy0Ow4qc%2fqeI1xl7PWbV7WUpzZ0P4q5yQc2WF7pI0BUMGL34Mtet%2b6wB9HeUykqeKyu;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8EJHngp9fUTgOFCFYiPxzLVYBvOaeXcv0rFL99YT97FQ11UyJTzgHzFeBW4%2b2%2boxfP2r%2byRvmImpE9MwiWcLNx4H87vzWybEDbYQ1z9f9W7gDuiwnY9riY5q9ijY4jy0Ow4qc%2fqeI1xl7PWbV7WUpzZ0P4q5yQc2WF7pI0BUMGL34Mtet%2b6wB9HeUykqeKyu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8EJHngp9fUTgOFCFYiPxzLVYBvOaeXcv0rFL99YT97FQ11UyJTzgHzFeBW4%2b2%2boxfP2r%2byRvmImpE9MwiWcLNx4H87vzWybEDbYQ1z9f9W7gDuiwnY9riY5q9ijY4jy0Ow4qc%2fqeI1xl7PWbV7WUpzZ0P4q5yQc2WF7pI0BUMGL34Mtet%2b6wB9HeUykqeKyu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=8EJHngp9fUTgOFCFYiPxzLVYBvOaeXcv0rFL99YT97FQ11UyJTzgHzFeBW4%2b2%2boxfP2r%2byRvmImpE9MwiWcLNx4H87vzWybEDbYQ1z9f9W7gDuiwnY9riY5q9ijY4jy0Ow4qc%2fqeI1xl7PWbV7WUpzZ0P4q5yQc2WF7pI0BUMGL34Mtet%2b6wB9HeUykqeKyu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_manual].yaml
+++ b/noggin/tests/unit/utility/cassettes/test___init__/test_with_ipa_spamcheck[spamcheck_manual].yaml
@@ -1,0 +1,895 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=zX9JJgLHKfVAMsawzy7pFWtoWre7HwsdgZ%2fpXx2wtWFpqx3vhNYfaUMdHxVpZvXQElDTFsvjvr%2b0xeFh7chTmRpS0jbwfzM%2f4kouOkRqEu6scu3MS55qQDxYMXd%2b40dQRPmFeoHewzBmcxEgH4BI4JevHQccsP1qsx4HVtmt4N1LUbkThiudeqXEzSeR7WuX;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=zX9JJgLHKfVAMsawzy7pFWtoWre7HwsdgZ%2fpXx2wtWFpqx3vhNYfaUMdHxVpZvXQElDTFsvjvr%2b0xeFh7chTmRpS0jbwfzM%2f4kouOkRqEu6scu3MS55qQDxYMXd%2b40dQRPmFeoHewzBmcxEgH4BI4JevHQccsP1qsx4HVtmt4N1LUbkThiudeqXEzSeR7WuX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"all": true, "givenname":
+      "Dummy", "sn": "User", "cn": "Dummy User", "mail": "dummy@example.com", "loginshell":
+      "/bin/bash", "userpassword": "dummy_password", "fascreationtime": "2020-07-17T11:52:16Z"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=zX9JJgLHKfVAMsawzy7pFWtoWre7HwsdgZ%2fpXx2wtWFpqx3vhNYfaUMdHxVpZvXQElDTFsvjvr%2b0xeFh7chTmRpS0jbwfzM%2f4kouOkRqEu6scu3MS55qQDxYMXd%2b40dQRPmFeoHewzBmcxEgH4BI4JevHQccsP1qsx4HVtmt4N1LUbkThiudeqXEzSeR7WuX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RU207bQBD9FcsvfQnBdi6ESkgNLU1RW4JE4IGCovHu2NnG3nX3kksR/969OEmR
+        EDxlfWbmzOyZs3mKJSpT6fhj9PT/kXD78yv+Yup6G90qlPFjJ4opU00FWw41vhZmnGkGlQqxW4+V
+        SIR6LVnkv5FoUoEKYS2a2MINSiW4OwlZAmd/QTPBoTrgjKO2sZeAcbSuXCi2AUKE4dp9L2XeSMYJ
+        a6ACs2khzcgSdSMqRrYtahPCRO2HUosdZwFqd7SBG7WYSGGaaXFt8u+4VQ6vsZlKVjJ+wbXcBjEa
+        MJz9Mciov18xzEaDHEZHZJT1jtIU4ei0yIdHg2zQT5KsGEK/5wvdyLb9WkiKm4ZJL4CnyJIsSU7S
+        kzQdZOngfpdtJdTNmpIF8BLfSsSNlkBBg0t6iufzHBQO+/O5/Y7H4x+r5fnXgtSnK/r5dHE/SZt8
+        eT6dJfTbzW3f3F3cze7G47P4+TFcuAYOJVL0N3ZdCT+jbscdeyidRMqd2mWoDiVnXJRWI3fSqLQf
+        qxIWUQusKs9xnDN+bMda+GANLMCe9xNuoG4q7BJR765EgAvOCFR7T4bUq+lkcnnVnV3czHzqQtRI
+        mbT7Fe20xw469tl72XdOeYfMtCs9FJeMclPn1iQOTwfDxO40OU180PqHSPRr1Kx+ZUPDsCEVtrx/
+        IeYt0pKtkL98iB5v7CNGuUI3YWHfIrrLg5rvLGVhLc0OXeJWQ37AanT9RDH3+/PUzseWUYU/ADei
+        G+ywaR98Z9HPtnQFlXHDtqr5ZkpZB6ngRr1tfHgNkjNeuoT2evGd7WDF+8mUaiNtqfft9WXUJkRB
+        rmgNKuJCR8p6sxMVQlpOGlnXNHYJOauY3vp4aUAC14i0G42VMrVlj7x68oOKHPEqEHeirJv1hq4z
+        EdS1TXtJkjpBwmt6ikPZvC1wg4WSZ/9cLHcN3njxmFKkkVMteghaPMReIJRSuFVzU1Xu/4Mezntj
+        OgKgds4XnnTqHvr2u6Ou7fsPAAD//wMAU96aXdoFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=zX9JJgLHKfVAMsawzy7pFWtoWre7HwsdgZ%2fpXx2wtWFpqx3vhNYfaUMdHxVpZvXQElDTFsvjvr%2b0xeFh7chTmRpS0jbwfzM%2f4kouOkRqEu6scu3MS55qQDxYMXd%2b40dQRPmFeoHewzBmcxEgH4BI4JevHQccsP1qsx4HVtmt4N1LUbkThiudeqXEzSeR7WuX
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:16 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=wOWqLGigxTsN45R4vgcZpOuzWQEHmAoCM8t%2fKiyNBrVlIXH1oCNWjbguntRgNmBbl7k1xcB8KYZf7WlJYYfg6dFpwhVEB66RHmwZjPerfDpTrQoYojGopFvNGeoSkwcPGv2P7BNVb76cb43pD0zUmQ%2fJy7R8%2bjJsdJauwJMeI2SxfROY6wqKYTi6qksHPgSR;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wOWqLGigxTsN45R4vgcZpOuzWQEHmAoCM8t%2fKiyNBrVlIXH1oCNWjbguntRgNmBbl7k1xcB8KYZf7WlJYYfg6dFpwhVEB66RHmwZjPerfDpTrQoYojGopFvNGeoSkwcPGv2P7BNVb76cb43pD0zUmQ%2fJy7R8%2bjJsdJauwJMeI2SxfROY6wqKYTi6qksHPgSR
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"all": false, "no_members":
+      false, "raw": false, "rights": false, "fasstatusnote": "spamcheck_manual"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '150'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wOWqLGigxTsN45R4vgcZpOuzWQEHmAoCM8t%2fKiyNBrVlIXH1oCNWjbguntRgNmBbl7k1xcB8KYZf7WlJYYfg6dFpwhVEB66RHmwZjPerfDpTrQoYojGopFvNGeoSkwcPGv2P7BNVb76cb43pD0zUmQ%2fJy7R8%2bjJsdJauwJMeI2SxfROY6wqKYTi6qksHPgSR
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RSTW/bMAz9K4IuuwSOnbbpttMKbCh6aDdg3Q5bi4CWGUeIPgxRShYE+e+jZLfZ
+        LttNenwkHx95lAEpmSjfi+OfzzUQRYiJnI/IyE9JA1i1QbVdWXAJjHyeCdnrHToHdqR8TNYeCm5B
+        mwJ1GfqAv8AOBivlbQkb32tHGzQjad5qN2+BNiWYdOeSbTGUWHO1rC/run5XvwTPdQtCrgDfiBPy
+        fxvaIWin9ADmVdko4+Hz7e3dQ/X46etjoW68xU4HVNGHw6gkQ/Nz8f5fWriTAuedVv/txHaqgBC1
+        d1FPzEW9qOvr5rpprhbN8kfhOQKlfHLReLVl1hoMYVYKtBp4JXsf8vwxpBd0i4cI7RmzmOX69aoP
+        Pg2lETuR2B2Szycm7MCkLGCysKQQQY+UyUcZD0MJ7yE47fpMmIaT37kIT3CviabIlJqDN1/uxEQQ
+        o2diDyT4fgShizOx9oFrdoKPYGAnWm10PJR4nyCAi4hdJW6IkuXqnBR2GN6QyIV3Y+GZWFSLi2Xu
+        rHyX2zYXdd3wt4MI5XDHtNWUkIWNKadTORaeGcqu5b3v9FpjJ7I34mm040nK7BGG4PPKXTKGv+Xm
+        pvfrbeUa0LHUv5adDT63vqzeVtz6NwAAAP//AwA0vWhPZQMAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=wOWqLGigxTsN45R4vgcZpOuzWQEHmAoCM8t%2fKiyNBrVlIXH1oCNWjbguntRgNmBbl7k1xcB8KYZf7WlJYYfg6dFpwhVEB66RHmwZjPerfDpTrQoYojGopFvNGeoSkwcPGv2P7BNVb76cb43pD0zUmQ%2fJy7R8%2bjJsdJauwJMeI2SxfROY6wqKYTi6qksHPgSR
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=pM%2bRv%2bfAv%2ftv5nBfbphgJgVPhbeWWw%2bY1Ayh8ZQfRSwQ%2b2t2rlJQ3GiWFi134MeMCCaDIt0dP6GsRCARgpCl%2b5zC3nbPNgMilBex44kTq8ApJX3V8f1K9Yx%2fXSzYaH1yXIrawLzugEqCD8rt4bxLPVfcaUBFMIlKRec3bjIADKGvKWxBhwyFQNMqTZxRZtw%2f;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pM%2bRv%2bfAv%2ftv5nBfbphgJgVPhbeWWw%2bY1Ayh8ZQfRSwQ%2b2t2rlJQ3GiWFi134MeMCCaDIt0dP6GsRCARgpCl%2b5zC3nbPNgMilBex44kTq8ApJX3V8f1K9Yx%2fXSzYaH1yXIrawLzugEqCD8rt4bxLPVfcaUBFMIlKRec3bjIADKGvKWxBhwyFQNMqTZxRZtw%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSpPma/evxdDiUR3XZv1/SzAfR6Z5y/AMAAP//AwC9Ji2lggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[], {"all": true, "no_members": false,
+      "sizelimit": 0, "whoami": true}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=pM%2bRv%2bfAv%2ftv5nBfbphgJgVPhbeWWw%2bY1Ayh8ZQfRSwQ%2b2t2rlJQ3GiWFi134MeMCCaDIt0dP6GsRCARgpCl%2b5zC3nbPNgMilBex44kTq8ApJX3V8f1K9Yx%2fXSzYaH1yXIrawLzugEqCD8rt4bxLPVfcaUBFMIlKRec3bjIADKGvKWxBhwyFQNMqTZxRZtw%2f
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RUbU/bMBD+K1a+7EtbkpSWgoQ0pCGEpgESsA+bJnRxnNSrY2c+m7ar+O87O+kL
+        G2iferm35+65x90kVqBXLjljm735fZNwHX6TT75p1uwRhU1+DFhSSmwVrDU04q2w1NJJUNjFHqOv
+        FtzgW8kVILcCnDTayb5fnuZpepKdZNkkz6bfYp4pfgruuALs2jjTJuRuhUWjg2VsDVr+jp1A7f1S
+        C0ex1w4f4EO5QbkCzo3XLnwvbNFaqblsQYFf9S4n+UK41ijJ172XErqJ+g/E+bYnbbQ1KXCP8ytr
+        fHtb3fnis1hj8DeivbWylvpSO7vuSGvBa/nLC1nG/appPpsUMBvyWT4eZpmA4WlVTIeTfHKcpnk1
+        heNxLAwjE/zS2FKsWmkjATsaszSbHNJI2USha5cln4Ou3+ebtkAHRJQ2rsvCFho+F3zx1ID2oGKa
+        78ctw1W7S8tS+6YgAoI/m0xTmjc9TbfwHLTRkoPaySfWfry5vbq6vhk9XN4/xFRliB+cC6Vi0lEh
+        9VEBOO9BnoV+rb/tOO+DNyDVAaBYQdMqMeKmiWHsWNsp81AL/5l1bhpRSktyMHTOOG5wHe1Z0dir
+        TBm+oIyK3ocIAqTXJuyzKA98jQgbmOqpDsKJ7YI6KA+75xcGDauex/4Drs9jMBg9Cg5Kfq5NTRQG
+        ywl0yUuo7ZR+xjKynfWag/sLGxFqgd3zd+s2rJ0swWqp6yDdnonkKwGS0L5IxD7Sl4bgxd016xNY
+        dw+2BGQkJYZCuwGrjKWeJSPuWxJsIZV06xivPVjQTohyxC4QfUPdWaTIfkAWGj93jQcsH+XjaRKX
+        KgNsNk7TsFcJDuI/WVf21BeEwbqSl0gF9W4gnivJWCCQNeBI4GXyQlFhrQkq0l6p8DzLvb1TRSj9
+        VxCUcYB4PJqNCPEPAAAA//8DANFw8WFiBQAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=SFbKTK6Dfmz%2bGgRuwiWEM%2bIFmMdwJsHiA2Rdd48nRBsSGjc5PBmiAt1zJg9%2faDDr4uFT7rW8y51duRqQ%2fcXiY0Ubzugywl4of9BdUolxG7FtPj993ZC4RUf0WugMhSNAU8%2fZZ6IJyavVIzuHF04LrQxFOJv4HY%2fOWQ0QQ8sXt7ENwSPNnZjyF5%2bgpJ7UrAxg;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SFbKTK6Dfmz%2bGgRuwiWEM%2bIFmMdwJsHiA2Rdd48nRBsSGjc5PBmiAt1zJg9%2faDDr4uFT7rW8y51duRqQ%2fcXiY0Ubzugywl4of9BdUolxG7FtPj993ZC4RUf0WugMhSNAU8%2fZZ6IJyavVIzuHF04LrQxFOJv4HY%2fOWQ0QQ8sXt7ENwSPNnZjyF5%2bgpJ7UrAxg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yQTWvDMAyG/4rxZZdg+kUZO62HUnJYW1jZZYyhxl4wxHaQnJUQ8t8nJ2btwSBL
+        el690iDRUNdE+SIGSZ1zgD3HsjzvBBn8NSj4kQ1ebNSz2iqxO5f/qZVarbeyENIZIqgNMfo5yNi3
+        JoncAL31dWrw4KbUx0y+WaJcyWgqJuncIHznrjz8BiR8iOzFx0L8BGRNLargWoj2ahsb+6led4Dg
+        ozGaHRIvwup5gSd69FzcTVdBp7HL9WKx5K+GCPMZJuw7A8nYjIzj18h9BjEgZ33XNPy1+h63aH1l
+        W2gSBJpNvB5Ph0N5VJf9+yXNfBCd7inHPwAAAP//AwAZeihGggEAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "preserve":
+      false}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SFbKTK6Dfmz%2bGgRuwiWEM%2bIFmMdwJsHiA2Rdd48nRBsSGjc5PBmiAt1zJg9%2faDDr4uFT7rW8y51duRqQ%2fcXiY0Ubzugywl4of9BdUolxG7FtPj993ZC4RUf0WugMhSNAU8%2fZZ6IJyavVIzuHF04LrQxFOJv4HY%2fOWQ0QQ8sXt7ENwSPNnZjyF5%2bgpJ7UrAxg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0xQS2sCQQz+K2EuvSyLj1JKTxUs4qG2UOmlSolOlIGZ2SUzoyzif2/iLtRb8uV7
+        JLkYplR8Ni9wuS8P6DxZKX+21wrMCX0h7YwtIXRmK1iglPBISeGLyV2rBHNGji4ejRAihhv0TZxc
+        E99dSsNkkOpw9rmEgQCxhB0xnDFBbDIkirmCQ8PiaWHfhBaz2znvcnebHwsyxkxka5ilVIK4i4hP
+        xA8J1PjUG1cwqSfTJ03eN1Zjx9PRaCytxYy3e3vZ7yDQxXrJ9aqnindA7hSek6dMFoooYNO/Y2OM
+        PomYGxZOLN5L6+x/3bKLe9eiVwu0sunr6mOxWK7q9dvXWhe7S36sn2tJ/gMAAP//AwBJDJkymwEA
+        AA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:17 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=SFbKTK6Dfmz%2bGgRuwiWEM%2bIFmMdwJsHiA2Rdd48nRBsSGjc5PBmiAt1zJg9%2faDDr4uFT7rW8y51duRqQ%2fcXiY0Ubzugywl4of9BdUolxG7FtPj993ZC4RUf0WugMhSNAU8%2fZZ6IJyavVIzuHF04LrQxFOJv4HY%2fOWQ0QQ8sXt7ENwSPNnZjyF5%2bgpJ7UrAxg
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yPTUvDQBCG/8qwFy8h9ENEPNmDlB6sgsWLiEyzY1jI7oaZTUsJ+e/OJoF4m4/3
+        fd6Z3jBJ1yTzBP1Shq5pCjCeRLAm0clXb9KtJa3MFTm4UBsVBPTj6JNYXAyvTmTezNa83L0fYBYo
+        2J+J4YoCISYQCqmA38jKtFBF32JyZ9e4dBv3dYeMIRHZEnYinVe6mvhCfCeQwZcJXMCm3GwfcnIV
+        bY5db1ertbYWE47PTbaf2ZAPmyzD8D2ojpgjL687u9Qtu1C5FptsQqtHPB/f9vvDsTy9fJxy5j/o
+        fflYKvQPAAD//wMAt/mjK1gBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 17 Jul 2020 11:52:18 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/utility/test___init__.py
+++ b/noggin/tests/unit/utility/test___init__.py
@@ -4,7 +4,9 @@ import pytest
 from flask import current_app, g, get_flashed_messages, session
 from werkzeug.exceptions import InternalServerError, NotFound
 
+from noggin import ipa_admin
 from noggin.security.ipa import maybe_ipa_login
+from noggin.tests.unit.utilities import captured_templates
 from noggin.utility import (
     group_or_404,
     require_self,
@@ -78,6 +80,27 @@ def test_with_ipa_anonymous(client):
         category, message = messages[0]
         assert message == "Please log in to continue."
         assert category == "warning"
+
+
+@pytest.mark.parametrize(
+    "spamcheck_status", ["spamcheck_awaiting", "spamcheck_denied", "spamcheck_manual"]
+)
+@pytest.mark.vcr()
+def test_with_ipa_spamcheck(client, dummy_user, spamcheck_status):
+    """Test the with_ipa decorator"""
+    ipa_admin.user_mod("dummy", fasstatusnote=spamcheck_status)
+    view = mock.Mock()
+    with current_app.test_request_context('/'):
+        maybe_ipa_login(current_app, session, "dummy", "dummy_password")
+        wrapped = with_ipa()(view)
+        with captured_templates(current_app) as templates:
+            wrapped("arg")
+            assert len(templates) == 1
+            template, context = templates[0]
+        assert template.name == 'spamcheck.html'
+        view.assert_not_called()
+        assert context["g"].current_user.username == "dummy"
+        assert context["g"].current_user.status_note == spamcheck_status
 
 
 def test_require_self_wrong_route(client):

--- a/noggin/tests/unit/utility/test___init__.py
+++ b/noggin/tests/unit/utility/test___init__.py
@@ -88,7 +88,7 @@ def test_with_ipa_anonymous(client):
 @pytest.mark.vcr()
 def test_with_ipa_spamcheck(client, dummy_user, spamcheck_status):
     """Test the with_ipa decorator"""
-    ipa_admin.user_mod("dummy", fasstatusnote=spamcheck_status)
+    ipa_admin.user_mod("dummy", fasstatusnote=spamcheck_status, disabled=True)
     view = mock.Mock()
     with current_app.test_request_context('/'):
         maybe_ipa_login(current_app, session, "dummy", "dummy_password")

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -99,9 +99,9 @@
     <button tabindex="0"
         class="btn btn-link"
         role="button" data-toggle="popover"
-        data-trigger="focus" 
-        title="{{_('Edit Group')}}" 
-        data-content="{{_("To change group details or add sponsors, file a ticket with")}} <a href='https://pagure.io/fedora-infrastructure/new_issue' target='_blank'>fedora-infra</a>" 
+        data-trigger="focus"
+        title="{{_('Edit Group')}}"
+        data-content="{{_("To change group details or add sponsors, file a ticket with")}} <a href='https://pagure.io/fedora-infrastructure/new_issue' target='_blank'>fedora-infra</a>"
         data-html="true">
         <i class="fa fa-fw fa-pencil" aria-hidden="true"></i>
 </button>
@@ -133,4 +133,14 @@
       </div>
     </div>
   </div>
+{% endmacro %}
+
+
+{% macro spamcheck_contact() %}
+{% set email_link %}
+<a href="mailto:spamcheck@fedoraproject.org?Subject=Not%20Spam:%20{{ g.current_user.username }}">spamcheck@fedoraproject.org</a>
+{% endset %}
+<p>
+    {{ _("If it is not correct, please send an email to %(email_link)s and explain the situation.", email_link=email_link) }}
+</p>
 {% endmacro %}

--- a/noggin/utility/__init__.py
+++ b/noggin/utility/__init__.py
@@ -2,7 +2,17 @@ import hashlib
 from functools import wraps
 
 import python_freeipa
-from flask import abort, current_app, flash, g, Markup, redirect, session, url_for
+from flask import (
+    abort,
+    current_app,
+    flash,
+    g,
+    Markup,
+    redirect,
+    render_template,
+    session,
+    url_for,
+)
 from flask_babel import lazy_gettext as _
 
 from noggin import app
@@ -32,6 +42,12 @@ def with_ipa():
             if ipa:
                 g.ipa = ipa
                 g.current_user = User(g.ipa.user_find(whoami=True)['result'][0])
+                if g.current_user.status_note in (
+                    "spamcheck_awaiting",
+                    "spamcheck_denied",
+                    "spamcheck_manual",
+                ):
+                    return render_template("spamcheck.html")
                 return f(*args, **kwargs, ipa=ipa)
             flash('Please log in to continue.', 'warning')
             return redirect(url_for('root'))

--- a/noggin/utility/token.py
+++ b/noggin/utility/token.py
@@ -1,74 +1,36 @@
 from datetime import datetime, timedelta
+from enum import Enum
 
 import jwt
 from flask import current_app
 
 
-class JWTToken:
-    def __init__(self, username):
-        self.username = username
+class Audience(Enum):
+    """
+    In JWT the audience is a constant that must remain the same between the token creator and the
+    token reader, as a way to prevent token re-use.
 
-    @classmethod
-    def from_user(cls, user):
-        raise NotImplementedError  # pragma: no cover
+    The longer the string, the longer the token, so we try to keep it short because some tokens end
+    up in URLs and that's limited.
+    """
 
-    @classmethod
-    def from_string(cls, token):
-        token_data = jwt.decode(
-            token, current_app.config["SECRET_KEY"], algorithms=["HS256"]
-        )
-        return cls(**token_data)
-
-    @property
-    def data(self):
-        raise NotImplementedError  # pragma: no cover
-
-    def as_string(self):
-        return str(
-            jwt.encode(self.data, current_app.config["SECRET_KEY"], algorithm="HS256"),
-            "ascii",
-        )
+    password_reset = "pr"
+    email_validation = "ev"
+    spam_check = "sc"
 
 
-class PasswordResetToken(JWTToken):
-    def __init__(self, username, last_change):
-        super().__init__(username)
-        self.last_change = last_change
-
-    @classmethod
-    def from_user(cls, user):
-        return cls(user.username, user.last_password_change)
-
-    @property
-    def data(self):
-        return {"username": self.username, "last_change": self.last_change}
-
-    def validate_last_change(self, user):
-        return user.last_password_change == self.last_change
+def make_token(data, audience, ttl=None):
+    data["aud"] = audience.value
+    if ttl is not None:
+        data["exp"] = datetime.utcnow() + timedelta(minutes=ttl)
+    token = jwt.encode(data, current_app.config["SECRET_KEY"], algorithm="HS256")
+    return str(token, "ascii")
 
 
-class EmailValidationToken(JWTToken):
-    def __init__(self, username, mail, valid_until=None):
-        super().__init__(username)
-        self.mail = mail
-        if valid_until is None:
-            self.valid_until = datetime.utcnow() + timedelta(
-                minutes=current_app.config["ACTIVATION_TOKEN_EXPIRATION"]
-            )
-        else:
-            self.valid_until = datetime.fromtimestamp(valid_until)
-
-    @classmethod
-    def from_user(cls, user):
-        return cls(user.username, user.mail)
-
-    @property
-    def data(self):
-        return {
-            "username": self.username,
-            "mail": self.mail,
-            "valid_until": self.valid_until.timestamp(),
-        }
-
-    def is_valid(self):
-        return datetime.utcnow() < self.valid_until
+def read_token(token, audience=None):
+    return jwt.decode(
+        token,
+        current_app.config["SECRET_KEY"],
+        algorithms=["HS256"],
+        audience=audience.value,
+    )


### PR DESCRIPTION
This PR implements the Noggin-side of the workflow described in #27 .

- Users are created with the `spamcheck_awaiting` status.
- Upon registration, a request is sent to Basset to check for spam likelihood. In addition to the user details, this request contains a callback URL and a token that Basset will have to provide with the result
- A webhook endpoint is added to receive Basset's result, which will update the user's status.
- When a user status is not `active`, a landing page is provided to explain to the user that their account is being spamchecked.