### PR TITLE
Install python3-devel RPM package

### DIFF
--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install RPM packages
   dnf:
-      name: ['git', 'vim', 'poetry', 'python3-flask', 'python3-pip', 'python3-cryptography', 'freeipa-server', 'fedora-messaging']
+      name: ['git', 'vim', 'poetry', 'python3-devel', 'python3-flask', 'python3-pip', 'python3-cryptography', 'freeipa-server', 'fedora-messaging']
       state: present
 
 - name: install python deps with poetry


### PR DESCRIPTION
- Otherwise, the "poetry install" command fails.