### PR TITLE
Fix multiple otp notices

### DIFF
--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -93,13 +93,13 @@
       </div>
     </div>
   </div>
-  {{ otp_notice() if otp_notice is defined }}
 {% else %}
   <div class="list-group-item text-center bg-light text-muted font-weight-bold">
     <div>{{ _("You have no OTP tokens") }}</div>
     <div><small>{{ _("Add an OTP token to enable two-factor authentication on your account.") }}</small></div>
   </div>
 {% endfor %}
+{{ otp_notice() if otp_notice is defined and tokens }}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
The note added to the user's otp settings page in
de1bc0c56ff6c5aedb36847b9854b287db7262bc would be presented to the
user multiple times if more than one OTP token was defined.

This fixes this issue so it only shows once if at least one token
is defined, and not at all if no tokens are defined.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>