### PR TITLE
Added instruction to make a dir fixing vagrant not starting

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -39,6 +39,7 @@ Check out the code and run ``vagrant up``::
 
     $ git clone https://github.com/fedora-infra/noggin
     $ cd noggin
+    $ mkdir ../freeipa-fas
     $ vagrant up
 
 Next, SSH into your newly provisioned development environment:


### PR DESCRIPTION
'vagrant up' does not start without this directory, gives on error:
* The host path of the shared folder is missing: ../freeipa-fas