### PR TITLE
Update Vagrant setup to Fedora 33

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box"
-  config.vm.box = "f31-cloud-libvirt"
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-33-1.2.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f33-cloud-libvirt"
   #config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.hostname = "ipa.noggin.test"
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -1,7 +1,18 @@
 ---
 - name: Install RPM packages
   dnf:
-      name: ['git', 'vim', 'poetry', 'python3-flask', 'python3-pip', 'python3-cryptography', 'freeipa-server', 'fedora-messaging']
+      name:
+        - fedora-messaging
+        - freeipa-server
+        - gcc
+        - git
+        - libffi-devel
+        - poetry
+        - python3-cryptography
+        - python3-devel
+        - python3-flask
+        - python3-pip
+        - vim
       state: present
 
 - name: install python deps with poetry


### PR DESCRIPTION
Previously, the old Fedora 31 vagrant setup would fail
on initial provisioning due to dependency issues. The
two solutions here was to update the packages before
installing the new packages, or update to a newer version
of Fedora.

This commit updates the vagrant setup to use Fedora 33.