### PR TITLE
Use the correct address for OpenID endpoints for openSUSE

### DIFF
--- a/noggin/templates/user-settings-profile.html
+++ b/noggin/templates/user-settings-profile.html
@@ -12,7 +12,7 @@
     {% set buttontext = _('Change Avatar')%}
     {%- if OPENID is defined %}
     <form method="GET" action="https://www.libravatar.org/openid/login/">
-      <input type="hidden" name="openid_identifier" value="{{ 'https://'+user.username+OPENID }}">
+      <input type="hidden" name="openid_identifier" value="{{ OPENID % (user.username) }}">
       <input name="change-avatar" type="submit" value="{{ buttontext }}" class="btn btn-sm btn-outline-primary">
     </form>
     {%- else %}

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -1,7 +1,7 @@
 {% extends "master.html" %}
 {% block website %}{{_("Fedora Accounts")}}{% endblock %}
 
-{% set OPENID = '.id.fedoraproject.org' %}
+{% set OPENID = 'https://%s.id.fedoraproject.org' %}
 
 {% block head %}
     <link href="{{ url_for('theme.static', filename='js/fedora-bootstrap/fedora-bootstrap.min.nodata.css') }}" rel="stylesheet" />

--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -1,7 +1,7 @@
 {% extends "master.html" %}
 {% block website %}{{_("openSUSE Accounts")}}{% endblock %}
 
-{% set OPENID = '.sso.opensuse.org' %}
+{% set OPENID = 'https://www.opensuse.org/openid/user/%s' %}
 
 {% block head %}
     <link href="{{ url_for('theme.static', filename='css/chameleon.nodata.css') }}" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
openSUSE set up Ipsilon in a different configuration, where the
OpenID endpoint isn't `<username>.id.opensuse.org`, but instead a
regular URL path where the username is at the end of the URL.