### PR TITLE
Add an additional confirmation when closing OTP QR

### DIFF
--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -114,6 +114,9 @@
         $('#otp-toggle').click(function() {
           $('#otp-qrcode').slideToggle("fast");
         })
+        $('#otp-modal').on("hide.bs.modal", function (e) {
+          if(!confirm("{{_('Are you sure you want to close the OTP dialog? This code will not be shown again, and you will be locked out of your account if you have no way to generate your OTP')}}")) return false;
+        });
     });
   </script>
   {% endif %}


### PR DESCRIPTION
Adds an additional confirmation when a user tries to close the OTP
QRcode, making sure that they understand that this is not going to be
shown again.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>