### PR TITLE
Add optional note above the login / register box

### DIFF
--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -7,14 +7,15 @@
     </div>
     <div class="form-group mb-0">
       {{ macros.with_errors(login_form.password, class="validate", placeholder="Password or Password + One-Time-Password", tabindex="2", label=False) }}
-      {% if lost_otp_token is not defined %}
-      <small><a href="{{ url_for('.forgot_password_ask') }}">{{ _("Forgot password?") }}</a></small>
-      {% else %}
-      <small><a href="{{ url_for('.forgot_password_ask') }}">{{ _("Forgotten password or lost OTP token?") }}</a></small>
-      {% endif %}
-      <div class="form-group mb-0">
-        <small><a href="{{ url_for('.otp_sync') }}">{{ _("Sync Token") }}</a></small>
-      </div>
+    </div>
+    <div class="form-group mb-0 text-right">
+    {% if lost_otp_token is not defined %}
+      <small><a href="{{ url_for('.forgot_password_ask') }}">{{ _("Forgot Password?") }}</a></small>
+    {% else %}
+      <small><a href="{{ url_for('.forgot_password_ask') }}">{{ _("Forgot Password or OTP?") }}</a></small>
+    {% endif %}
+     <span class="text-muted"> | </span>
+    <small><a href="{{ url_for('.otp_sync') }}">{{ _("Sync Token") }}</a></small>
     </div>
   </div>
   <div class="card-footer d-flex justify-content-between">

--- a/noggin/templates/index.html
+++ b/noggin/templates/index.html
@@ -11,6 +11,7 @@
         </div>
         <div class="col">
           <div class="card">
+          {{ login_note() if login_note is defined }}
           <ul class="card-header nav nav-tabs pb-0" role="tablist">
             <li class="nav-item">
               <a class="nav-link {{'active' if activetab == 'login'}}" id="login-tab" data-toggle="pill" href="#login" role="tab">{{ _("Login") }}</a>

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -154,3 +154,12 @@
     {{ _("To let admins know that you're not a spammer, please send an email to %(email_link)s and explain the situation.", email_link=email_link) }}
 </p>
 {% endmacro %}
+
+{# an optional macro to show a note between the password field and the submite button on the login page #}
+{% macro login_note() %}
+<div class="alert alert-info text-center mb-0">
+    <div>
+        {{ _("By using a Fedora account, you agree to follow the <a href='https://docs.fedoraproject.org/en-US/project/code-of-conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>.") }}
+    </div>
+</div>
+{% endmacro %}


### PR DESCRIPTION
This adds an additional macro that appears above the login / register
box on the unlogged in main page. The FAS theme also now uses this box
to inform users that if they use a Fedora account, they must adhere to
the Fedora Code Of Conduct.

![Screenshot from 2021-02-22 16-19-57](https://user-images.githubusercontent.com/592259/108670343-71028980-752a-11eb-9bea-f056a8ce39f2.png)
![Screenshot from 2021-02-22 16-19-39](https://user-images.githubusercontent.com/592259/108670350-7233b680-752a-11eb-81b8-96e803e9783d.png)


This also slightly tweaks the links for sync token and forgotten
password to clean them up a littel bit.

Resolves: #495

Signed-off-by: Ryan Lerch <rlerch@redhat.com>