### PR TITLE
Fix the centos theme

### DIFF
--- a/noggin/themes/centos/templates/main.html
+++ b/noggin/themes/centos/templates/main.html
@@ -1,7 +1,7 @@
 {% extends "master.html" %}
 
 {% block head %}
-    <link rel="stylesheet" href="{{ url_for('theme.static', filename='vendor/font-awesome-4.7.0/css/font-awesome.min.css) }}" type="text/css">
+    <link rel="stylesheet" href="{{ url_for('theme.static', filename='vendor/font-awesome-4.7.0/css/font-awesome.min.css') }}" type="text/css">
     <link rel="stylesheet" href="{{ url_for('theme.static', filename='vendor/bootstrap-4.3.1/bootstrap.min.css') }}" type="text/css">
     <link rel="stylesheet" href="{{ url_for('theme.static', filename='fonts/Montserrat.css') }}" type="text/css">
     <link rel="stylesheet" href="{{ url_for('theme.static', filename='css/default.css') }}" type="text/css">


### PR DESCRIPTION
A missing ' in the centos theme was causing it to crash with
template errors. This commit fixes the issue.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>