### PR TITLE
fade out successfull flash messages in 10 seconds

### DIFF
--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -241,7 +241,7 @@ def user_settings_otp_disable(ipa, username):
             ):
                 flash(_('Sorry, You cannot disable your last active token.'), 'warning')
             else:
-                flash('Cannot disable the token.', 'danger')
+                flash(_('Cannot disable the token.'), 'danger')
                 current_app.logger.error(
                     f'Something went wrong disabling an OTP token for user {username}: {e}'
                 )

--- a/noggin/static/css/main.css
+++ b/noggin/static/css/main.css
@@ -62,3 +62,19 @@
   flex-flow: column;
 }
 
+.fadeout-success {
+    -webkit-animation: cssAnimation 10s forwards; 
+    animation: cssAnimation 10s forwards;
+}
+
+@keyframes cssAnimation {
+    0%   {opacity: 1;}
+    90%  {opacity: 1;}
+    100% {opacity: 0;}
+}
+
+@-webkit-keyframes cssAnimation {
+    0%   {opacity: 1;}
+    90%  {opacity: 1;}
+    100% {opacity: 0;}
+}

--- a/noggin/themes/centos/templates/main.html
+++ b/noggin/themes/centos/templates/main.html
@@ -36,12 +36,23 @@
         {% if flashes %}
         <div class="container flash-messages mt-4">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash }}
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
+                {% if category == 'success' %} 
+                {# Hide out success messages in 10 seconds #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show fadeout-success">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% else %}
+                {# Other messages require a click to close #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% endif %}
             {% endfor %}
         </div>
         {% endif %}

--- a/noggin/themes/default/templates/main.html
+++ b/noggin/themes/default/templates/main.html
@@ -33,12 +33,23 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash }}
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
+                {% if category == 'success' %} 
+                {# Hide out success messages in 10 seconds #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show fadeout-success">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% else %}
+                {# Other messages require a click to close #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% endif %}
             {% endfor %}
         </div>
         {% endif %}

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -47,12 +47,23 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash }}
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
+                {% if category == 'success' %} 
+                {# Hide out success messages in 10 seconds #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show fadeout-success">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% else %}
+                {# Other messages require a click to close #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% endif %}
             {% endfor %}
         </div>
         {% endif %}

--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -48,12 +48,23 @@
         {% if flashes %}
         <div class="container flash-messages fixed-top mt-5">
             {% for category, flash in flashes %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show">
-                {{ flash }}
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
+                {% if category == 'success' %} 
+                {# Hide out success messages in 10 seconds #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show fadeout-success">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% else %}
+                {# Other messages require a click to close #}
+                <div class="alert alert-{{ category }} alert-dismissible fade show">
+                    {{ flash }}
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                {% endif %}
             {% endfor %}
         </div>
         {% endif %}


### PR DESCRIPTION
Successful messages are annoyingly in front when scrolling the page, this hides them automatically in 10 seconds if not closed before that.