### PR TITLE
Update search with loading animations

### DIFF
--- a/noggin/static/js/search.js
+++ b/noggin/static/js/search.js
@@ -24,14 +24,18 @@ $("#search")
       display: "uid",
       source: bloodhound_users,
       templates: {
-        header: "<h5>Users</h5>",
+        header: "<h5 class='mb-0'>"+USERS_SEARCH_LABEL+"</h5>",
+        pending: "<h5 class='mb-0'>"+USERS_SEARCH_LABEL+"</h5><h5 class='text-center'><i class='fa fa-circle-o-notch fa-spin fa-fw'></i></h5>"
       },
     },
     {
       name: "groups",
       display: "cn",
       source: bloodhound_groups,
-      templates: { header: "<h5>Groups</h5>" },
+      templates: { 
+        header: "<h5 class='mb-0'>"+GROUPS_SEARCH_LABEL+"</h5>",
+        pending: "<h5 class='mb-0'>"+GROUPS_SEARCH_LABEL+"</h5><h5 class='text-center'><i class='fa fa-circle-o-notch fa-spin fa-fw'></i></h5>"
+      },
     }
   )
   .on("typeahead:selected", function (evt, itm, name) {

--- a/noggin/templates/master.html
+++ b/noggin/templates/master.html
@@ -19,6 +19,11 @@
         <script src="{{ url_for('static', filename='js/vendor/corejs-typeahead-1.2.1/typeahead.jquery.min.js') }}"></script>
         <script>
           var URL_SEARCH = {{ url_for('root.search_json')|tojson }};
+          
+          /* Translated strings for use in search.js. These are the labels that are shown
+             in the searchbox dropdown */
+          var GROUPS_SEARCH_LABEL = '{{ _("Groups") }}'
+          var USERS_SEARCH_LABEL = '{{ _("Users") }}'
         </script>
         <script src="{{ url_for('static', filename='js/search.js') }}"></script>
         <script src="{{ url_for('static', filename='js/vendor/moment-2.24.0/moment.js') }}"></script>


### PR DESCRIPTION
Previously, there were no loading animations for the search box, and due
to the fact we are doing two seperate calls (for users and groups),
these could return at different times. So this commit adds sepearte
spinner animations for the two results classes.

Additionally, this moves the string for "users" and "groups" that is
used to label the groups in the search dropdown into the templates as
variables, so they can be translated.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>