### PR TITLE
Set a BASE_URL variable in the master template to be used in search.js

### DIFF
--- a/noggin/static/js/search.js
+++ b/noggin/static/js/search.js
@@ -33,5 +33,5 @@ $('#search').typeahead(
 ).on('typeahead:selected', function(evt, itm, name) {
 var path = name == "users" ? "user" : "group";
 var n = path == "group" ? itm.cn : itm.uid;
-window.location.href = '/' + path + '/' + n + '/';
+window.location.href = BASE_URL + '/' + path + '/' + n + '/';
 });

--- a/noggin/templates/master.html
+++ b/noggin/templates/master.html
@@ -19,6 +19,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/1.2.1/typeahead.jquery.min.js"></script>
         <script>
           var URL_SEARCH = {{ url_for('root.search_json')|tojson }};
+          var BASE_URL = {{ request.url_root.rstrip('/') }};
         </script>
         <script src="{{ url_for('static', filename='js/search.js') }}"></script>
         <script src="{{ url_for('static', filename='js/vendor/moment-2.24.0/moment.js') }}"></script>


### PR DESCRIPTION
Basically this variable allows to specify the full URL where noggin
is deployed. Then in search.js we are able to build the full URL
linking to where the user/group are.

The current behavior assumed that noggin was running at the root of
the web-server (ie: /) while this is not necessarily true (it could
run at say /accounts/).

This commit should fix that.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>