### PR TITLE
OTP: Use default token algorithm (SHA1)

### DIFF
--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -184,9 +184,7 @@ def user_settings_otp(ipa, username):
         try:
             maybe_ipa_login(current_app, session, username, addotpform.password.data)
             result = ipa.otptoken_add(
-                o_ipatokenowner=username,
-                o_ipatokenotpalgorithm='sha512',
-                o_description=addotpform.description.data,
+                o_ipatokenowner=username, o_description=addotpform.description.data,
             )['result']
 
             uri = urlparse(result['uri'])

--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -212,11 +212,7 @@ def dummy_user_with_gpg_key(client, dummy_user):
 @pytest.fixture
 def dummy_user_with_otp(client, logged_in_dummy_user):
     ipa = logged_in_dummy_user
-    result = ipa.otptoken_add(
-        o_ipatokenowner="dummy",
-        o_ipatokenotpalgorithm='sha512',
-        o_description="dummy's token",
-    )
+    result = ipa.otptoken_add(o_ipatokenowner="dummy", o_description="dummy's token",)
     token = OTPToken(result['result'])
     yield token
     # Deletion needs to be done as admin to remove the last token

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -682,8 +682,7 @@ def test_spamcheck(client, dummy_stageuser, mocker, spamcheck_status, spamcheck_
 @pytest.mark.vcr()
 def test_spamcheck_disabled(client, dummy_user):
     response = client.post(
-        "/register/spamcheck-hook",
-        json={"token": "foobar", "status": "active"},
+        "/register/spamcheck-hook", json={"token": "foobar", "status": "active"},
     )
     assert response.status_code == 501
     assert response.json == {"error": "Spamcheck disabled"}
@@ -699,10 +698,7 @@ def test_spamcheck_bad_payload(client, dummy_user, mocker, spamcheck_on):
 @pytest.mark.parametrize("payload", [{"token": "foobar"}, {"status": "active"}])
 @pytest.mark.vcr()
 def test_spamcheck_bad_missing_key(client, dummy_user, mocker, payload, spamcheck_on):
-    response = client.post(
-        "/register/spamcheck-hook",
-        json=payload,
-    )
+    response = client.post("/register/spamcheck-hook", json=payload,)
     assert response.status_code == 400
     assert response.json["error"].startswith("Missing key: ")
 
@@ -711,8 +707,7 @@ def test_spamcheck_bad_missing_key(client, dummy_user, mocker, payload, spamchec
 def test_spamcheck_expired_token(client, dummy_user, mocker, spamcheck_on):
     token = make_token({"sub": "dummy"}, audience=Audience.spam_check, ttl=-1)
     response = client.post(
-        "/register/spamcheck-hook",
-        json={"token": token, "status": "active"},
+        "/register/spamcheck-hook", json={"token": token, "status": "active"},
     )
     assert response.status_code == 400
     assert response.json == {"error": "The token has expired"}
@@ -722,8 +717,7 @@ def test_spamcheck_expired_token(client, dummy_user, mocker, spamcheck_on):
 def test_spamcheck_invalid_token(client, dummy_user, mocker, spamcheck_on):
     token = make_token({"sub": "dummy"}, audience=Audience.email_validation)
     response = client.post(
-        "/register/spamcheck-hook",
-        json={"token": token, "status": "active"},
+        "/register/spamcheck-hook", json={"token": token, "status": "active"},
     )
     assert response.status_code == 400
     assert response.json["error"] == "Invalid token: Invalid audience"
@@ -733,8 +727,7 @@ def test_spamcheck_invalid_token(client, dummy_user, mocker, spamcheck_on):
 def test_spamcheck_wrong_status(client, dummy_user, mocker, spamcheck_on):
     token = make_token({"sub": "dummy"}, audience=Audience.spam_check)
     response = client.post(
-        "/register/spamcheck-hook",
-        json={"token": token, "status": "this-is-wrong"},
+        "/register/spamcheck-hook", json={"token": token, "status": "this-is-wrong"},
     )
     assert response.status_code == 400
     assert response.json == {"error": "Invalid status: this-is-wrong."}

--- a/noggin/tests/unit/controller/test_user_otp.py
+++ b/noggin/tests/unit/controller/test_user_otp.py
@@ -20,9 +20,7 @@ from noggin.tests.unit.utilities import (
 def dummy_user_with_2_otp(client, logged_in_dummy_user, dummy_user_with_otp):
     ipa = logged_in_dummy_user
     result = ipa.otptoken_add(
-        o_ipatokenowner="dummy",
-        o_ipatokenotpalgorithm="sha512",
-        o_description="dummy's other token",
+        o_ipatokenowner="dummy", o_description="dummy's other token",
     )['result']
     token = OTPToken(result)
     yield dummy_user_with_otp, token


### PR DESCRIPTION
Previously, we set this to SHA512 but not all authenticator apps are
compatible with that.

Signed-off-by: Nils Philippsen <nils@redhat.com>