### PR TITLE
Update Vagrantfile to use Fedora 32

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box"
-  config.vm.box = "f31-cloud-libvirt"
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-32-1.6.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f32-cloud-libvirt"
   #config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.hostname = "ipa.noggin.test"
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"


### PR DESCRIPTION
The packaged version of Noggin also is shipped for Fedora 32 and newer,
so this brings the Vagrant environment in sync with what it is packaged
for.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>