### PR TITLE
Don't redirect the OpenShift healthz endpoints to HTTPS

### DIFF
--- a/noggin/app.py
+++ b/noggin/app.py
@@ -91,5 +91,7 @@ def create_app(config=None):
     import_all("noggin.controller")
     app.register_blueprint(blueprint)
     app.register_blueprint(healthz, url_prefix="/healthz")
+    # Don't force the Openshift health views to HTTPS
+    talisman(force_https=False)(app.view_functions["healthz.check"])
 
     return app

--- a/noggin/tests/unit/controller/cassettes/test_root/test_healthz_no_https.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_root/test_healthz_no_https.yaml
@@ -1,0 +1,213 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Tue, 16 Mar 2021 13:48:25 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=Gnqov0%2bQ2aec4MybJ5VO%2fcV7A7qX%2fVuI0FXsRXQEbDNfnjQEjGnZiZp4SeA4n2locWZjGzotQjaEnWP9Zz6tmXYQl8wp7Mai7UTpFzJDGoOzotguRGDvghNlc8mQ%2fzXj8w5WzgIsMfCdH%2bNds4eGtKUvo4gFgE2xvZe27IJkbYeOkmo%2blvxXpdok3NCyWPck;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gnqov0%2bQ2aec4MybJ5VO%2fcV7A7qX%2fVuI0FXsRXQEbDNfnjQEjGnZiZp4SeA4n2locWZjGzotQjaEnWP9Zz6tmXYQl8wp7Mai7UTpFzJDGoOzotguRGDvghNlc8mQ%2fzXj8w5WzgIsMfCdH%2bNds4eGtKUvo4gFgE2xvZe27IJkbYeOkmo%2blvxXpdok3NCyWPck
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Mar 2021 13:48:26 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gnqov0%2bQ2aec4MybJ5VO%2fcV7A7qX%2fVuI0FXsRXQEbDNfnjQEjGnZiZp4SeA4n2locWZjGzotQjaEnWP9Zz6tmXYQl8wp7Mai7UTpFzJDGoOzotguRGDvghNlc8mQ%2fzXj8w5WzgIsMfCdH%2bNds4eGtKUvo4gFgE2xvZe27IJkbYeOkmo%2blvxXpdok3NCyWPck
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Mar 2021 13:48:26 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Gnqov0%2bQ2aec4MybJ5VO%2fcV7A7qX%2fVuI0FXsRXQEbDNfnjQEjGnZiZp4SeA4n2locWZjGzotQjaEnWP9Zz6tmXYQl8wp7Mai7UTpFzJDGoOzotguRGDvghNlc8mQ%2fzXj8w5WzgIsMfCdH%2bNds4eGtKUvo4gFgE2xvZe27IJkbYeOkmo%2blvxXpdok3NCyWPck
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 16 Mar 2021 13:48:26 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1


### PR DESCRIPTION
OpenShift needs these endpoints to return a 200 code.