### PR TITLE
Making Group's mailing_list a link

### DIFF
--- a/noggin/templates/group.html
+++ b/noggin/templates/group.html
@@ -18,7 +18,7 @@
           </h3>
           {% if group.description %}<div>{{ group.description }}</div>{% endif %}
           {% if group.mailing_list %}
-            <div id="group-mailinglist"><i class="fa fa-fw fa-envelope" aria-hidden="true"></i> <a href="{{group.mailing_list}}">{{group.mailing_list}}</a></div>
+            <div id="group-mailinglist"><i class="fa fa-fw fa-envelope" aria-hidden="true"></i> <a href="mailto:{{group.mailing_list}}">{{group.mailing_list}}</a></div>
           {% endif %}
           {% if group.irc_channel %}
             <div id="group-ircchannel"><i class="fa fa-fw fa-comments-o" aria-hidden="true"></i> <a href="{{group.irc_channel}}">{{group.irc_channel}}</a></div>


### PR DESCRIPTION
Fixes #552 

Added `mailto` in group template to `mailing_list` attribute.

To make a full replica of FAS system a new attribute `mailing_list_url` would be added to LDAP system and then added to `Group` model, form and template.