### PR TITLE
Make first name and last name optional

### DIFF
--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -16,11 +16,11 @@ from noggin.utility.timezones import TIMEZONES
 
 class UserSettingsProfileForm(FlaskForm):
     firstname = StringField(
-        'First Name', validators=[DataRequired(message='First name must not be empty')]
+        'First Name', validators=[Optional()]
     )
 
     lastname = StringField(
-        'Last Name', validators=[DataRequired(message='Last name must not be empty')]
+        'Last Name', validators=[Optional()]
     )
 
     mail = EmailField(


### PR DESCRIPTION
See https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/

Asking names when this is not needed go against GDPR spirit
(Art 5.c: "data minimization"), and since FAS do not ask that, it
is hard to argue we need the information.

This is also a problems for people having more than 1 name,
or people having just 1
(see https://en.wikipedia.org/wiki/Mononymous_person#Modern_times ).

There is also people who do not want to give their name for whatever reasons,
and who could do that before with FAS

Finally, since the information is requested by default without opt-out, someone
who would change last name or first name will be forced to change it in FAS, thus adding
to the burden of name change. In the western world, that mean mostly
woman and/or trans people. So not having opt-out do not get in a direction
of simplifying their life.