### PR TITLE
Lower minimum age for registration to 13 to match FAS

### DIFF
--- a/noggin/form/register_user.py
+++ b/noggin/form/register_user.py
@@ -37,10 +37,10 @@ class RegisterUserForm(ModestForm):
     )
 
     underage = BooleanField(
-        _('I am over 16 years old'),
+        _('I am over 13 years old'),
         validators=[
             DataRequired(
-                message=_("You must be over 16 years old to create an account")
+                message=_("You must be over 13 years old to create an account")
             )
         ],
     )

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -563,7 +563,7 @@ def test_underage(client, post_data_step_1):
     assert_form_field_error(
         result,
         field_name="register-underage",
-        expected_message="You must be over 16 years old to create an account",
+        expected_message="You must be over 13 years old to create an account",
     )
 
 


### PR DESCRIPTION
The United States Children's Online Privacy Protection Act (U.S COPPA)
states the minimum age is 13. Changing this number has other undesirable
consequences, so we should not unless there's an actual reason to do so.

Fixes: 47b8b42ffb68f3a954c31df9c840f44ad8ab640e
Fixes: #518