### PR TITLE
Make first name and last name optional

### DIFF
--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -21,12 +21,12 @@ from .base import BaseForm, CSVListField
 class UserSettingsProfileForm(BaseForm):
     firstname = StringField(
         _('First Name'),
-        validators=[DataRequired(message=_('First name must not be empty'))],
+        validators=[Optional()],
     )
 
     lastname = StringField(
         _('Last Name'),
-        validators=[DataRequired(message=_('Last name must not be empty'))],
+        validators=[Optional()],
     )
 
     mail = EmailField(

--- a/noggin/form/register_user.py
+++ b/noggin/form/register_user.py
@@ -4,7 +4,7 @@ from wtforms.fields.html5 import EmailField
 from wtforms.validators import DataRequired, EqualTo, Length
 
 from noggin import app
-from noggin.form.validators import Email
+from noggin.form.validators import Email, Optional
 
 from .base import BaseForm, ModestForm, strip, SubmitButtonField
 
@@ -12,13 +12,13 @@ from .base import BaseForm, ModestForm, strip, SubmitButtonField
 class RegisterUserForm(ModestForm):
     firstname = StringField(
         _('First Name'),
-        validators=[DataRequired(message=_('First name must not be empty'))],
+        validators=[Optional()],
         filters=[strip],
     )
 
     lastname = StringField(
         _('Last Name'),
-        validators=[DataRequired(message=_('Last name must not be empty'))],
+        validators=[Optional()],
         filters=[strip],
     )
 


### PR DESCRIPTION
Asking names when this is not needed go against GDPR spirit
(Art 5.c: "data minimization"), and since FAS do not ask that, it
is hard to argue we need the information.

This is also a problems for people having more than 1 name,
or people having just 1
(see https://en.wikipedia.org/wiki/Mononymous_person#Modern_times ).

There is also people who do not want to give their name for whatever reasons,
and who could do that before with FAS.

Finally, since the information is requested by default without opt-out, someone
who would change last name or first name will be forced to change it in FAS, thus adding
to the burden of name change. In the western world, that mean mostly
woman and/or trans people. So not having opt-out do not get in a direction
of simplifying their life, which seems to not go in favor of diversity.

Signed-off-by: M. S <misc@redhat.com>