### PR TITLE
Use markupsafe.Markup for rendering HTML

### DIFF
--- a/noggin/form/base.py
+++ b/noggin/form/base.py
@@ -1,7 +1,8 @@
 from flask_wtf import FlaskForm
+from markupsafe import escape, Markup
 from wtforms import Field, SubmitField
 from wtforms.widgets import TextInput
-from wtforms.widgets.core import html_params, HTMLString
+from wtforms.widgets.core import html_params
 
 
 class BaseForm(FlaskForm):
@@ -32,7 +33,6 @@ class ButtonWidget:
     data on the field.
     """
 
-    html_params = staticmethod(html_params)
     button_type = "button"
 
     def __call__(self, field, **kwargs):
@@ -47,11 +47,7 @@ class ButtonWidget:
         classes.append(kwargs.get("class"))
         kwargs["class"] = " ".join(c for c in classes if c)
         # Rendering
-        return HTMLString(
-            '<button {params}>{label}</button>'.format(
-                params=self.html_params(**kwargs), label=label
-            )
-        )
+        return Markup(f"<button {html_params(**kwargs)}>{escape(label)}</button>")
 
 
 class ButtonSubmitWidget(ButtonWidget):

--- a/poetry.lock
+++ b/poetry.lock
@@ -167,7 +167,7 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -1239,7 +1239,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 deploy = ["gunicorn"]
 
 [metadata]
-content-hash = "0c3e5e18f8f608821c7516a07f743d6b3820f4615d8f74124961e9671f5004cb"
+content-hash = "2f298acd3dcca7d36ef3e02e16b49b4b6552b65376511e69c1418c4d93f5bc4d"
 python-versions = "^3.6"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ noggin-messages = "^0.0.1"
 whitenoise = "^5.0.1"
 flask-babel = "^1.0.0"
 flask-healthz = "^0.0.1"
+markupsafe = "^1.1.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"


### PR DESCRIPTION
The HTMLString class will be removed in WTForms 3.0. Additionally,
escape label strings used in button widgets.

Signed-off-by: Nils Philippsen <nils@redhat.com>