### PR TITLE
Default locale and timezone fallbacks in the UI

### DIFF
--- a/noggin/l10n.py
+++ b/noggin/l10n.py
@@ -28,6 +28,7 @@ def guess_locale():
 
 
 LOCALES = [
+    'en-US',
     'af-ZA',
     'am-ET',
     'ar-AE',
@@ -72,7 +73,6 @@ LOCALES = [
     'dsb-DE',
     'dv-MV',
     'el-GR',
-    'en-US',
     'en-GB',
     'en-029',
     'en-AU',

--- a/noggin/templates/user-settings-profile.html
+++ b/noggin/templates/user-settings-profile.html
@@ -76,5 +76,11 @@
         }
     }
   });
+  $('#locale').selectize({
+    sortField	: [{field: 'value', direction: 'asc'}],
+  });
+  $('#timezone').selectize({
+    sortField	: [{field: 'value', direction: 'asc'}],
+  });
   </script>
 {% endblock %}

--- a/noggin/utility/timezones.py
+++ b/noggin/utility/timezones.py
@@ -1,4 +1,5 @@
 TIMEZONES = [
+    'UTC',
     'Africa/Abidjan',
     'Africa/Accra',
     'Africa/Addis_Ababa',
@@ -587,7 +588,6 @@ TIMEZONES = [
     'US/Pacific',
     'US/Pacific-New',
     'US/Samoa',
-    'UTC',
     'Universal',
     'W-SU',
     'WET',


### PR DESCRIPTION
In some cases, a user may have been imported into ipa without a locale
or a timezone set. As these are required fields on the noggin side of
things, when they edit their profile for the first time, the <select>
boxes showed the first items in this list (af-ZA for locale and
Africa/Abidjan for Timezone.)

This commit fixes this issue by putting en-US and UTC at the top of the
lists of Locales and Timezones, so if these are not set, the select
boxes default to those values when editing the form.

Additionally, the UI for the select boxes now use selectize, so the user
can search for a locale and a timezone by substring. Selectize also
sorts the options when presenting them to the user as well.

https://pagure.io/fedora-infrastructure/issue/9761

Signed-off-by: Ryan Lerch <rlerch@redhat.com>