### PR TITLE
Add an optional note to the user settings OTP page

### DIFF
--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -93,6 +93,7 @@
       </div>
     </div>
   </div>
+  {{ otp_notice() if otp_notice is defined }}
 {% else %}
   <div class="list-group-item text-center bg-light text-muted font-weight-bold">
     <div>{{ _("You have no OTP tokens") }}</div>

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -135,6 +135,14 @@
   </div>
 {% endmacro %}
 
+{# an optional macro to show a note that when applied it also applies to kinit / krb5 / kerberos #}
+{% macro otp_notice() %}
+<div class="alert alert-info text-center">
+    <div><strong>{{_("Additional configuration is required when using Kerberos tickets when OTP is enabled")}}</strong></div>
+    <div>{{_("Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/#pkinit'>documentation</a> for details on configuring your system")}}</div>
+</div>
+{% endmacro %}
+
 
 {% macro spamcheck_contact() %}
 {% set email_link %}


### PR DESCRIPTION
Add an optional note to the user settings OTP page that is defined in
the main.html in the themes templates to display a note at the top of
the OTP page.

This is used in Fedora Accounts to point users at the documentation for
getting a kerberos ticket when OTP is enabled.

Resolves: #433 

Signed-off-by: Ryan Lerch <rlerch@redhat.com>