### PR TITLE
Justify use of `# nosec`

### DIFF
--- a/noggin/security/ipa_admin.py
+++ b/noggin/security/ipa_admin.py
@@ -47,6 +47,8 @@ class IPAAdmin:
             self.init_app(app)
 
     def init_app(self, app):
+        # Move FreeIPA admin user and password values from the main configuration into the one for
+        # the `ipa-admin` extension. Overwrite the values in the main configuration.
         app.extensions["ipa-admin"] = {
             "username": app.config['FREEIPA_ADMIN_USER'],
             "password": app.config['FREEIPA_ADMIN_PASSWORD'],

--- a/noggin/utility/templates.py
+++ b/noggin/utility/templates.py
@@ -8,6 +8,8 @@ def gravatar(email, size):
     return (
         current_app.config["AVATAR_SERVICE_URL"]
         + "avatar/"
+        # We use MD5 to hash email addresses because gravatar.com uses that as a key. We could use
+        # SHA256 instead if we limited ourselves to using libravatar.org.
         + hashlib.md5(email.lower().encode('utf8')).hexdigest()  # nosec
         + "?s="
         + str(size)


### PR DESCRIPTION
Describe that password values are overwritten and why we use MD5 to
look up avatar image URLs.

Fixes: #335

Signed-off-by: Nils Philippsen <nils@redhat.com>