### PR TITLE
Separate UI field for otp token

### DIFF
--- a/news/572.feature
+++ b/news/572.feature
@@ -1,0 +1,1 @@
+Handling separately OTP from password in UI

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -20,6 +20,10 @@ from . import blueprint as bp
 def handle_login_form(form):
     username = form.username.data.lower()
     password = form.password.data
+    otp = form.otp.data
+
+    if otp is not None:
+        password += otp
 
     try:
         # This call will set the cookie itself, we don't have to.

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -20,10 +20,9 @@ from . import blueprint as bp
 def handle_login_form(form):
     username = form.username.data.lower()
     password = form.password.data
-    otp = form.otp.data
 
-    if otp is not None:
-        password += otp
+    if form.otp.data:
+        password += form.otp.data
 
     try:
         # This call will set the cookie itself, we don't have to.

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -214,10 +214,7 @@ def user_settings_otp(ipa, username):
             # Prefill the form for the next step
             confirmotpform.process(
                 MultiDict(
-                    {
-                        "confirm-secret": secret,
-                        "confirm-description": description,
-                    }
+                    {"confirm-secret": secret, "confirm-description": description,}
                 )
             )
     if confirmotpform.validate_on_submit():

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -214,7 +214,7 @@ def user_settings_otp(ipa, username):
             # Prefill the form for the next step
             confirmotpform.process(
                 MultiDict(
-                    {"confirm-secret": secret, "confirm-description": description,}
+                    {"confirm-secret": secret, "confirm-description": description}
                 )
             )
     if confirmotpform.validate_on_submit():

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -198,9 +198,15 @@ def user_settings_otp(ipa, username):
     confirmotpform = UserSettingsConfirmOTPForm(prefix="confirm-")
     user = User(user_or_404(ipa, username))
     secret = None
+
     if addotpform.validate_on_submit():
+        description = addotpform.description.data
+        password = addotpform.password.data
+        if addotpform.otp.data:
+            password += addotpform.otp.data
+
         try:
-            maybe_ipa_login(current_app, session, username, addotpform.password.data)
+            maybe_ipa_login(current_app, session, username, password)
         except python_freeipa.exceptions.InvalidSessionPassword:
             addotpform.password.errors.append(_("Incorrect password"))
         else:
@@ -210,7 +216,7 @@ def user_settings_otp(ipa, username):
                 MultiDict(
                     {
                         "confirm-secret": secret,
-                        "confirm-description": addotpform.description.data,
+                        "confirm-description": description,
                     }
                 )
             )

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -115,7 +115,7 @@ class UserSettingsAddOTPForm(ModestForm):
     otp = PasswordField(
         _('One-Time Password'),
         validators=[Optional()],
-        description=_("Enter your One-Time Password token if you have enrolled one"),
+        description=_("Enter your One-Time Password"),
     )
 
     submit = SubmitButtonField(_("Generate OTP Token"))

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -115,7 +115,7 @@ class UserSettingsAddOTPForm(ModestForm):
     otp = PasswordField(
         _('One-Time Password'),
         validators=[Optional()],
-        description=_("Enter your One-Time Password token if you have enrolled one")
+        description=_("Enter your One-Time Password token if you have enrolled one"),
     )
 
     submit = SubmitButtonField(_("Generate OTP Token"))

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -112,6 +112,12 @@ class UserSettingsAddOTPForm(ModestForm):
         description=_("please reauthenticate so we know it is you"),
     )
 
+    otp = PasswordField(
+        _('One-Time Password'),
+        validators=[Optional()],
+        description=_("Enter your One-Time Password token if you have enrolled one")
+    )
+
     submit = SubmitButtonField(_("Generate OTP Token"))
 
 

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -16,10 +16,6 @@ class LoginUserForm(ModestForm):
         validators=[DataRequired(message=_('You must provide a password'))],
     )
 
-    otp = StringField(
-        _('One-Time Password'),
-        validators=[Optional()],
-        description=_("Enter your One-Time Password (if you have one)"),
-    )
+    otp = StringField(_('One-Time Password'), validators=[Optional()])
 
     submit = SubmitButtonField(_('Log In'))

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -1,6 +1,6 @@
 from flask_babel import lazy_gettext as _
 from wtforms import PasswordField, StringField
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Optional
 
 from .base import ModestForm, SubmitButtonField
 
@@ -17,7 +17,8 @@ class LoginUserForm(ModestForm):
     )
 
     otp = PasswordField(
-        _('One-Time-Password'),
+        _('One-Time Password'),
+        validators=[Optional()],
     )
 
     submit = SubmitButtonField(_('Log In'))

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -16,6 +16,10 @@ class LoginUserForm(ModestForm):
         validators=[DataRequired(message=_('You must provide a password'))],
     )
 
-    otp = StringField(_('One-Time Password'), validators=[Optional()],)
+    otp = StringField(
+        _('One-Time Password'),
+        validators=[Optional()],
+        description=_("Enter your One-Time Password (if you have one)"),
+    )
 
     submit = SubmitButtonField(_('Log In'))

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -16,9 +16,6 @@ class LoginUserForm(ModestForm):
         validators=[DataRequired(message=_('You must provide a password'))],
     )
 
-    otp = PasswordField(
-        _('One-Time Password'),
-        validators=[Optional()],
-    )
+    otp = StringField(_('One-Time Password'), validators=[Optional()],)
 
     submit = SubmitButtonField(_('Log In'))

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -16,4 +16,8 @@ class LoginUserForm(ModestForm):
         validators=[DataRequired(message=_('You must provide a password'))],
     )
 
+    otp = PasswordField(
+        _('One-Time-Password'),
+    )
+
     submit = SubmitButtonField(_('Log In'))

--- a/noggin/form/password_reset.py
+++ b/noggin/form/password_reset.py
@@ -19,11 +19,7 @@ class NewPasswordForm(BaseForm):
 
     password_confirm = PasswordField(_('Confirm New Password'))
 
-    otp = PasswordField(
-        _('One-Time Password'),
-        validators=[Optional()],
-        description=_("Enter your One-Time Password (if you have one)"),
-    )
+    otp = StringField(_('One-Time Password'), validators=[Optional()])
 
 
 class PasswordResetForm(NewPasswordForm):
@@ -31,7 +27,6 @@ class PasswordResetForm(NewPasswordForm):
     current_password = PasswordField(
         _('Current Password'),
         validators=[DataRequired(message=_('Current password must not be empty'))],
-        description=_("Just the password, don't add the OTP token if you have one"),
     )
 
 

--- a/noggin/form/password_reset.py
+++ b/noggin/form/password_reset.py
@@ -22,7 +22,7 @@ class NewPasswordForm(BaseForm):
     otp = PasswordField(
         _('One-Time Password'),
         validators=[Optional()],
-        description=_("Enter your One-Time Password token if you have enrolled one"),
+        description=_("Enter your One-Time Password (if you have one)"),
     )
 
 

--- a/noggin/form/password_reset.py
+++ b/noggin/form/password_reset.py
@@ -1,6 +1,6 @@
 from flask_babel import lazy_gettext as _
 from wtforms import PasswordField, StringField
-from wtforms.validators import DataRequired, EqualTo
+from wtforms.validators import DataRequired, EqualTo, Optional
 
 from .base import BaseForm
 from .validators import PasswordLength
@@ -19,8 +19,10 @@ class NewPasswordForm(BaseForm):
 
     password_confirm = PasswordField(_('Confirm New Password'))
 
-    otp = StringField(
-        _('OTP Token'), description=_("Enter your OTP token if you have enrolled one")
+    otp = PasswordField(
+        _('One-Time Password'),
+        validators=[Optional()],
+        description=_("Enter your One-Time Password token if you have enrolled one"),
     )
 
 

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -5,8 +5,11 @@
     <div class="form-group">
       {{ macros.with_errors(login_form.username, class="validate", placeholder="Username", tabindex="1", label=False) }}
     </div>
+    <div class="form-group">
+      {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
+    </div>
     <div class="form-group mb-0">
-      {{ macros.with_errors(login_form.password, class="validate", placeholder="Password or Password + One-Time-Password", tabindex="2", label=False) }}
+      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time-Password (optional)", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0 text-right">
     {% if lost_otp_token is not defined %}

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -9,7 +9,7 @@
       {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0">
-      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time-Password (optional)", tabindex="2", label=False) }}
+      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (optional)", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0 text-right">
     {% if lost_otp_token is not defined %}

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -9,7 +9,7 @@
       {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0">
-      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (optional)", tabindex="3", label=False) }}
+      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (if you have one)", tabindex="3", label=False) }}
     </div>
     <div class="form-group mb-0 text-right">
     {% if lost_otp_token is not defined %}

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -9,7 +9,7 @@
       {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0">
-      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (optional)", tabindex="2", label=False) }}
+      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (optional)", tabindex="3", label=False) }}
     </div>
     <div class="form-group mb-0 text-right">
     {% if lost_otp_token is not defined %}
@@ -23,6 +23,6 @@
   </div>
   <div class="card-footer d-flex justify-content-between">
     <div>{{ macros.non_field_errors(login_form) }}</div>
-    {{ login_form.submit(color="primary", tabindex="3") }}
+    {{ login_form.submit(color="primary", tabindex="4") }}
   </div>
 </form>

--- a/noggin/templates/password-reset.html
+++ b/noggin/templates/password-reset.html
@@ -17,7 +17,9 @@
                 <div class="form-group">{{ macros.with_errors(password_reset_form.current_password, tabindex="2")}}</div>
                 <div class="form-group">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
                 <div class="form-group">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
-                <div class="form-group">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+                {% if tokens %}
+                  <div class="form-group">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+                {% endif %}
               </div>
               <div class="card-footer d-flex justify-content-between">
                 <div>{{ macros.non_field_errors(password_reset_form) }}</div>

--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -63,7 +63,7 @@
           <div class="form-group">{{ macros.with_errors(addotpform.description, label=False, tabindex="2", placeholder=_("Token name"))}}</div>
           <div class="form-group">{{ macros.with_errors(addotpform.password, label=False, tabindex="3", placeholder=_("Password"))}}</div>
           {% if tokens %}
-          <div class="form-group">{{ macros.with_errors(addotpform.otp, label=False, tabindex="4", placeholder=_("One-Time Password (optional)"))}}</div>
+          <div class="form-group">{{ macros.with_errors(addotpform.otp, label=False, tabindex="4", placeholder=_("One-Time Password"))}}</div>
           {% endif %}
           <div>{{ macros.non_field_errors(addotpform) }}</div>
           {{ addotpform.submit(color="primary", class="btn-block", tabindex="5") }}

--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -61,10 +61,9 @@
         <form action="{{ url_for('.user_settings_otp', username=current_user.username) }}" method="post" class="px-4 py-3" novalidate>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           <div class="form-group">{{ macros.with_errors(addotpform.description, label=False, tabindex="2", placeholder=_("Token name"))}}</div>
-          {% if tokens %}
-          <div class="form-group">{{ macros.with_errors(addotpform.password, label=False, tabindex="3", placeholder=_("Password + One-Time-Password"))}}</div>
-          {% else %}
           <div class="form-group">{{ macros.with_errors(addotpform.password, label=False, tabindex="3", placeholder=_("Password"))}}</div>
+          {% if tokens %}
+          <div class="form-group">{{ macros.with_errors(addotpform.otp, label=False, tabindex="3", placeholder=_("One-Time Password (optional)"))}}</div>
           {% endif %}
           <div>{{ macros.non_field_errors(addotpform) }}</div>
           {{ addotpform.submit(color="primary", class="btn-block", tabindex="4") }}

--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -63,10 +63,10 @@
           <div class="form-group">{{ macros.with_errors(addotpform.description, label=False, tabindex="2", placeholder=_("Token name"))}}</div>
           <div class="form-group">{{ macros.with_errors(addotpform.password, label=False, tabindex="3", placeholder=_("Password"))}}</div>
           {% if tokens %}
-          <div class="form-group">{{ macros.with_errors(addotpform.otp, label=False, tabindex="3", placeholder=_("One-Time Password (optional)"))}}</div>
+          <div class="form-group">{{ macros.with_errors(addotpform.otp, label=False, tabindex="4", placeholder=_("One-Time Password (optional)"))}}</div>
           {% endif %}
           <div>{{ macros.non_field_errors(addotpform) }}</div>
-          {{ addotpform.submit(color="primary", class="btn-block", tabindex="4") }}
+          {{ addotpform.submit(color="primary", class="btn-block", tabindex="5") }}
         </form>
       </div>
     </div>

--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -10,7 +10,6 @@ from noggin.app import create_app, ipa_admin
 from noggin.representation.agreement import Agreement
 from noggin.representation.otptoken import OTPToken
 from noggin.security.ipa import maybe_ipa_login, untouched_ipa_client
-from noggin.tests.unit.utilities import get_otp, otp_secret_from_uri
 
 
 @pytest.fixture(scope="session")

--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -224,7 +224,9 @@ def dummy_user_with_gpg_key(client, dummy_user):
 
 @pytest.fixture
 def dummy_user_with_otp(client, dummy_user):
-    result = ipa_admin.otptoken_add(o_ipatokenowner="dummy", o_description="dummy's token")
+    result = ipa_admin.otptoken_add(
+        o_ipatokenowner="dummy", o_description="dummy's token"
+    )
     token = OTPToken(result["result"])
     yield token
     # Deletion needs to be done as admin to remove the last token

--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -10,6 +10,7 @@ from noggin.app import create_app, ipa_admin
 from noggin.representation.agreement import Agreement
 from noggin.representation.otptoken import OTPToken
 from noggin.security.ipa import maybe_ipa_login, untouched_ipa_client
+from noggin.tests.unit.utilities import get_otp, otp_secret_from_uri
 
 
 @pytest.fixture(scope="session")
@@ -223,7 +224,16 @@ def dummy_user_with_gpg_key(client, dummy_user):
 
 
 @pytest.fixture
-def dummy_user_with_otp(client, logged_in_dummy_user):
+def dummy_user_with_otp(client, dummy_user):
+    result = ipa_admin.otptoken_add(o_ipatokenowner="dummy", o_description="dummy's token")
+    token = OTPToken(result["result"])
+    yield token
+    # Deletion needs to be done as admin to remove the last token
+    ipa_admin.otptoken_del(token.uniqueid)
+
+
+@pytest.fixture
+def logged_in_dummy_user_with_otp(client, logged_in_dummy_user):
     ipa = logged_in_dummy_user
     result = ipa.otptoken_add(o_ipatokenowner="dummy", o_description="dummy's token",)
     token = OTPToken(result['result'])

--- a/noggin/tests/unit/controller/cassettes/test_authentication/test_login_with_otp.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_authentication/test_login_with_otp.yaml
@@ -15,13 +15,13 @@ interactions:
       Referer:
       - https://ipa.noggin.test/ipa/session/login_password
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/login_password
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -29,20 +29,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 06 Aug 2020 09:27:23 GMT
+      - Wed, 21 Apr 2021 02:41:51 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=6E%2bGnX7foJ73wzFejnD%2fBq0mCn1dDTHTbD9nQYGoQeenBtE%2fSvf0b1mpcyriB4ak4my2mJdIVRkz3H2c3xE4kcGWcywVC61a7U7fbgx9ejW1Cj5cBzhjwiVmQT%2f%2bD1fqwbzTABX1N3Oy4soKKxkw3ld3IPfEHOtsESK3HnEWyzwTM3UXxvZDz2TYR7TDhoE0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,19 +64,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      - ipa_session=MagBearerToken=6E%2bGnX7foJ73wzFejnD%2fBq0mCn1dDTHTbD9nQYGoQeenBtE%2fSvf0b1mpcyriB4ak4my2mJdIVRkz3H2c3xE4kcGWcywVC61a7U7fbgx9ejW1Cj5cBzhjwiVmQT%2f%2bD1fqwbzTABX1N3Oy4soKKxkw3ld3IPfEHOtsESK3HnEWyzwTM3UXxvZDz2TYR7TDhoE0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
-        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
-        XINDlIAqoMaB5MGWKNUCAAAA//8DAMPMtr2XAAAA
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAPz/BoKXAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -89,11 +89,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -106,8 +106,8 @@ interactions:
 - request:
     body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
       "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@example.com",
-      "userpassword": "dummy_password123456", "random": false, "noprivate": false, "all":
-      true, "raw": false, "no_members": false, "fascreationtime": "2020-08-06T09:27:23Z",
+      "userpassword": "dummy_password", "random": false, "noprivate": false, "all":
+      true, "raw": false, "no_members": false, "fascreationtime": "2021-04-21T02:41:51Z",
       "version": "2.235"}]}'
     headers:
       Accept:
@@ -121,28 +121,28 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      - ipa_session=MagBearerToken=6E%2bGnX7foJ73wzFejnD%2fBq0mCn1dDTHTbD9nQYGoQeenBtE%2fSvf0b1mpcyriB4ak4my2mJdIVRkz3H2c3xE4kcGWcywVC61a7U7fbgx9ejW1Cj5cBzhjwiVmQT%2f%2bD1fqwbzTABX1N3Oy4soKKxkw3ld3IPfEHOtsESK3HnEWyzwTM3UXxvZDz2TYR7TDhoE0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5RUbW/aMBD+KyifCwQIUCZVGusqNm0qlUr7oeuELvYRPBzb8wuFVv3vs50EWqlT
-        1U85P3f3+O65c54SjcZxm3xqPb00ifCfX8lXV5b71o1Bnfw+aSWUGcVhL6DEt9xMMMuAm8p3E7EC
-        iTRvBcv8DxJLOJjKbaVKPKxQGymCJXUBgj2CZVIAP+JMoPW+14ALtCFdGrYDQqQTNpw3OleaCcIU
-        cHC7GrKMbNAqyRnZ16gPqCqqD8asG84VmMb0jmuznmnp1Hx15fIfuDcBL1HNNSuYuBBW7ysxFDjB
-        /jpkNPaXToa9cTpJ23RMxu1eD6ENg9NBe9gfZmnaX40gG8TEULK//kFqijvFdBQgUDwlyyUFi5aV
-        uFx6JOmn/TQ9TUfppD/uD+6S5zrfi2rVAyVrEAV+LBV3VoMPhSYtB4OjrEqaTn+OH8/tipSTLT2f
-        rO9mPZVvvswXKf12fZO524vbxe10elaxeVFKEFAgxahKUIGIMxr24MQbRZDRBKsemDmh5EzIwusY
-        LIvGVjvEtiheL13E/WCIxqhPaOwDjRaMClfmfqiBsTccpX4GWS+LtKba/cOmcukLMmvkPOLdnImu
-        V2Udna4eLz1UtZYlUqb9Ksm66W6AuseIEhg/Jn3GHZSKY4fIslkAAkIKRoAfuq5CL+ez2ffLzuLi
-        etHc/v8+Xu7+OzzKP33UWwy9rPwLxtAHmGWziB622jXoBvcW8iNWYihBrpZxovGasP2e0VS/jSBo
-        qPU4++h8Z/TPPnUL3IXCa33DdLwBUdhkSinSVqBq3VcB90nMQq1lkEQ4zsNTpEf7oEggAFoy8UqM
-        cKWvrHpxSdY57YyS538AAAD//wMA2cUe3SUFAAA=
+        H4sIAAAAAAAAA5RUbW/aQAz+KyifCyQ00DKp0thW0WlTmQTth64Tcu5McuNesnuhsKr/fXeXAK1U
+        reoHFOex/cR+bPOYaDSO2+RD5/G5SaR//Ey+OCF2nRuDOvl10kkoMzWHnQSBr7mZZJYBN43vJmIl
+        EmVeC1bFbySWcDCN26o68XCN2igZLKVLkOwvWKYk8CPOJFrvewm4QBvSlWFbIEQ5acP7Whe1ZpKw
+        Gji4bQtZRtZoa8UZ2bWoD2gqal+MqfacKzB70zvmpppq5erZ6ocrvuHOBFxgPdOsZPJSWr1rxKjB
+        SfbHIaOxv0FKTlfkPO3CIC+6WYZFtyBnZ93hYJin6XDln6OYGEr2n39QmuK2ZjoKECgek+WSgkXL
+        BC6XHvGcgyzN/W+QZ8PsLnlq872otn6gpAJZ4vtScWs1+FDYpxVgcJQ3SZPJ9836alwSMd7Qz+Pq
+        bprVxfrTbJHSq/lN7m4vbxe3k8lFw+ZFESChRIpRlaACkRc07MGJN8ogowlWOzBzQsmFVKXXMVgW
+        jd0rQkAqyQjww+5Fmo/Xs+n063VvcTlfxFDHqHSi8NMKMVk2Oh+l2Wk2jE6uPLOpkPPo7RdM9n17
+        VXQKYPwZMW5B1Bx7RInDVPaL9EYNlRJImfa7pNqu+wHqx+gYYZrrOtyCa3fkGFGyDcqXd9bi/+nP
+        LyrRGPclDPodg6/96aPeYChj5S8YQxtglvtF9LDVbo+ucWehOGICQ0VqtYwTjZWF7feMpvnbCO2G
+        Jo+zj843Rv/kUzfAXWiklSZo5w2IuiYTSpF2AlXnvgm4T2IWaq2CQtJxHk6RHu3DEAMBUMHki/mF
+        T/rKmotL8t64d5o8/QMAAP//AwCTQlKUJQUAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -155,11 +155,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -183,18 +183,18 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      - ipa_session=MagBearerToken=6E%2bGnX7foJ73wzFejnD%2fBq0mCn1dDTHTbD9nQYGoQeenBtE%2fSvf0b1mpcyriB4ak4my2mJdIVRkz3H2c3xE4kcGWcywVC61a7U7fbgx9ejW1Cj5cBzhjwiVmQT%2f%2bD1fqwbzTABX1N3Oy4soKKxkw3ld3IPfEHOtsESK3HnEWyzwTM3UXxvZDz2TYR7TDhoE0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
-        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPTMlGoBAAAA//8DAO6xzS5tAAAA
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPWMlWoBAAAA//8DALVaZhVtAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -207,11 +207,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:
@@ -224,7 +224,7 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: user=dummy&new_password=dummy_password123456&old_password=dummy_password123456
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
     headers:
       Accept:
       - text/plain
@@ -237,7 +237,7 @@ interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/change_password
   response:
@@ -258,11 +258,11 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -275,7 +275,7 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: user=dummy&password=dummy_password123456
+    body: user=admin&password=adminPassw0rd%21
     headers:
       Accept:
       - text/plain
@@ -284,13 +284,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '34'
+      - '36'
       Content-Type:
       - application/x-www-form-urlencoded
       Referer:
       - https://ipa.noggin.test/ipa/session/login_password
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/login_password
   response:
@@ -309,13 +309,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=ioRKBul0flqtm%2bwKT%2bgEw9lzEDWVTSTJBerAC%2bqxUNpmwgGDAhMJShZ04XCGw1To4O0KwOfi6XzCmziwq3M08%2fwP2VUCUa8HoEPBLFllkMoC1F%2fBdI%2bj8hnqdxyyzG89oSBJ3or%2fl9DFohvlWLDsR%2bXcX%2ba9nqOeemA%2fkPhFWnVdFO48uZTaAsFH6LR7iAyC;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -339,19 +339,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      - ipa_session=MagBearerToken=ioRKBul0flqtm%2bwKT%2bgEw9lzEDWVTSTJBerAC%2bqxUNpmwgGDAhMJShZ04XCGw1To4O0KwOfi6XzCmziwq3M08%2fwP2VUCUa8HoEPBLFllkMoC1F%2fBdI%2bj8hnqdxyyzG89oSBJ3or%2fl9DFohvlWLDsR%2bXcX%2ba9nqOeemA%2fkPhFWnVdFO48uZTaAsFH6LR7iAyC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
-        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgc1OAVlQ6+Pm7u3v66YW4
-        BocoAVVAjQPJgy1RqgUAAAD//wMAZ5CzXpcAAAA=
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAPz/BoKXAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -364,11 +364,232 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_add", "params": [[null], {"type": "totp", "description":
+      "dummy''s token", "ipatokenowner": "dummy", "ipatokenotpalgorithm": "sha1",
+      "ipatokenotpdigits": 6, "ipatokentotpclockoffset": 0, "ipatokentotptimestep":
+      30, "ipatokenhotpcounter": 0, "qrcode": false, "no_qrcode": false, "all": true,
+      "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '367'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ioRKBul0flqtm%2bwKT%2bgEw9lzEDWVTSTJBerAC%2bqxUNpmwgGDAhMJShZ04XCGw1To4O0KwOfi6XzCmziwq3M08%2fwP2VUCUa8HoEPBLFllkMoC1F%2fBdI%2bj8hnqdxyyzG89oSBJ3or%2fl9DFohvlWLDsR%2bXcX%2ba9nqOeemA%2fkPhFWnVdFO48uZTaAsFH6LR7iAyC
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xSXXPaMBD8K4xmSh/CpzGmMONp08QYKMVpDQmh6TBCEqBgW0aSSQjDf68ktw1J
+        XvJ2p73du9vTAXAiskiCTuFwGtIUSrYhCZPphuzV068DmM8XUBDHns9VDqInb7s728w4mQ6vh9t+
+        bUyzwWP3jN60Aghxv2rHTz+sWvd766t37yAXHH+XCqe6MFoxTuU61upArGEdvKrAdEWlMLDzApMK
+        RBFDG7ZcCiJNRe1NhaQxEZKkBm7kOFvcEyRRBEWu+68evOLqXLL05UQPCeGGhbM43hsME4E4Va1Y
+        8ox8FIVc9JSdJXSbEYpNWftTG1oN1CxjVFuU7VZ7WYZoUS9bddjGDsJLy2kadsapNlvblcl1p1rV
+        w1VNly+jwPf7o8rYC8ed9wh+pkJkhLuG/cGunfCLgiBOpBvat+H1VWtw6d84w9CaTL95o4ugG3h2
+        f9q8GAaz2cQKwl7rpz+b+I1+1w9uvcFls1fMT+U6xf9XdcPeeb2YEk4ZdpX72tB9SvQ242B8pXOs
+        PXtjkPueXUoocZUTJYzchK1WNNGRVOcGRyW8g1GmOyVZFKlUqIUh178YnGNMcEH1zy9UuAN3wFAI
+        54w/U8yd/sYppwlSU0ZaAOKYJqfW60V2hIv8BwC70q40wPEPAAAA//8DAIR+BqRYAwAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:52 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ioRKBul0flqtm%2bwKT%2bgEw9lzEDWVTSTJBerAC%2bqxUNpmwgGDAhMJShZ04XCGw1To4O0KwOfi6XzCmziwq3M08%2fwP2VUCUa8HoEPBLFllkMoC1F%2fBdI%2bj8hnqdxyyzG89oSBJ3or%2fl9DFohvlWLDsR%2bXcX%2ba9nqOeemA%2fkPhFWnVdFO48uZTaAsFH6LR7iAyC
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPWMlWoBAAAA//8DALVaZhVtAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:52 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password800692
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgc1OAVlQ6+Pm7u3v66YW4
+        BocoAVVAjQPJgy1RqgUAAAD//wMAWKMDYZcAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:52 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -393,27 +614,27 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTW2/aMBT+K8jPXJIQoFRC2sMqNE0qk9q+rJqQYx8SD8fOfKEwxH/fsZMC1brL
-        U06+z+fi73w+EgPWS0due8dL+HwkTIUv+ejr+tB7smDIt36PcGEbSQ+K1vAeLZRwgkrbck8RK4Fp
-        +97hDbXMAHVCKyfaekeyXnPqIPyv14iQLMmS5CaZJvNslo2/klPI1MV3YI5JatvCTjcE4QaM1SpE
-        2pRUiZ+xNpUXXChwyL0FfBgopGsr9pQx7ZUL/1tTNEYoJhoqqd93kBNsC67RUrBDh+KBdqLux9rq
-        tSbe8TVE4sFWS6N9s9p88cVnONiA19CsjCiFulPOHFoZG+qV+OFB8Hi/ZD5JZ8k8GfAZmw3SFOiA
-        jm/Gg0k2yZMk20xpPo6JYWRs/6INh30jTBTgz8KmaZJHYfNOWMxHUV3zwllFVfk/O7lKZVRpJRiV
-        Z3vwsPEP96vl8tP98PHu4bF1hNiBemuhDufK1wXKFfB0MsXpkjzNI+n/RkqN+tkKpIzsqBBqVFBb
-        RbLSNXBhcD8a9Y18gEb83Ph60/+Y3XcruSTXVMirBNjTupEwZLqOtG3f0dn1ynYWk5ptkdrgc4Hg
-        Pnx8YHbAr7AawoX1Zl0G18Q6wRp4zravMdQOIy1i7z5Ti0iGoOti+5wtlC5RnxA5sK7dV2vz216K
-        sTNeMVzxdW+LFWnUi6S9ULVXU8cqPHNCFozRYRPKSxkMyy/xWcmQ+ruIeGKHI7a+JPnwZjglp18A
-        AAD//wMAxjS2z4YEAAA=
+        H4sIAAAAAAAAA4xTyW7bMBD9FYFnL5K8pQEM9NDAKArEBZJcWhQGRY0k1hSpcnHsGvn3Dkl5CRqk
+        PQgavlk48+bxSDQYJyy5TY4X8/uRMOn/5JNr20PyZECTH4OElNx0gh4kbeEtN5fccipM9D0FrAam
+        zFvBFTVMA7VcSctjvSPZbEpqwZ83G0RInuZZOsUvn2az7Bt58Zmq+AnMMkFNLGxVRxDuQBslvaV0
+        TSX/HWpTccG5BIu+14DzDfl0ZfieMqactP681UWnuWS8o4K6fQ9ZzrZgOyU4O/QoBsSO+oMxzakm
+        zngy0fFgmpVWrltXX13xBQ7G4y10a81rLu+k1YdIY0ed5L8c8DLMl6dsUrGbdEjzaTHMMiiGBVss
+        hrN8Nk3TWYX/eUj0LeP1z0qXsO+4DgS8Q+wiTwOxeU8s5iOptnsuWUNl/T87OaW2lIvQbOm3/BH2
+        tO0EjJhqQ2dC4YSmARGDxgWX44KaJjhN1NpZGa6fO5SKIuI7kK9Vd4qUri0wz+NZNr+Zp9kkm/VJ
+        7zhxVEalkpxRcS4ce79fr1af70ePdw+PIbRRLZRc44IVLii076Hxpb1rqfyjmDS9xIRiW4yr8LmA
+        Vx8+PtA7KK+wFnz3qtrUXjWhqJcGxpn4Gj1vnoNluGvA5DI4vdHfYgYlW0pVI/vesmBs3FeU+W2S
+        oW21kwxXfH23wYo0jEuyxFdNWmpZgzEv6AWtladVOiG8YMuLfSbCp/7NAUbssMWoSzIdfRhNyMsf
+        AAAA//8DAEF8NZOGBAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -426,11 +647,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -455,27 +676,27 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTWYvbMBD+K8HPOWTHuQqBPnQJpbAp7O5Ll2LG8iRRI0uqjmzSkP9eSXYu2B5P
-        Gn1zaOabT8dEo3HcJh86x1uTCn+8Jp9cXR86LwZ18r3bSSpmFIeDgBrfczPBLANuGt9LxNZIpXkv
-        WJY/kFrKwTRuK1XiYYXaSBEsqdcg2C+wTArgV5wJtN53D7hQNqRLw/ZAqXTChvtWl0ozQZkCDm7f
-        QpbRLVolOaOHFvUBTUftxZjNueYKzNn0jiezWWjp1HL11ZVf8GACXqNaarZm4kFYfWjIUOAE++mQ
-        VXE+MhulEzIjvWpCJ700RejBcDrsjbJRTki2GkM+jImhZf/8m9QV7hXTkYBQ4pgURQUWLauxKDyS
-        ZCQjaUpyMssmWf4tObX5nlSr3iq6AbHGP6eSKRnfpXLpRzAb5Dy2PCiZGJRgNpe+zlReFFCFpX58
-        XC4Wnx/7zw9PzzHUtTNH7xkRri49iwFPR2PfNMnTvNHI3507FPeKi7jfCtUYyQlT/ceUw3bKGhi/
-        aR73UCuOfSrrWNg00r8IdSNrrJj20pB+tZGXAA2uw3lmKAgpGP0nM8K04uSSbn3cyn8XDI+AKc5b
-        97DV7oxu8WChvGLK/1LUO6xusmsM7MlVsQ7KjM8H+fk40/zbMFLYwTx21aViHp3BaPsx3YrOhVx7
-        AQTLorHJyafugLswULvLwI83IDIhHOchBrWWur0H5VdX+6KYS4k7SsIDvo9G4Enen/bHyek3AAAA
-        //8DAOj91U+UBAAA
+        H4sIAAAAAAAAA4xT24rbMBD9lcXPudjObVsI9KFLKIVNYXdfWkqQ5bGjRpZUXbJJQ/69M7Jzg2Xb
+        B+PRmavOHB0SCy5In3y8O1ybXOHvR/I5NM3+7sWBTX727pJSOCPZXrEG3nILJbxg0rW+l4jVwLV7
+        K1gXv4B7Lplr3V6bBGED1mlFlrY1U+IP80IrJi+4UODRdwsEKkvp2okd41wH5em8sYWxQnFhmGRh
+        10Fe8A14o6Xg+w7FgHai7uDc+lSzYu5kouPJrRdWB7OsvoXiK+wd4Q2YpRW1UA/K231LhmFBid8B
+        RBnvl6d8VPH7tM/ycdHPMij6BZ/N+pN8Mk7TSYX/aUykkbH9q7Yl7IywkQAqcUhWq5J58KKB1QoR
+        rJln6SxP03ycTfLvybHLR1K9eS35mqka3kkd43edijflFmJDivyPzKzLDN0tS1pyvEbDhLxAn2DH
+        GiNhwHXT6kKUKjQF0koxWTa9n6bZKJtEp2vVd9ZKeC9YauTdrUG27YaFUMOCuXV0rnUDpbC4V417
+        iX6Chpc5rxVyFnY78+NysfjyOHh+eHo+hXKmtBL8n6G12IK6fScRV64Tp9R8g74KnwvQnMytTltH
+        2NtwQjew96y4YAZfKdgtlFfZDRA5ulrVpMzYkuSHca59t8QnsTiP0/a4mkcnGd08rlfyudI1ckmW
+        B+eTI6ZumQx0iW6ztBw0WCRTBSkpBqzVtjuT8suLfab2XOKGKmqAc7QCT8aDD4NRcvwLAAD//wMA
+        RXdJQ5QEAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -488,11 +709,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:52 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -518,19 +739,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLiZDKSVTlxK6pEOylQ7GdluDX8hWIYT8e+Qp27n3XGkFtIV8
-        hV6sB77eJwE6UWyhY65IUatqDeeP8sVyVygEhQs30IkvJspFBFX1j1cbe4uYkG0k7zk6c3BGF7XL
-        yrdjw3+W2/gchsco5/s0Ay/+FotLsfmzvMoLbDsAAAD//wMAMi41IaoAAAA=
+        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLibQLs3UpYQu6ZBspYOx3dbgF7JVCCH/HnnKdu49V1oBbSFf
+        oRfrga/3SYBOFFvomCtS1Kpaw/mjfLHcFQpB4cINdOKLiXIRQVX949XG3iImZBvJe47OHJzRRe2y
+        8u3Y8J/lNj6H4THK+T7NwIu/xeJSbP4ir/IM2w4AAP//AwBpxZ4aqgAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -543,11 +764,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -574,19 +795,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      - ipa_session=MagBearerToken=dmfhn%2fOipnn2wckzkVttlAFdQwtBleisqXYcqQlmEnKSEm6enIoW9xxIcOlFrorQE0tgqP1NN0nILTXxA0VE9F9Amg5Ir1ixD5jYFDnDm0jyWyyP06xo7gFspN9OvP4afKkb8WPcVJDTjLtl4m7yUkVfFiakRJKPbS5Lqn6O70RFOyfjB6JEH%2f%2fkxxl6gehC
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLiZDKSVTlxK6pEOylQ7GdluDX8hWIYT8e+Qp27n3XGkFtIV8
-        hV6sB77eJwE6UWyhY65IUatqDeeP8sVyVygEhQs30IkvJspFBFX1j1cbe4uYkG0k7zk6c3BGF7XL
-        yrdjw3+W2/gchsco5/s0Ay/+FotLsfmzvMoLbDsAAAD//wMAMi41IaoAAAA=
+        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLibQLs3UpYQu6ZBspYOx3dbgF7JVCCH/HnnKdu49V1oBbSFf
+        oRfrga/3SYBOFFvomCtS1Kpaw/mjfLHcFQpB4cINdOKLiXIRQVX949XG3iImZBvJe47OHJzRRe2y
+        8u3Y8J/lNj6H4THK+T7NwIu/xeJSbP4ir/IM2w4AAP//AwBpxZ4aqgAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -599,11 +820,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:24 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=96
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -629,13 +850,13 @@ interactions:
       Referer:
       - https://ipa.noggin.test/ipa/session/login_password
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/login_password
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -643,20 +864,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Thu, 06 Aug 2020 09:27:25 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=Vpy%2fcCgwYcxDxUqreTry6NdwdDpIjlFYdvwwyIHJKd9eq4eqQiVNjlhHWBSCXTScE34%2f6xUIIWo2CR%2f%2bW3YJDB6mTJMQoJM1xHs8wbq93aUv4INXF7TofFwFgV1NtwqPM9rOS50mNuxjnfs67dJ%2fSYul%2ffVcTdSN1sI0f63XP1rVKghEWJHS%2byNCsU3Q9PfD;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -678,19 +899,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      - ipa_session=MagBearerToken=Vpy%2fcCgwYcxDxUqreTry6NdwdDpIjlFYdvwwyIHJKd9eq4eqQiVNjlhHWBSCXTScE34%2f6xUIIWo2CR%2f%2bW3YJDB6mTJMQoJM1xHs8wbq93aUv4INXF7TofFwFgV1NtwqPM9rOS50mNuxjnfs67dJ%2fSYul%2ffVcTdSN1sI0f63XP1rVKghEWJHS%2byNCsU3Q9PfD
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
-        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
-        XINDlIAqoMaB5MGWKNUCAAAA//8DAMPMtr2XAAAA
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAPz/BoKXAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -703,11 +924,224 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:25 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [["989a23c5-dc0b-479f-acb1-21a9d6cdf265"],
+      {"continue": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Vpy%2fcCgwYcxDxUqreTry6NdwdDpIjlFYdvwwyIHJKd9eq4eqQiVNjlhHWBSCXTScE34%2f6xUIIWo2CR%2f%2bW3YJDB6mTJMQoJM1xHs8wbq93aUv4INXF7TofFwFgV1NtwqPM9rOS50mNuxjnfs67dJ%2fSYul%2ffVcTdSN1sI0f63XP1rVKghEWJHS%2byNCsU3Q9PfD
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4yOOw+CMBSF/0pzZ0vkqXVy0BAXMJFNGUp7SRpLIQVMDOG/2046un0nJ+exgMVx
+        1hMcyPKLLVcapcN7vW4IvLie0Stge8ajWKRUim1Dkx1rKRdNSKOQM5kJ2UZZCrWLjHPXcft2ITih
+        xgklKasrmfonGvL4q+cB4MfR2t66HjNr7aSSXx6sMkINXPsZLjtljkWZ55ciqM63CvxztKPqjfeT
+        gAUxrB8AAAD//wMAMtjEH/MAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:53 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=Vpy%2fcCgwYcxDxUqreTry6NdwdDpIjlFYdvwwyIHJKd9eq4eqQiVNjlhHWBSCXTScE34%2f6xUIIWo2CR%2f%2bW3YJDB6mTJMQoJM1xHs8wbq93aUv4INXF7TofFwFgV1NtwqPM9rOS50mNuxjnfs67dJ%2fSYul%2ffVcTdSN1sI0f63XP1rVKghEWJHS%2byNCsU3Q9PfD
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPWMlWoBAAAA//8DALVaZhVtAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:53 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:53 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=ge1xWzCKht3wf8u19wewZDRNw6DeTyVZMwtmmeG0NAC3u%2f43lzorOG0c3IMzNos119LPGwzMPUzcaZWTZyCyCTwEkRnm49ieYgzEMTWL6WX%2bgWljiZg1%2foz2xp1WofH2WCkTHyoGbseIqqz8FhEN82PPDKmoz8GEVzPwh3Du1d75dIIylhnpxDI2GuqMbWYV;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ge1xWzCKht3wf8u19wewZDRNw6DeTyVZMwtmmeG0NAC3u%2f43lzorOG0c3IMzNos119LPGwzMPUzcaZWTZyCyCTwEkRnm49ieYgzEMTWL6WX%2bgWljiZg1%2foz2xp1WofH2WCkTHyoGbseIqqz8FhEN82PPDKmoz8GEVzPwh3Du1d75dIIylhnpxDI2GuqMbWYV
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAPz/BoKXAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 02:41:53 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -732,19 +1166,19 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      - ipa_session=MagBearerToken=ge1xWzCKht3wf8u19wewZDRNw6DeTyVZMwtmmeG0NAC3u%2f43lzorOG0c3IMzNos119LPGwzMPUzcaZWTZyCyCTwEkRnm49ieYgzEMTWL6WX%2bgWljiZg1%2foz2xp1WofH2WCkTHyoGbseIqqz8FhEN82PPDKmoz8GEVzPwh3Du1d75dIIylhnpxDI2GuqMbWYV
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA0yNsQrDMAxEf8VoLp5KKZ06tIQu6ZBsTQZTqyCQnSDHhRDy75HJ0G7vTnenBQRT
-        5gkuZvnHjyNGr/jq14OBr+OMRYHPIczQq5eUnMzqwg0ZJ/QmJxTT7ZkOoDRRZBDNxMyskvyPR6H4
-        ptFxmXA+ULzWz6p61La9Ny2UtyiJhljuR3u2J1g3AAAA//8DAETYZbiwAAAA
+        H4sIAAAAAAAAA0yNsQ7CMAxEfyXyjLLAAhMDqGIpQ7vRDhExkiUnrZwGqar673XUAbZ357vzAoIp
+        8wQXs/zjxxGjV3z168HA13HGosDnEGbo1UtKTmZ14YaME3qTE4rp9kwHUJooMohmYmZWSf7Ho1B8
+        0+i4TDgfKF7rZ1U9atvemxbKW5REQyz3kz3bI6wbAAAA//8DAB8zzoOwAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -757,11 +1191,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:25 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Transfer-Encoding:
       - chunked
       Vary:
@@ -785,18 +1219,18 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      - ipa_session=MagBearerToken=ge1xWzCKht3wf8u19wewZDRNw6DeTyVZMwtmmeG0NAC3u%2f43lzorOG0c3IMzNos119LPGwzMPUzcaZWTZyCyCTwEkRnm49ieYgzEMTWL6WX%2bgWljiZg1%2foz2xp1WofH2WCkTHyoGbseIqqz8FhEN82PPDKmoz8GEVzPwh3Du1d75dIIylhnpxDI2GuqMbWYV
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
-      - python-requests/2.23.0
+      - python-requests/2.25.1
     method: POST
     uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
-        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPTMlGoBAAAA//8DAO6xzS5tAAAA
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPWMlWoBAAAA//8DALVaZhVtAAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -809,11 +1243,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 06 Aug 2020 09:27:25 GMT
+      - Wed, 21 Apr 2021 02:41:53 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
-      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
       - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
       Transfer-Encoding:

--- a/noggin/tests/unit/controller/cassettes/test_authentication/test_login_with_otp.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_authentication/test_login_with_otp.yaml
@@ -1,0 +1,828 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:23 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
+        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAMPMtr2XAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@example.com",
+      "userpassword": "dummy_password123456", "random": false, "noprivate": false, "all":
+      true, "raw": false, "no_members": false, "fascreationtime": "2020-08-06T09:27:23Z",
+      "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '341'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5RUbW/aMBD+KyifCwQIUCZVGusqNm0qlUr7oeuELvYRPBzb8wuFVv3vs50EWqlT
+        1U85P3f3+O65c54SjcZxm3xqPb00ifCfX8lXV5b71o1Bnfw+aSWUGcVhL6DEt9xMMMuAm8p3E7EC
+        iTRvBcv8DxJLOJjKbaVKPKxQGymCJXUBgj2CZVIAP+JMoPW+14ALtCFdGrYDQqQTNpw3OleaCcIU
+        cHC7GrKMbNAqyRnZ16gPqCqqD8asG84VmMb0jmuznmnp1Hx15fIfuDcBL1HNNSuYuBBW7ysxFDjB
+        /jpkNPaXToa9cTpJ23RMxu1eD6ENg9NBe9gfZmnaX40gG8TEULK//kFqijvFdBQgUDwlyyUFi5aV
+        uFx6JOmn/TQ9TUfppD/uD+6S5zrfi2rVAyVrEAV+LBV3VoMPhSYtB4OjrEqaTn+OH8/tipSTLT2f
+        rO9mPZVvvswXKf12fZO524vbxe10elaxeVFKEFAgxahKUIGIMxr24MQbRZDRBKsemDmh5EzIwusY
+        LIvGVjvEtiheL13E/WCIxqhPaOwDjRaMClfmfqiBsTccpX4GWS+LtKba/cOmcukLMmvkPOLdnImu
+        V2Udna4eLz1UtZYlUqb9Ksm66W6AuseIEhg/Jn3GHZSKY4fIslkAAkIKRoAfuq5CL+ez2ffLzuLi
+        etHc/v8+Xu7+OzzKP33UWwy9rPwLxtAHmGWziB622jXoBvcW8iNWYihBrpZxovGasP2e0VS/jSBo
+        qPU4++h8Z/TPPnUL3IXCa33DdLwBUdhkSinSVqBq3VcB90nMQq1lkEQ4zsNTpEf7oEggAFoy8UqM
+        cKWvrHpxSdY57YyS538AAAD//wMA2cUe3SUFAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=9MdB68d1nRFOxTOimdnM3W1v2g0wEYaJucag7QCfX3kvOv4hg46NCfYxDxzsTWlXRhvBkWYZP4PPBbuvXze4h1HA55SvGKmWzkMzfZ31SxHQU%2f%2fx3PIcaBm4PMYRXZkKDDf6e5XHrN2mvrKxCIOllfEMx4TiZ05pdpXbosds27zcIW7PX6TFzv7d5%2boxQKGj
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPTMlGoBAAAA//8DAO6xzS5tAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password123456&old_password=dummy_password123456
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password123456
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
+        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgc1OAVlQ6+Pm7u3v66YW4
+        BocoAVVAjQPJgy1RqgUAAAD//wMAZ5CzXpcAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[null], {"whoami": true, "all": true,
+      "raw": false, "no_members": true, "pkey_only": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTW2/aMBT+K8jPXJIQoFRC2sMqNE0qk9q+rJqQYx8SD8fOfKEwxH/fsZMC1brL
+        U06+z+fi73w+EgPWS0due8dL+HwkTIUv+ejr+tB7smDIt36PcGEbSQ+K1vAeLZRwgkrbck8RK4Fp
+        +97hDbXMAHVCKyfaekeyXnPqIPyv14iQLMmS5CaZJvNslo2/klPI1MV3YI5JatvCTjcE4QaM1SpE
+        2pRUiZ+xNpUXXChwyL0FfBgopGsr9pQx7ZUL/1tTNEYoJhoqqd93kBNsC67RUrBDh+KBdqLux9rq
+        tSbe8TVE4sFWS6N9s9p88cVnONiA19CsjCiFulPOHFoZG+qV+OFB8Hi/ZD5JZ8k8GfAZmw3SFOiA
+        jm/Gg0k2yZMk20xpPo6JYWRs/6INh30jTBTgz8KmaZJHYfNOWMxHUV3zwllFVfk/O7lKZVRpJRiV
+        Z3vwsPEP96vl8tP98PHu4bF1hNiBemuhDufK1wXKFfB0MsXpkjzNI+n/RkqN+tkKpIzsqBBqVFBb
+        RbLSNXBhcD8a9Y18gEb83Ph60/+Y3XcruSTXVMirBNjTupEwZLqOtG3f0dn1ynYWk5ptkdrgc4Hg
+        Pnx8YHbAr7AawoX1Zl0G18Q6wRp4zravMdQOIy1i7z5Ti0iGoOti+5wtlC5RnxA5sK7dV2vz216K
+        sTNeMVzxdW+LFWnUi6S9ULVXU8cqPHNCFozRYRPKSxkMyy/xWcmQ+ruIeGKHI7a+JPnwZjglp18A
+        AAD//wMAxjS2z4YEAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTWYvbMBD+K8HPOWTHuQqBPnQJpbAp7O5Ll2LG8iRRI0uqjmzSkP9eSXYu2B5P
+        Gn1zaOabT8dEo3HcJh86x1uTCn+8Jp9cXR86LwZ18r3bSSpmFIeDgBrfczPBLANuGt9LxNZIpXkv
+        WJY/kFrKwTRuK1XiYYXaSBEsqdcg2C+wTArgV5wJtN53D7hQNqRLw/ZAqXTChvtWl0ozQZkCDm7f
+        QpbRLVolOaOHFvUBTUftxZjNueYKzNn0jiezWWjp1HL11ZVf8GACXqNaarZm4kFYfWjIUOAE++mQ
+        VXE+MhulEzIjvWpCJ700RejBcDrsjbJRTki2GkM+jImhZf/8m9QV7hXTkYBQ4pgURQUWLauxKDyS
+        ZCQjaUpyMssmWf4tObX5nlSr3iq6AbHGP6eSKRnfpXLpRzAb5Dy2PCiZGJRgNpe+zlReFFCFpX58
+        XC4Wnx/7zw9PzzHUtTNH7xkRri49iwFPR2PfNMnTvNHI3507FPeKi7jfCtUYyQlT/ceUw3bKGhi/
+        aR73UCuOfSrrWNg00r8IdSNrrJj20pB+tZGXAA2uw3lmKAgpGP0nM8K04uSSbn3cyn8XDI+AKc5b
+        97DV7oxu8WChvGLK/1LUO6xusmsM7MlVsQ7KjM8H+fk40/zbMFLYwTx21aViHp3BaPsx3YrOhVx7
+        AQTLorHJyafugLswULvLwI83IDIhHOchBrWWur0H5VdX+6KYS4k7SsIDvo9G4Enen/bHyek3AAAA
+        //8DAOj91U+UBAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_find", "params": [[null], {"private": false, "posix":
+      false, "external": false, "nonposix": false, "all": false, "raw": false, "no_members":
+      true, "pkey_only": false, "user": "dummy", "fasgroup": true, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '241'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLiZDKSVTlxK6pEOylQ7GdluDX8hWIYT8e+Qp27n3XGkFtIV8
+        hV6sB77eJwE6UWyhY65IUatqDeeP8sVyVygEhQs30IkvJspFBFX1j1cbe4uYkG0k7zk6c3BGF7XL
+        yrdjw3+W2/gchsco5/s0Ay/+FotLsfmzvMoLbDsAAAD//wMAMi41IaoAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "group_find", "params": [[null], {"private": false, "posix":
+      false, "external": false, "nonposix": false, "all": false, "raw": false, "no_members":
+      true, "pkey_only": false, "membermanager_user": "dummy", "fasgroup": true, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vsdyeqySs%2bBWvST0A8MgCisUSnAI5U6MSedhYR1ySY8Ba5yitYY5phJe42wQvWCbQvssPoPJzo5D21EjtgiJqlqjOVhw15%2fa0PD%2fofk9%2fvd7TaW7i5rB1EvxS%2belG5u8DgdMgtBuie7cTfeqTKWE7dK4M1xbdt9EQiBMIhJLdex9ciuhxCKpGZ1ygr5GWt%2bf
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0SMuwrDMAxFf8VoLiZDKSVTlxK6pEOylQ7GdluDX8hWIYT8e+Qp27n3XGkFtIV8
+        hV6sB77eJwE6UWyhY65IUatqDeeP8sVyVygEhQs30IkvJspFBFX1j1cbe4uYkG0k7zk6c3BGF7XL
+        yrdjw3+W2/gchsco5/s0Ay/+FotLsfmzvMoLbDsAAAD//wMAMi41IaoAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:24 GMT
+      Keep-Alive:
+      - timeout=30, max=96
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:25 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz0xP
+        wTHAEy5kpGdkbKZUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAMPMtr2XAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:25 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yNsQrDMAxEf8VoLp5KKZ06tIQu6ZBsTQZTqyCQnSDHhRDy75HJ0G7vTnenBQRT
+        5gkuZvnHjyNGr/jq14OBr+OMRYHPIczQq5eUnMzqwg0ZJ/QmJxTT7ZkOoDRRZBDNxMyskvyPR6H4
+        ptFxmXA+ULzWz6p61La9Ny2UtyiJhljuR3u2J1g3AAAA//8DAETYZbiwAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:25 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=ViTHIMnsbItePYqauPlttbKABiEZhHCpDEj30mZW2H4m9dMznivETDzmG7HCdNxCSHoGSIbfON83E%2fqH80zXFFChqSQDqvf0F43JI5Qt5NAaejc2Pguu5%2f19mWncfvh3i6DlERAuJpMf7qYsrU7RGx95VqNjdnsryzfl1bC7VfPNjbIl21MD4sTVtAI6P1Qn
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPTMlGoBAAAA//8DAO6xzS5tAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Aug 2020 09:27:25 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.43 (Fedora) OpenSSL/1.1.1d mod_wsgi/4.6.6 Python/3.7 mod_auth_gssapi/1.6.1
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_add_second_confirm.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_add_second_confirm.yaml
@@ -36,13 +36,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:47 GMT
+      - Wed, 21 Apr 2021 03:14:20 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=UOHelK1sYpXd1R%2bUMD6xrohBjY9ryV9Z%2fxtPwtv1PWaTcXWCMriRWZMOT0oNZ1CJxb%2bVOVqmQE5MS5cBcIMU2awdFe9VDHyC4UA22FFwMPYkMS24Noln4R3iimlEccN9Wdew5mnhlOxNWUkVyS8ZZA6GI3NfQxc9S6LOui3SeiBRseGcsOcin5vpahpfX8Wc;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=ffIRdISGQ6f2B8%2bEQ3Hp83a5ircsfpbEFkWA%2feod051uXqJb7tEY1J6eag%2f3FwMTyUMkhtlM8R9mCoaqB5YK4OSsep79yKSwnzI%2btrqnOuWcPzKcLaIVZSpmDC2PKrES%2bYRQBez2sd6uKM2wTIoJaBnyxsdluhAdXkt7L2jhbaFyiqC%2bmJYrulaoxnxi%2b2N4;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UOHelK1sYpXd1R%2bUMD6xrohBjY9ryV9Z%2fxtPwtv1PWaTcXWCMriRWZMOT0oNZ1CJxb%2bVOVqmQE5MS5cBcIMU2awdFe9VDHyC4UA22FFwMPYkMS24Noln4R3iimlEccN9Wdew5mnhlOxNWUkVyS8ZZA6GI3NfQxc9S6LOui3SeiBRseGcsOcin5vpahpfX8Wc
+      - ipa_session=MagBearerToken=ffIRdISGQ6f2B8%2bEQ3Hp83a5ircsfpbEFkWA%2feod051uXqJb7tEY1J6eag%2f3FwMTyUMkhtlM8R9mCoaqB5YK4OSsep79yKSwnzI%2btrqnOuWcPzKcLaIVZSpmDC2PKrES%2bYRQBez2sd6uKM2wTIoJaBnyxsdluhAdXkt7L2jhbaFyiqC%2bmJYrulaoxnxi%2b2N4
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -89,7 +89,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:22 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -107,7 +107,7 @@ interactions:
     body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
       "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@example.com",
       "userpassword": "dummy_password", "random": false, "noprivate": false, "all":
-      true, "raw": false, "no_members": false, "fascreationtime": "2021-04-21T02:58:47Z",
+      true, "raw": false, "no_members": false, "fascreationtime": "2021-04-21T03:14:20Z",
       "version": "2.235"}]}'
     headers:
       Accept:
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UOHelK1sYpXd1R%2bUMD6xrohBjY9ryV9Z%2fxtPwtv1PWaTcXWCMriRWZMOT0oNZ1CJxb%2bVOVqmQE5MS5cBcIMU2awdFe9VDHyC4UA22FFwMPYkMS24Noln4R3iimlEccN9Wdew5mnhlOxNWUkVyS8ZZA6GI3NfQxc9S6LOui3SeiBRseGcsOcin5vpahpfX8Wc
+      - ipa_session=MagBearerToken=ffIRdISGQ6f2B8%2bEQ3Hp83a5ircsfpbEFkWA%2feod051uXqJb7tEY1J6eag%2f3FwMTyUMkhtlM8R9mCoaqB5YK4OSsep79yKSwnzI%2btrqnOuWcPzKcLaIVZSpmDC2PKrES%2bYRQBez2sd6uKM2wTIoJaBnyxsdluhAdXkt7L2jhbaFyiqC%2bmJYrulaoxnxi%2b2N4
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -131,18 +131,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5RU227aQBD9FeTncDExBCpFKm0jUrUKlULykKZC493BbNlb90KgUf69u2sDiRQ1
-        ygPy+MzM2fE5szxmBq3nLvvQenweEhkeP7MvXohd68aiyX6dtDLKrOawkyDwtTSTzDHgts7dJKxC
-        ouxrxar8jcQRDrZOO6WzAGs0VskYKVOBZH/BMSWBH3Em0YXcS8BH2tiuLNsCIcpLF9/XptSGScI0
-        cPDbBnKMrNFpxRnZNWgoqCdqXqxd7TmXYPdhSFzb1dQor2fLH778hjsbcYF6ZljF5IV0ZleLocFL
-        9scjo+n7zvCsIIOi34Z+Qdt5jmW7HMOoPegPil5vsAzPYWqMI4fjH5ShuNXMJAEixWO2WFBw6JjA
-        xSIgWb/Xz3tF+PUHo+LsLntq+oOoTj9QsgJZ4ftacesMhFLYt5VgcVjUTZPJd8kvxxUR4w39PF7d
-        TXNdrj/N5j16eX1T+NuL2/ntZHJeswVRBEiokGJSJapA5DmNe3ASgirKaGPUGGZPKDmXqgo6xsih
-        dfUOsQ3Kl0uXcK5CpV0h5ynRLZnshnFXKblSAikzwVHVnN2NUJce2sPXEpBKMgL8wJ7SH69m0+nX
-        q8784nqeSm19HQ7LK4DxZ+W4BaE5dogSBwv3W/cGc8Wo9KIMvLEmz4ejYS8/zUcp6f+XDGtJDKbt
-        iLa+w2bfrORRCh2uPpoNRnwZbjBGAcEu9osYYGf8Hl3jzkF5xATGGdVykRxN1HH7A6Ot/zaievHU
-        o/cp+Yb1T6F1A9zHT2tmjVaEAJKj2YRSpK1I1bqvC+6z1IXGqKiZ9JzHq0iP8cGXSABUMPnCknhk
-        mKy+cVnRGXdOs6d/AAAA//8DAHC0AUUlBQAA
+        H4sIAAAAAAAAA5RU227aQBD9FeTnADY4tFSKVNpGpIoUKoXkIU2Fxrtje8te3L0QaJR/7+7aQCJF
+        TfuAPD4zc3Z8ziyPiUbjuE0+9B6fh0T6x/fkixNi17sxqJMfJ72EMtNw2EkQ+FqaSWYZcNPmbiJW
+        IVHmtWJV/ERiCQfTpq1qEg83qI2SIVK6Asl+g2VKAj/iTKL1uZeAC7ShXRm2BUKUkza8r3XRaCYJ
+        a4CD23aQZWSNtlGckV2H+oJ2ou7FmHrPWYLZhz5xbeq5Vq5ZlN9ccYk7E3CBzUKzislzafWuFaMB
+        J9kvh4zG74OiSNP8HfRhlJf9LMOiD+/HZf90dJqn6Wnpn5PYGEb2xz8oTXHbMB0FCBSPyWpFwaJl
+        AlcrjySjdJSluf+Ns3w0ukueun4vqm0eKKlBVvh/rbi1Gnwp7NsKMDjJ26bZ7HIhLqYVEdMN/Tyt
+        7+ZZU6w/LZYpvbi+yd3t+e3ydjY7a9m8KAIkVEgxqhJUIPKMhj048UEVZDQh6gwzJ5ScSVV5HUNk
+        0dh2h9gG5culizhXvtLUyHlMDAsmh37cOiZrJZAy7R1V3dnDAA3pod1/LQGpJCPAD+wx/fFqMZ9/
+        vRosz6+XsdS01+GwvAIYf1aOWxANxwFR4mDhfuveYK4YlU4UnjfUZNnk/STNxtk0Jt3fkn4tica4
+        HcHWf7A57Wx23UoepWj81Ue9wYCX/gZjEBDMar+IHrba7dE17iwUR0xgmFGVq+hopA7b7xlN+7cR
+        1AunHr2PyTesf/KtG+AufFo3a7DCBxAdTWaUIu0Fqt59W3CfxC7UWgXNpOM8XEV6jA++BAKggskX
+        loQj/WTtjUvywXQwTp7+AAAA//8DAATxfm8lBQAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -155,7 +155,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:22 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -183,7 +183,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=UOHelK1sYpXd1R%2bUMD6xrohBjY9ryV9Z%2fxtPwtv1PWaTcXWCMriRWZMOT0oNZ1CJxb%2bVOVqmQE5MS5cBcIMU2awdFe9VDHyC4UA22FFwMPYkMS24Noln4R3iimlEccN9Wdew5mnhlOxNWUkVyS8ZZA6GI3NfQxc9S6LOui3SeiBRseGcsOcin5vpahpfX8Wc
+      - ipa_session=MagBearerToken=ffIRdISGQ6f2B8%2bEQ3Hp83a5ircsfpbEFkWA%2feod051uXqJb7tEY1J6eag%2f3FwMTyUMkhtlM8R9mCoaqB5YK4OSsep79yKSwnzI%2btrqnOuWcPzKcLaIVZSpmDC2PKrES%2bYRQBez2sd6uKM2wTIoJaBnyxsdluhAdXkt7L2jhbaFyiqC%2bmJYrulaoxnxi%2b2N4
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -207,7 +207,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:23 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -258,7 +258,7 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:23 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -309,13 +309,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:23 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -343,7 +343,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -353,14 +353,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xSa0/bMBT9K5GllS99BPKoqBSNdkMdKyQdzcpjTJMTX1JviR38YKoQ/322u42W
-        fuHbvT4+95z7eEICpK4VGnlP2yFtseK/gHHV4rrigqpVY4BvSK7wIfre9bZ/EFpRJR0c72DKgIo2
-        IBW0Dg58hxOQpaAG4sw9E9006wPpOZL7wYufUKqyxnJT919F9Kq6zRVvd1Q1ow8aKHHE8j4aFpEf
-        9UJSkF5Y4LiH46Oid4+PfB/CAAfHu575bwbixZXDtKDmBdlhaLUaDQZWeuDwkzSbTs/Sfn66yEdv
-        EXtPpdQgEsd+F/pb/I6EUoBKoujqdH4++3ATpWfLxXAxCcbDL9Pb7OPscnIRL8f5/ObrLEuv4+n5
-        5edhkGZXs+XtRTDpbBaRxJ3/O0sWn8aHnRYE5SQx07fjWrdgu8mzfG7zBjNcASnWP7Tc65zYBe1N
-        NnlLo92SJWZMXVImjFcVZTZS5hbQsyn8iGttbTBd1yaVRhGLtRUbEwLEM+Y25+DdoTvkKCAEFy8U
-        t+C/cSsoK43L2hbY24vt8hGE3JwbCvvH/QA9/wEAAP//AwC09KHH+wIAAA==
+        H4sIAAAAAAAAA4xSa2/TMBT9K5Elypc+MiVNlkoRTF1o2kC7pVEnYAh5tpcaEjv4MVRN+++zXWAt
+        /bJv9/r43Mc59xEIInWjwMR7PAxpBxX/SRhXHWxqLqjatgb4CuQWnoFvfe/wB6Y1VdLB0RGmDKho
+        S6QinYMD3+GYSCSogThzz1i37e6t9BzJ/eB3PwhSqIFyX/dvRfBfdZsr3h111Yz+0oRiR0xgHPsx
+        QoPYD6NBiMb+AAZjMkjug/Pze5T4CcTH+/xmRLxM5TAtqHkBVgyttpPRyLYeOfz9cjWbzZfDKltX
+        k9c0e0el1ESkjv0m9A/4PUmQICoN19Mi2kSLeJ7Nb9ar6w9lUc6yvPhYjK+W06y8zPN4GlwuFl/y
+        T9WmKLNN+flmMZ/19kakUe+fZ+k6vzjrdURQjlOjvpVr1xG7TbWqrmzeQgZrgu9237U82Rxbg06U
+        TV+zaB+x1MjUxyhlvK4ps5EytwCeTOEH2Gg7BtNNY1JpOkKxs80uMCbYM8Ptz8G7BbfAUYgQXLxQ
+        nMF/4k5QhsyUjS1w4ovd8oEIuT83EA6TYQCengEAAP//AwBFNexk+wIAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -373,7 +373,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:25 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -401,7 +401,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -426,7 +426,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
@@ -455,7 +455,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -465,17 +465,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTyW7bMBD9FYNnL5IiLwlgoIcGRlEgLpDk0qAwKGossaZIlYtj1/C/d0jKS9Ag
-        7UHQ8M3CmTePB6LBOGHJXe9wMV8OhEn/J59d0+x7zwY0+dHvkZKbVtC9pA285+aSW06Fib7ngFXA
-        lHkveE0N00AtV9LyWO9AVquSWvDn1QoRkiVZmuT4ZeNZPv1Ojj5TFT+BWSaoiYWtagnCLWijpLeU
-        rqjkv0NtKi44l2DR9xZwviGfrgzfUcaUk9afN7poNZeMt1RQt+sgy9kGbKsEZ/sOxYDYUXcwpj7V
-        xBlPJjoeTb3QyrXL9TdXfIW98XgD7VLzist7afU+0thSJ/kvB7wM801hmrNxng1olpeDNIViUNzS
-        2WCcjfMkGa/xPwmJvmW8/lXpEnYt14GAD4idZkkgdtYRi/lIqm1fS1ZTWf3PTk6pDeUiNFv6LX+C
-        HW1aAUOmmtCZUDihqUHEoFHB5aigpg5OE7V2Vobr5g6looj4FuRb1Z0ipWsKzPN4mk5mkyS9SWdd
-        0gdOHJVRqSRnVJwLx94flovFl4fh0/3jUwitVQMl17hghQsK7XtodGnvWir/KCZNJzGh2Abj1vhc
-        wKsPHx/oLZRXWAO+e7VeVV41oaiXBsaZ+Bo9b56Debirz+Q8OL3R3WL6JZtLVSH73rJgbNxXlPld
-        L0XbaicZrvj6boMVaRiXpD1ftddQy2qMOaIXtFaeVumE8IItL/aZCJ/6NwcYscUWoy5JPrwd3pDj
-        HwAAAP//AwBPe+0IhgQAAA==
+        H4sIAAAAAAAAA4xTyW7bMBD9FYNn25G8ZAMM9NDAKArEBZJcGhTGiBpZrClS5eLYNfLvHZLyEjRI
+        exA0fLNw5s3jnhm0Xjp229ufzOc94yr82WffNLvek0XDfvR7rBS2lbBT0OB7bqGEEyBt8j1FbIVc
+        2/eCK7DcIDihlROp3p4tlyU4DOflkhA2ykZ5NqFvnE9G2Xf2GjJ18RO54xJsKux0ywhu0VitgqXN
+        CpT4HWuDPOFCoSPfW8CHhkK6tmILnGuvXDivTdEaobhoQYLfdpATfI2u1VLwXYdSQOqoO1hbH2rS
+        jAeTHA+2nhvt20X1zRdfcWcD3mC7MGIl1J1yZpdobMEr8cujKON8UBRZNrmCAYwm1SDPsRjA9bga
+        TEfTSZZNK/pfxsTQMl3/ok2J21aYSMAHxF6NskjsuCOW8olU176UvAa1+p+dHFIbEDI2W4Ytf8It
+        NK3EIddN7ExqmtDWKFPQRSHURQG2jk6btHZUhu/mjqWSiMQG1VvVHSKVbwrKC3ieX15fZvk4v+mS
+        PnDSqByUVoKDPBZOvd8v5vMv98PHu4fHGFrrBkthaMGaFhTbD9DFqb1zqfyjmLKdxKTma4qr6Llg
+        UB89PjQbLM+wBkP3ulqugmpi0SANirPpNQbeAgezeFefq1l0BqO7xfZLPlN6RewHy6F1aV9J5re9
+        nGxnvOK04vO7LVWEOC7Le6FqrwHHa4p5JS8aowOtyksZBFue7CMRIfVvDihiQy0mXbLJ8GY4Zq9/
+        AAAA//8DAL+JCP6GBAAA
     headers:
       Cache-Control:
       - no-cache, private
@@ -488,7 +488,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:26 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -517,7 +517,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -527,17 +527,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xT227bMAz9lUDPudiuc+mAAHtYEQwDmgFtX1YMhiwxthZZ0nRJ4wX590mycwOK
-        bg+GqUNSJA+PDkiDcdyiT4PDtUmE/72iL65p2sGLAY1+DgeIMqM4bgVu4D03E8wyzE3ne4lYBUSa
-        94Jl+QuIJRybzm2lQh5WoI0UwZK6woL9wZZJgfkFZwKs990CLlwb0qVhe0yIdMKG81aXSjNBmMIc
-        u30PWUa2YJXkjLQ96gO6jvqDMfXpzg02J9M7nky90tKp9ea7K79BawLegFprVjHxIKxuOzIUdoL9
-        dsBonG8O85xM82yEs5yO0hTKUXmPF6NpNs2TZLrx/1lMDC378m9SU9grpiMB4YoDKgqKLVjWQFF4
-        BGVJlibzLEmy6SJf/EDHPt+TatUbJTUWFXyQmvvvOtVPSjTEgiHyPzLnfabrp6RhyXGMBjN+gT7D
-        HjeKw5jIptMFo8I1pac1xKTpbDFL0rt0EZ2mU99ZK+6jYC4976YG3pWblExMSmzq6KxlA5Rpv1fp
-        9xL9AZpc+rxWyFnYXc+P69Xq6+P4+eHp+RRKsJCCkX+GVmwH4vadRFyYXpxckq33bfxzgdAnNsVp
-        6x622p3QLbQWlxdM+VcKegf0KruBQI7cFFVQZiwZ5OfjTPduA5+BxWXsdkjEMjqD0fdjhpQshaw8
-        l8GyYCw6+tQd5i4M0W82LMcbOJIpHOchBrSWuj8H5dOLfab2fMUNVaGA76MTOMrH9+M7dPwLAAD/
-        /wMAy8oHv5QEAAA=
+        H4sIAAAAAAAAA4xT227bMAz9lcLPudiOk7YDAuxhRTAMaAa0fVkxGLRM21pkSdMljRfk3yfJzg0o
+        uj0Ypg5JkTw82kcKtWUm+nSzvzQJd7/X6Itt2+7mRaOKfo5uopJqyaDj0OJ7bsqpocB073sJWI1E
+        6PeCRfELiSEMdO82QkYOlqi04N4SqgZO/4ChggM745Sjcb5rwPprfbrQdAeECMuNP29UIRXlhEpg
+        YHcDZCjZoJGCUdINqAvoOxoOWjfHOyvQR9M5nnSzUsLKdfXdFt+w0x5vUa4VrSl/4EZ1PRkSLKe/
+        LdIyzAdFEcfZLYwhzapxkmAxhrtZNZ6n8yyO55X7L0Kib9mVfxOqxJ2kKhDgr9hHeV6CQUNbzHOH
+        RGmcJvFtGsezJEtnP6LDkO9INfKtJA3wGj9Izdx3meomJQpDQR/5H5nxkGmHKUu/5DBGC5Sdoc+4
+        g1YynBDR9rqgJbdt4Wj1MUmyuFvEySy5D07dq++kFftRMBOOd90g68tNC8qnBegmOBvRYkmV26tw
+        ewl+D03PfV4q5CTsvufH9Wr19XHy/PD0fAwlwAWn5J+hNd0iv34nAed6ECcTZON8lXsu6PsEnR+3
+        7mCj7BHdYGegOGPSvVJUWywvslv05Igqr70yQ0kvPxen+3fr+fQsLkO3I8KXwemNoR89KsmSi9px
+        6S2D2kQHl7oFZv0Qw2b9cpwBgUxuGfMxqJRQw9krvzzbJ2pPV1xR5Qu4PnqBR9nkfjKLDn8BAAD/
+        /wMApwiFrpQEAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -550,7 +550,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:26 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -565,28 +565,41 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: user=dummy&password=dummy_password420573
+    body: '{"method": "otptoken_add", "params": [[null], {"type": "totp", "description":
+      "pants token", "ipatokenowner": "dummy", "ipatokenotpkey": "BJ3F2NQ2CADX6ZOEDGGKATDQMVTKY3XLC73ASUHIBVGGGWJJOYFXIFIT",
+      "ipatokenotpalgorithm": "sha1", "ipatokenotpdigits": 6, "ipatokentotpclockoffset":
+      0, "ipatokentotptimestep": 30, "ipatokenhotpcounter": 0, "qrcode": false, "no_qrcode":
+      false, "all": true, "raw": false, "no_members": false, "version": "2.235"}]}'
     headers:
       Accept:
-      - text/plain
+      - application/json
       Accept-Encoding:
       - gzip, deflate
       Connection:
       - keep-alive
       Content-Length:
-      - '40'
+      - '443'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
-      - https://ipa.noggin.test/ipa/session/login_password
+      - https://ipa.noggin.test/ipa
       User-Agent:
       - python-requests/2.25.1
     method: POST
-    uri: https://ipa.noggin.test/ipa/session/login_password
+    uri: https://ipa.noggin.test/ipa/session/json
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+        H4sIAAAAAAAAA4xSa2/aMBT9K5Gl8YlHQiJSkKItLSWFrrCKrKVbp8nEl+AtsTM/OqGq/3222VZa
+        vvTbvT4+93HOfUQCpK4UGnmPhyFtsOI/gXHV4KrkgqptbYCvSG5xgL61vcMfhJZUSQcPXmDKgIrW
+        IBU0Dg59hxOQhaAG4sw9N5gp6TmKw/n6BxSqqLDcV/1XD72qbXPFmxc9NaO/NFDiiJswJgMc+p14
+        fYI70ToKOzjexJ3A9/Ew2ETBsP9qm98MhKMSXdc7h2lBzQuyUmi1HfV6tnXP4R/miyybzrv5+TIf
+        vaXZeyqlBpE49rvIP+C3JBQCVHI6Cyf9+XX/LB2vBl8W5+Msu0zz8fXVTX55F64+nsVhuvx8MT29
+        ybLsdjZb3E1W08k0b+1tSAat/44ly4s0aDUgKCeJ0d7KtWvAbpMv8k82rzHDJZD17ruWR5sTa8+R
+        sslbFm0XLDEytUmRMF6WlNlImUtAT6bwA660HYPpqjKpNB2x2NlmKSFAPDPc/hy8e3SPHAWE4OKZ
+        4gz+GzeCssJMWdkCR77YLR9AyP2xoag77Ibo6Q8AAAD//wMAP/mOdfkCAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -594,20 +607,195 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
-      Content-Length:
-      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
-      - text/plain; charset=UTF-8
+      - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:48 GMT
+      - Wed, 21 Apr 2021 03:14:26 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgc1OAVlQ6+Pm7u3v66YW4
+        BocoAVVAjQPJgy1RqgUAAAD//wMAWKMDYZcAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:26 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
-      Set-Cookie:
-      - ipa_session=MagBearerToken=hsSxFU9suT5GWZQerw9pBq8AFjneROZ%2fFWTCEuGtHW595cuGKBS19t%2bSpPKvWR2Pb9sKw9jgNT847nBpDoWgvoIznje0gPZKHPjYwUzA98reF51Elez0l3F3jymYRZNWObhC9MMs8ztae7Rwov%2bg2wZhYE%2fOnpwB5HNQZgmZ6QU%2blNONnJGL8lDxpL1V745r;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[null], {"whoami": true, "all": true,
+      "raw": false, "no_members": true, "pkey_only": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xTyW7bMBD9FYNn25G8ZAMM9NDAKArEBZJcGhTGiBpZrClS5eLYNfLvHZLyEjRI
+        exA0fLNw5s3jnhm0Xjp229ufzOc94yr82WffNLvek0XDfvR7rBS2lbBT0OB7bqGEEyBt8j1FbIVc
+        2/eCK7DcIDihlROp3p4tlyU4DOflkhA2ykZ5NqFvnE9G2Xf2GjJ18RO54xJsKux0ywhu0VitgqXN
+        CpT4HWuDPOFCoSPfW8CHhkK6tmILnGuvXDivTdEaobhoQYLfdpATfI2u1VLwXYdSQOqoO1hbH2rS
+        jAeTHA+2nhvt20X1zRdfcWcD3mC7MGIl1J1yZpdobMEr8cujKON8UBRZNrmCAYwm1SDPsRjA9bga
+        TEfTSZZNK/pfxsTQMl3/ok2J21aYSMAHxF6NskjsuCOW8olU176UvAa1+p+dHFIbEDI2W4Ytf8It
+        NK3EIddN7ExqmtDWKFPQRSHURQG2jk6btHZUhu/mjqWSiMQG1VvVHSKVbwrKC3ieX15fZvk4v+mS
+        PnDSqByUVoKDPBZOvd8v5vMv98PHu4fHGFrrBkthaMGaFhTbD9DFqb1zqfyjmLKdxKTma4qr6Llg
+        UB89PjQbLM+wBkP3ulqugmpi0SANirPpNQbeAgezeFefq1l0BqO7xfZLPlN6RewHy6F1aV9J5re9
+        nGxnvOK04vO7LVWEOC7Le6FqrwHHa4p5JS8aowOtyksZBFue7CMRIfVvDihiQy0mXbLJ8GY4Zq9/
+        AAAA//8DAL+JCP6GBAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:26 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4xT227bMAz9lcLPudiOk7YDAuxhRTAMaAa0fVkxGLRM21pkSdMljRfk3yfJzg0o
+        uj0Ypg5JkTw82kcKtWUm+nSzvzQJd7/X6Itt2+7mRaOKfo5uopJqyaDj0OJ7bsqpocB073sJWI1E
+        6PeCRfELiSEMdO82QkYOlqi04N4SqgZO/4ChggM745Sjcb5rwPprfbrQdAeECMuNP29UIRXlhEpg
+        YHcDZCjZoJGCUdINqAvoOxoOWjfHOyvQR9M5nnSzUsLKdfXdFt+w0x5vUa4VrSl/4EZ1PRkSLKe/
+        LdIyzAdFEcfZLYwhzapxkmAxhrtZNZ6n8yyO55X7L0Kib9mVfxOqxJ2kKhDgr9hHeV6CQUNbzHOH
+        RGmcJvFtGsezJEtnP6LDkO9INfKtJA3wGj9Izdx3meomJQpDQR/5H5nxkGmHKUu/5DBGC5Sdoc+4
+        g1YynBDR9rqgJbdt4Wj1MUmyuFvEySy5D07dq++kFftRMBOOd90g68tNC8qnBegmOBvRYkmV26tw
+        ewl+D03PfV4q5CTsvufH9Wr19XHy/PD0fAwlwAWn5J+hNd0iv34nAed6ECcTZON8lXsu6PsEnR+3
+        7mCj7BHdYGegOGPSvVJUWywvslv05Igqr70yQ0kvPxen+3fr+fQsLkO3I8KXwemNoR89KsmSi9px
+        6S2D2kQHl7oFZv0Qw2b9cpwBgUxuGfMxqJRQw9krvzzbJ2pPV1xR5Qu4PnqBR9nkfjKLDn8BAAD/
+        /wMApwiFrpQEAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:26 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -631,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -641,12 +829,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xRS0/DMAz+K1UuXNapW7shkCZxQROXDYneEEJu4nWBNCl5gKpp/504FRpjF25O
-        Pvt72Adm0QXl2W12OJXPByZ78OYdtfE9qNZY6fcdIcztYcZeJtnvDiFb6V2Cl2eYj6CXHTqPfYLL
-        IuECHbcyQkanbxG6brhyWRpKHaZ5Q+65Ajfy/jCyP+z09qY/d/Sl0Z54z7Cg5UdAKRLMd4vrZlEs
-        8ko0Iq8aWOawnDf5DuZFgVUJ5c2Yxw89xglWb+tHUuxAQ4uiGV6Du5ASlOlCcPUfsQnXqxhqIvhK
-        m7aVmiof18eOxMxN0HSfGVmyQXPwSEl2oBzGPxc9gB1IfpZFq+M+sw4838fGY2xBaw0Z1kEpWos4
-        1b2VmkfbiuZTnLvNdr1+2Ezr+6eaYn+idePJWDW9mZbs+A0AAP//AwBXSjahQAIAAA==
+        H4sIAAAAAAAAA7xTXUvDMBT9KyUvvrSjXbtlFQa+yPBlE+ybiNwmaRdtk5oPpQz/u0mGzDmQvbi3
+        m3tuzj0nh+yQYtp2Bl1Hu0P5uEN8ACNfmZBmgK6Viptt7xGkt5Chpzj6OUF5y40O8PwIMw40vGfa
+        sCHAeRpwyjRR3EFShDa1fT9e6ShcChOyfmHEkA70nvebEf1i92cjh6OtVvA3yzgNF0vAOMWEJDgt
+        5klBZmkC+YwlZZMvFg0p0xLosZ8PwdRBVcDMODDXQtWmuvcbexDQMlqPz1afDFPv6UTM8hwhMRFL
+        ZyqmZClk23LhK+OeD33G0aVDGUCYf4mkyTGdQ54muF5AUtRFngBucJKlKZRZU2TlNLtIJOcI+SMS
+        z0ykFf7LTL0kZQUBw7zLBjrNXE87DaBGv34aOan799RRD4Zs3aTLFTGlpFcsbNd51/RQD4oL4nR3
+        niD4uVlvVqu79aS6fai873em9D4xVEzKSY4+vwAAAP//AwCVLaL71AMAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -659,7 +848,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:27 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -695,7 +884,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -703,20 +892,20 @@ interactions:
       - Keep-Alive
       Content-Encoding:
       - gzip
+      Content-Length:
+      - '20'
       Content-Security-Policy:
       - frame-ancestors 'none'
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:27 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=x5XXhkdBdACHtTCBeyt74vsWPE9AYaHfUbPRkrOVEDA7F9e%2fYA8bFu39zVp0CuQpm5Kz4rcK9XbbACue%2f5STYzN0UNFqwlUvfNQGYezEGkMjLEeeauwUYN%2frkuT8ZwxYAdC6xakADyFaIB0%2bWawTGJJoYaOd%2flFroCKlIPYOPeoRqhqCcaNA7ly5XbG57eQl;path=/ipa;httponly;secure;
-      Transfer-Encoding:
-      - chunked
+      - ipa_session=MagBearerToken=HNrxb8l5uAPtdc0jn2XHyXVRKEN569jsSKhNTu9p4ubvFyuHur4mAJnkwuHe6ZzOEv6zOMTbfScQOTyddiTQFYvgsTGnRf%2b4RyXij0MNFF49OtRHpBMxF7wLm0nmnI0V6MKVVZd5OJ5UAY2BoUa0FSAvvNSsl%2brpaFEV83i0xp%2boCEY1W85G%2fYOPKOCJ1MwO;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -738,7 +927,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=x5XXhkdBdACHtTCBeyt74vsWPE9AYaHfUbPRkrOVEDA7F9e%2fYA8bFu39zVp0CuQpm5Kz4rcK9XbbACue%2f5STYzN0UNFqwlUvfNQGYezEGkMjLEeeauwUYN%2frkuT8ZwxYAdC6xakADyFaIB0%2bWawTGJJoYaOd%2flFroCKlIPYOPeoRqhqCcaNA7ly5XbG57eQl
+      - ipa_session=MagBearerToken=HNrxb8l5uAPtdc0jn2XHyXVRKEN569jsSKhNTu9p4ubvFyuHur4mAJnkwuHe6ZzOEv6zOMTbfScQOTyddiTQFYvgsTGnRf%2b4RyXij0MNFF49OtRHpBMxF7wLm0nmnI0V6MKVVZd5OJ5UAY2BoUa0FSAvvNSsl%2brpaFEV83i0xp%2boCEY1W85G%2fYOPKOCJ1MwO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -763,7 +952,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:29 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -792,7 +981,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=x5XXhkdBdACHtTCBeyt74vsWPE9AYaHfUbPRkrOVEDA7F9e%2fYA8bFu39zVp0CuQpm5Kz4rcK9XbbACue%2f5STYzN0UNFqwlUvfNQGYezEGkMjLEeeauwUYN%2frkuT8ZwxYAdC6xakADyFaIB0%2bWawTGJJoYaOd%2flFroCKlIPYOPeoRqhqCcaNA7ly5XbG57eQl
+      - ipa_session=MagBearerToken=HNrxb8l5uAPtdc0jn2XHyXVRKEN569jsSKhNTu9p4ubvFyuHur4mAJnkwuHe6ZzOEv6zOMTbfScQOTyddiTQFYvgsTGnRf%2b4RyXij0MNFF49OtRHpBMxF7wLm0nmnI0V6MKVVZd5OJ5UAY2BoUa0FSAvvNSsl%2brpaFEV83i0xp%2boCEY1W85G%2fYOPKOCJ1MwO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -802,14 +991,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4yS207jMBCGXyXyzV7Qlh6StEWqtAJBQUKAtC0gVqtoYk9SbxM79WHZquq7r+0I
-        ldKbvRv7/z3zzYx3RKG2lSEX0e4Q/twR3oCRaxTSNGvctndZloPGNM4ydybj4d9btby/fZHqflKO
-        L88utZ1v7l5wc5VPlsvEnM9fb56mhr09Uz28npH9r070OS9UpVTcrGqfnegVDMgXB+MlNzrI6ZFm
-        nEgrSdeyKDQGZNI/cRheozbYBHl0qr+DQVWDWgdDMpqmyXg6CTaGmiruMkgRRGbrevtNR+FtcMj8
-        N1JDK9At4Edi8qWIPxvZHBW3gm8schYe0iIZ50k/6cYsZ904h7QL6TDvFjDs9zEegeM6Hsy7QHWg
-        CprZNuiXsnhcPPmKNQgokeXbzOoTM/M9ncDM/gekQ8XMNdVhdCZkWXLhI+Om3G6XSiv8NgYeSVlB
-        3YR9lwVUGt2ddgyg/Hcig8ihtvOMajB05Yx7Z0GlpAcWtqp80+wQN4oL6rAr/x5YzcX3h8f5/O6h
-        t7j+sfBt/0Gl25WRuDftjcj+HwAAAP//AwBv6wb14QIAAA==
+        H4sIAAAAAAAAA8ySUW/aMBDHv0rkl70QlpCQkElIWxmtQCuUlsHKNKGL7QSPxE5tp4UhvvvioIlR
+        pAlpD9ubff+78+/O/x2SVJWZRu+s3fH4dYdYAVqsKRe6WNPtIbZcxqBo4C+X1R21Bw/Psw4PegM9
+        dHqbWX/z8WkuZYsN+4sfb68VfG6Pt2R2P5yPPw0nj120/9awfu8LWSok06vcdEdqBS56lUFYyrSq
+        5eBE05WIM4HXIkkUrZGRc5ahWU6VpkUtewedUIUlqyTB6zAp83z7Rll10en7L5zKY86JVnL2VFJG
+        ajmCMHRCjO3Q8QPbx23HBq9N7SjxOp0ER04EpK4W8XeKNc5AHWb61Q294jZ3LYq6Rm8LarY9HU/v
+        TDwHDikl8XZZqjM8YmY6g+xeAtjAvFs93SC4y0WaMm5Oulof2jesS+zQ4wsyWonJlRdlm6v8VvQ3
+        L4s5qLhUX6I0mwQf3NtHd12QVDvX97f/qR0K4PqvzJB4IQnAc+ww7oDtx75nQ5iEtus4ELmJ70Yt
+        95+a4RLAP5jBdMai5GbJLYMkS45BUzN9ApmiVUxVDCCNS1DLqlAP+1RWDhqvqszKUYhKKQwxL7PM
+        TEyO50IyjivuzDQAkjP+fjS+uRmMmtP+w9TM/UylOvwY8ptR00P7nwAAAP//AwCOjHERyAQAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -822,7 +1012,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:29 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -850,7 +1040,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=x5XXhkdBdACHtTCBeyt74vsWPE9AYaHfUbPRkrOVEDA7F9e%2fYA8bFu39zVp0CuQpm5Kz4rcK9XbbACue%2f5STYzN0UNFqwlUvfNQGYezEGkMjLEeeauwUYN%2frkuT8ZwxYAdC6xakADyFaIB0%2bWawTGJJoYaOd%2flFroCKlIPYOPeoRqhqCcaNA7ly5XbG57eQl
+      - ipa_session=MagBearerToken=HNrxb8l5uAPtdc0jn2XHyXVRKEN569jsSKhNTu9p4ubvFyuHur4mAJnkwuHe6ZzOEv6zOMTbfScQOTyddiTQFYvgsTGnRf%2b4RyXij0MNFF49OtRHpBMxF7wLm0nmnI0V6MKVVZd5OJ5UAY2BoUa0FSAvvNSsl%2brpaFEV83i0xp%2boCEY1W85G%2fYOPKOCJ1MwO
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -874,7 +1064,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:29 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -925,13 +1115,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:29 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=LIIGv%2fBB4etBqDFfNPOV2uRCRUdrEv0i30ITsuDxytRz3lZlMTKTC5RpRywB8lCBR2BBa8ZiLQZPWHAaxZXRmA8hS5PXCE1rsUUVqFo%2b4yyrXIyy6DQ5ioTek7EJqlzGRAA8RKblSloEkNA%2bGC7vVwLm0fbFSQmFJuDVqH64b6buGX4zDp%2fkUlxp6Rjs9wHr;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=3DyELHv%2frqHfgLwbgI3Yf8xar%2fucDzp0q5wwmQqixtCcJsRf5Lvz6VYx7i%2b3JFTC21%2fWnRT5YGMS1LfhXNh%2bEBmYM1UeKUGXE38G06uXc2Y5iL35b2ISbJ38TDHGSvprmm7fn46EVX2r06lE5%2bxM35T8zLcs%2bhyH4R2lgZzMCuuEAzZJ7KlESJ%2bKJ2DZuij0;path=/ipa;httponly;secure;
       Transfer-Encoding:
       - chunked
       Vary:
@@ -955,7 +1145,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=LIIGv%2fBB4etBqDFfNPOV2uRCRUdrEv0i30ITsuDxytRz3lZlMTKTC5RpRywB8lCBR2BBa8ZiLQZPWHAaxZXRmA8hS5PXCE1rsUUVqFo%2b4yyrXIyy6DQ5ioTek7EJqlzGRAA8RKblSloEkNA%2bGC7vVwLm0fbFSQmFJuDVqH64b6buGX4zDp%2fkUlxp6Rjs9wHr
+      - ipa_session=MagBearerToken=3DyELHv%2frqHfgLwbgI3Yf8xar%2fucDzp0q5wwmQqixtCcJsRf5Lvz6VYx7i%2b3JFTC21%2fWnRT5YGMS1LfhXNh%2bEBmYM1UeKUGXE38G06uXc2Y5iL35b2ISbJ38TDHGSvprmm7fn46EVX2r06lE5%2bxM35T8zLcs%2bhyH4R2lgZzMCuuEAzZJ7KlESJ%2bKJ2DZuij0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -980,7 +1170,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:31 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -995,7 +1185,7 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "otptoken_del", "params": [["cf57b505-4dbd-4ba6-a62b-fa200e43a396"],
+    body: '{"method": "otptoken_del", "params": [["9a7707cc-7046-4c50-a35e-9f388fc909ad"],
       {"continue": false, "version": "2.235"}]}'
     headers:
       Accept:
@@ -1009,7 +1199,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=LIIGv%2fBB4etBqDFfNPOV2uRCRUdrEv0i30ITsuDxytRz3lZlMTKTC5RpRywB8lCBR2BBa8ZiLQZPWHAaxZXRmA8hS5PXCE1rsUUVqFo%2b4yyrXIyy6DQ5ioTek7EJqlzGRAA8RKblSloEkNA%2bGC7vVwLm0fbFSQmFJuDVqH64b6buGX4zDp%2fkUlxp6Rjs9wHr
+      - ipa_session=MagBearerToken=3DyELHv%2frqHfgLwbgI3Yf8xar%2fucDzp0q5wwmQqixtCcJsRf5Lvz6VYx7i%2b3JFTC21%2fWnRT5YGMS1LfhXNh%2bEBmYM1UeKUGXE38G06uXc2Y5iL35b2ISbJ38TDHGSvprmm7fn46EVX2r06lE5%2bxM35T8zLcs%2bhyH4R2lgZzMCuuEAzZJ7KlESJ%2bKJ2DZuij0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1019,10 +1209,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4yOvQqDMBSFXyXcuYpotNipQ4t00ULdaocbc4XQGCVqoYjv3mRqx27f4XB+VrA0
-        LXqGA1t/sUOlSTq8P7YdgxfqhbyCtkv3Io3SgEshAy4wCzCLRdBhHEXEE0zyDB4uMi19j/btQnAi
-        TTNJVtVXNg9PMqz5q6cB8ONk7WBdj1m0dlLJL49WmVaNqP0Myl6ZY1kVxaUM6/OtBv+c7KQG430e
-        5mEC2wcAAP//AwBZ786Z8wAAAA==
+        H4sIAAAAAAAAA4yOvQqDMBSFXyXcuRFBbUynDi3SRQt1qx1CcoXQGCWaQhHfvcnUjt2+w+H8rOBw
+        9maBA1l/sRfaoAp4f2w7Ai9hPEYFXDCWMikpS/M9zWWRUpEVSHmflWUvecqFgkeIzH4YhHuHEJzQ
+        4IKKNO2VLOMTLen+6ukA4jg6N7rQY70xQWr15clpK/UkTJwRatD2WDdVdamT9nxrIT5HN+vRRj9P
+        eJLB9gEAAP//AwB590MS8wAAAA==
     headers:
       Cache-Control:
       - no-cache, private
@@ -1035,7 +1225,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:31 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1063,7 +1253,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=LIIGv%2fBB4etBqDFfNPOV2uRCRUdrEv0i30ITsuDxytRz3lZlMTKTC5RpRywB8lCBR2BBa8ZiLQZPWHAaxZXRmA8hS5PXCE1rsUUVqFo%2b4yyrXIyy6DQ5ioTek7EJqlzGRAA8RKblSloEkNA%2bGC7vVwLm0fbFSQmFJuDVqH64b6buGX4zDp%2fkUlxp6Rjs9wHr
+      - ipa_session=MagBearerToken=3DyELHv%2frqHfgLwbgI3Yf8xar%2fucDzp0q5wwmQqixtCcJsRf5Lvz6VYx7i%2b3JFTC21%2fWnRT5YGMS1LfhXNh%2bEBmYM1UeKUGXE38G06uXc2Y5iL35b2ISbJ38TDHGSvprmm7fn46EVX2r06lE5%2bxM35T8zLcs%2bhyH4R2lgZzMCuuEAzZJ7KlESJ%2bKJ2DZuij0
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1087,7 +1277,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:32 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:
@@ -1140,13 +1330,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:32 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=%2b%2bZMzys3gDrQRl4IhyqohsRHh52%2fRrjj6qZMSQ5npZQWjk0sBqQQwcbsOhsudvw06uIxXL%2fiU2SlRSJ7IPPLOTRK6aV5DT0dkdn3Lo%2fB3Cuj6QlfiTv3lkkRMescPFz%2fs7fvl0UXcoCOHaM1LUiDm%2b1WFOJBtE6s5ba%2fG2xVlccfG%2bFyKd3RD%2f5Tc5uJxpyy;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=32mE1bpycUcg53ENAFn5bT6YK2OUTO6BRySDDfYjqiztfzEgfT84Nyk4fujB03003G2u%2fnvbr04k8d7%2fh1c%2bc01AG6gAvbHyEUjceLDkJ0fYlyuudny3RVP%2fSiVlDqrQYSAB5kg72iWbgvCNwbzNrRz34Nmr2ZksFLfClUFnPUhFnjUJq85fvXxgiv0P6LZw;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1168,7 +1358,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=%2b%2bZMzys3gDrQRl4IhyqohsRHh52%2fRrjj6qZMSQ5npZQWjk0sBqQQwcbsOhsudvw06uIxXL%2fiU2SlRSJ7IPPLOTRK6aV5DT0dkdn3Lo%2fB3Cuj6QlfiTv3lkkRMescPFz%2fs7fvl0UXcoCOHaM1LUiDm%2b1WFOJBtE6s5ba%2fG2xVlccfG%2bFyKd3RD%2f5Tc5uJxpyy
+      - ipa_session=MagBearerToken=32mE1bpycUcg53ENAFn5bT6YK2OUTO6BRySDDfYjqiztfzEgfT84Nyk4fujB03003G2u%2fnvbr04k8d7%2fh1c%2bc01AG6gAvbHyEUjceLDkJ0fYlyuudny3RVP%2fSiVlDqrQYSAB5kg72iWbgvCNwbzNrRz34Nmr2ZksFLfClUFnPUhFnjUJq85fvXxgiv0P6LZw
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1193,7 +1383,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:33 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1208,7 +1398,7 @@ interactions:
       code: 200
       message: Success
 - request:
-    body: '{"method": "otptoken_del", "params": [["cf57b505-4dbd-4ba6-a62b-fa200e43a396"],
+    body: '{"method": "otptoken_del", "params": [["f37d6a30-7b8a-4b43-a7f7-100a91f41921"],
       {"continue": false, "version": "2.235"}]}'
     headers:
       Accept:
@@ -1222,7 +1412,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=%2b%2bZMzys3gDrQRl4IhyqohsRHh52%2fRrjj6qZMSQ5npZQWjk0sBqQQwcbsOhsudvw06uIxXL%2fiU2SlRSJ7IPPLOTRK6aV5DT0dkdn3Lo%2fB3Cuj6QlfiTv3lkkRMescPFz%2fs7fvl0UXcoCOHaM1LUiDm%2b1WFOJBtE6s5ba%2fG2xVlccfG%2bFyKd3RD%2f5Tc5uJxpyy
+      - ipa_session=MagBearerToken=32mE1bpycUcg53ENAFn5bT6YK2OUTO6BRySDDfYjqiztfzEgfT84Nyk4fujB03003G2u%2fnvbr04k8d7%2fh1c%2bc01AG6gAvbHyEUjceLDkJ0fYlyuudny3RVP%2fSiVlDqrQYSAB5kg72iWbgvCNwbzNrRz34Nmr2ZksFLfClUFnPUhFnjUJq85fvXxgiv0P6LZw
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1232,10 +1422,10 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6SPQQ6CMBAAv9L0bEmFgsGTFyVewEQ+sKXFNJaWtMUL4e8WTPQB3nYnm8nsjJ30
-        kw74iMyk9Q5h6Zx1cZ1xZ4WMA6N0H/kgvYfHCnDX5wee05wwwQVhHAoCRcpJDymlkmWQlcURNe0N
-        BfuUBhkbUG8nI3D0CAiw6Z0Eb81/viUKDQxbVW3D5QuV+H00OmU6NYJer0AMypzqpqquddKe7+3a
-        9JLOq08LS8okw8sbAAD//wMAifWfWxgBAAA=
+        H4sIAAAAAAAAA4yOvQ6CMBSFX6W5sxCQRsTJQUNcwEQ2YbjYS9JYCinUxBDe3XbS0e07OTk/Cxia
+        rJrhwJZf7FAqEg7vzbph8EJlySvoklTsMImCtN1jwFueBJh2aRBHEWZxx+NsG0PjIpPtezRvF4IT
+        KZpJsLK6snl4kmb1Xz01gB8nYwbjerRVykkpvjwaqR9yROVnUPRSH4syzy9FWJ1vFfjnZCY5aO/z
+        MAsTWD8AAAD//wMASE6ujfMAAAA=
     headers:
       Cache-Control:
       - no-cache, private
@@ -1248,7 +1438,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:33 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1276,7 +1466,220 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=MY8uDQRjfJw8kiDS6p6yrcxZfCiuI8pSMD348ucT6rLk2M6IEguYiDmW0HvWkEuhlR%2bZ9nnb73pvuOTkB0seP1nuWJLuZ%2ff13sne72b%2fqnr41i0w1pXsgG9bGHvkQIP912UrFmEG8a4XIn%2bEgxyCdi8Df06wsR%2f%2fhQW%2f5aSRsuztOVKBehsG0dBD9rCDQZsG
+      - ipa_session=MagBearerToken=32mE1bpycUcg53ENAFn5bT6YK2OUTO6BRySDDfYjqiztfzEgfT84Nyk4fujB03003G2u%2fnvbr04k8d7%2fh1c%2bc01AG6gAvbHyEUjceLDkJ0fYlyuudny3RVP%2fSiVlDqrQYSAB5kg72iWbgvCNwbzNrRz34Nmr2ZksFLfClUFnPUhFnjUJq85fvXxgiv0P6LZw
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPWMlWoBAAAA//8DALVaZhVtAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:34 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//AwAAAAAAAAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:34 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=93owIEpZkXYB4ftna607mgHSAPhA6Qa6dsx4C57GdvITrAj90U2TXPY3euWsOgXI%2buSojNR6wyop29SpOb7BRXX3IE5rluP4NPbxtT2owqEJJfkBbOrqWJn%2fDOogEEPL69Ng8VKcNC1oOQevMWQ%2bii974JSpm0RyiZOJWMnBrrvxoYlb9hcaFnXjXoLOru1w;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=93owIEpZkXYB4ftna607mgHSAPhA6Qa6dsx4C57GdvITrAj90U2TXPY3euWsOgXI%2buSojNR6wyop29SpOb7BRXX3IE5rluP4NPbxtT2owqEJJfkBbOrqWJn%2fDOogEEPL69Ng8VKcNC1oOQevMWQ%2bii974JSpm0RyiZOJWMnBrrvxoYlb9hcaFnXjXoLOru1w
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Sz1hP
+        wTHAEy5kpGdkYqBUq6OglFpUlF8E1JhXmpMD5GamINgFRZl5yZkFiTkgcxNTcjPzHPz83d09/fRC
+        XINDlIAqoMaB5MGWKNUCAAAA//8DAPz/BoKXAAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:35 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_del", "params": [["9a7707cc-7046-4c50-a35e-9f388fc909ad"],
+      {"continue": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '121'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=93owIEpZkXYB4ftna607mgHSAPhA6Qa6dsx4C57GdvITrAj90U2TXPY3euWsOgXI%2buSojNR6wyop29SpOb7BRXX3IE5rluP4NPbxtT2owqEJJfkBbOrqWJn%2fDOogEEPL69Ng8VKcNC1oOQevMWQ%2bii974JSpm0RyiZOJWMnBrrvxoYlb9hcaFnXjXoLOru1w
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6SPQQ7CIBAAv0I4S4MptcWTF228tCb2AxughkihAeql6d+lNdEHeNudbCazM/Yq
+        TCbiI7KTMTuElffOp3XGwkmVBkbpPvFBhQCPFWAOZUlLIUhJ2YEwUVACeaEI7/Oq6gWnHOQRtd0N
+        RfdUFlkXUe8mK3HySIiw6b2C4Ox/viUJLQxbVePi5Qu1/H00em2FHsGsVyAHbU9NW9fXJuvO925t
+        eikf9KeFZTzL8fIGAAD//wMATForFBgBAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 21 Apr 2021 03:14:35 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=JPkGjaM7OKnx4VTZtnVRAtFaXYHIL%2bdcJfN8XfTXd%2f%2bahJxE1zyUMKO6Esro4svQg6PBNKLgxpO8Ft%2fcBGX0xBAYApvLfGZ4uzNVgclNktj1eLtSsFQ2GrT7SV53lykkT%2friX1bKX4odiZuSavKQOmA%2bnkO7a2u5IQ%2flS%2baZLNJvboHdJP9%2f36QC1IwbXaZu
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1300,7 +1703,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:49 GMT
+      - Wed, 21 Apr 2021 03:14:35 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1353,13 +1756,13 @@ interactions:
       Content-Type:
       - text/plain; charset=UTF-8
       Date:
-      - Wed, 21 Apr 2021 02:58:50 GMT
+      - Wed, 21 Apr 2021 03:14:35 GMT
       Keep-Alive:
       - timeout=30, max=100
       Server:
       - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
       Set-Cookie:
-      - ipa_session=MagBearerToken=4Ip9jtbWj%2bjG%2fHS5lyzC113MTXg%2bM256BifeitrTF8fxEUG2hH5SR4g%2bSjKgksQGYSNfXbcEQGYONbt%2f4scNYSQOTcWJnVRPTyrCk4zVkFPdo6XI4LGObKa2RaQDaUbSRgefbINodQAJAm3w5lDzp0f3jpg%2be9VrWZux0A%2fFinvT5Wae5eNBzjYNPQc9Rxa9;path=/ipa;httponly;secure;
+      - ipa_session=MagBearerToken=fxh5VC2CJAZfDgN0ndUVjPKHwQ2GRxMCzfUN4K6%2fbYRHElj%2fRwLMjG%2begprFnowfoll7QdsmauNioOzWzvCmSfAY5EU5BshSL9EU4af1OdQEjHN26992%2bk4CKfav73fPzSVl%2fOoSk755HlQVid1NTO023%2fh9vXzH15yJk0n8zTi5K9IhXPgZlfMekwlvPQo6;path=/ipa;httponly;secure;
       Vary:
       - Accept-Encoding
       X-Frame-Options:
@@ -1381,7 +1784,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=4Ip9jtbWj%2bjG%2fHS5lyzC113MTXg%2bM256BifeitrTF8fxEUG2hH5SR4g%2bSjKgksQGYSNfXbcEQGYONbt%2f4scNYSQOTcWJnVRPTyrCk4zVkFPdo6XI4LGObKa2RaQDaUbSRgefbINodQAJAm3w5lDzp0f3jpg%2be9VrWZux0A%2fFinvT5Wae5eNBzjYNPQc9Rxa9
+      - ipa_session=MagBearerToken=fxh5VC2CJAZfDgN0ndUVjPKHwQ2GRxMCzfUN4K6%2fbYRHElj%2fRwLMjG%2begprFnowfoll7QdsmauNioOzWzvCmSfAY5EU5BshSL9EU4af1OdQEjHN26992%2bk4CKfav73fPzSVl%2fOoSk755HlQVid1NTO023%2fh9vXzH15yJk0n8zTi5K9IhXPgZlfMekwlvPQo6
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1406,7 +1809,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:50 GMT
+      - Wed, 21 Apr 2021 03:14:37 GMT
       Keep-Alive:
       - timeout=30, max=99
       Server:
@@ -1435,7 +1838,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=4Ip9jtbWj%2bjG%2fHS5lyzC113MTXg%2bM256BifeitrTF8fxEUG2hH5SR4g%2bSjKgksQGYSNfXbcEQGYONbt%2f4scNYSQOTcWJnVRPTyrCk4zVkFPdo6XI4LGObKa2RaQDaUbSRgefbINodQAJAm3w5lDzp0f3jpg%2be9VrWZux0A%2fFinvT5Wae5eNBzjYNPQc9Rxa9
+      - ipa_session=MagBearerToken=fxh5VC2CJAZfDgN0ndUVjPKHwQ2GRxMCzfUN4K6%2fbYRHElj%2fRwLMjG%2begprFnowfoll7QdsmauNioOzWzvCmSfAY5EU5BshSL9EU4af1OdQEjHN26992%2bk4CKfav73fPzSVl%2fOoSk755HlQVid1NTO023%2fh9vXzH15yJk0n8zTi5K9IhXPgZlfMekwlvPQo6
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1460,7 +1863,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:50 GMT
+      - Wed, 21 Apr 2021 03:14:37 GMT
       Keep-Alive:
       - timeout=30, max=98
       Server:
@@ -1488,7 +1891,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - ipa_session=MagBearerToken=4Ip9jtbWj%2bjG%2fHS5lyzC113MTXg%2bM256BifeitrTF8fxEUG2hH5SR4g%2bSjKgksQGYSNfXbcEQGYONbt%2f4scNYSQOTcWJnVRPTyrCk4zVkFPdo6XI4LGObKa2RaQDaUbSRgefbINodQAJAm3w5lDzp0f3jpg%2be9VrWZux0A%2fFinvT5Wae5eNBzjYNPQc9Rxa9
+      - ipa_session=MagBearerToken=fxh5VC2CJAZfDgN0ndUVjPKHwQ2GRxMCzfUN4K6%2fbYRHElj%2fRwLMjG%2begprFnowfoll7QdsmauNioOzWzvCmSfAY5EU5BshSL9EU4af1OdQEjHN26992%2bk4CKfav73fPzSVl%2fOoSk755HlQVid1NTO023%2fh9vXzH15yJk0n8zTi5K9IhXPgZlfMekwlvPQo6
       Referer:
       - https://ipa.noggin.test/ipa
       User-Agent:
@@ -1512,7 +1915,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 21 Apr 2021 02:58:50 GMT
+      - Wed, 21 Apr 2021 03:14:38 GMT
       Keep-Alive:
       - timeout=30, max=97
       Server:

--- a/noggin/tests/unit/controller/test_authentication.py
+++ b/noggin/tests/unit/controller/test_authentication.py
@@ -93,6 +93,27 @@ def test_login(client, dummy_user):
 
 
 @pytest.mark.vcr()
+def test_login_with_otp(client, dummy_user):
+    """Test a successful Login with password + otp"""
+    result = client.post(
+        '/',
+        data={
+            "login-username": "dummy",
+            "login-password": "dummy_password",
+            "login-otp": "123456",
+            "login-submit": "1",
+        },
+        follow_redirects=True,
+    )
+    page = BeautifulSoup(result.data, 'html.parser')
+    messages = page.select(".flash-messages .alert-success")
+    assert len(messages) == 1
+    assert messages[0].get_text(strip=True) == 'Welcome, dummy!×'
+    assert session.get("noggin_username") == "dummy"
+    assert session.get("noggin_session") is not None
+
+
+@pytest.mark.vcr()
 def test_login_no_password(client, dummy_user):
     """Test not giving a password"""
     result = client.post(

--- a/noggin/tests/unit/controller/test_authentication.py
+++ b/noggin/tests/unit/controller/test_authentication.py
@@ -11,7 +11,9 @@ from noggin.app import ipa_admin
 from noggin.tests.unit.utilities import (
     assert_form_field_error,
     assert_form_generic_error,
-    assert_redirects_with_flash, get_otp, otp_secret_from_uri,
+    assert_redirects_with_flash,
+    get_otp,
+    otp_secret_from_uri,
 )
 
 

--- a/noggin/tests/unit/controller/test_authentication.py
+++ b/noggin/tests/unit/controller/test_authentication.py
@@ -84,12 +84,14 @@ def test_login(client, dummy_user):
             "login-password": "dummy_password",
             "login-submit": "1",
         },
-        follow_redirects=True,
+        follow_redirects=False,
     )
-    page = BeautifulSoup(result.data, 'html.parser')
-    messages = page.select(".flash-messages .alert-success")
-    assert len(messages) == 1
-    assert messages[0].get_text(strip=True) == 'Welcome, dummy!×'
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/",
+        expected_message="Welcome, dummy!",
+        expected_category="success",
+    )
     assert session.get("noggin_username") == "dummy"
     assert session.get("noggin_session") is not None
 
@@ -106,12 +108,14 @@ def test_login_with_otp(client, dummy_user_with_otp):
             "login-otp": otp,
             "login-submit": "1",
         },
-        follow_redirects=True,
+        follow_redirects=False,
     )
-    page = BeautifulSoup(result.data, 'html.parser')
-    messages = page.select(".flash-messages .alert-success")
-    assert len(messages) == 1
-    assert messages[0].get_text(strip=True) == 'Welcome, dummy!×'
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/",
+        expected_message="Welcome, dummy!",
+        expected_category="success",
+    )
     assert session.get("noggin_username") == "dummy"
     assert session.get("noggin_session") is not None
 

--- a/noggin/tests/unit/controller/test_authentication.py
+++ b/noggin/tests/unit/controller/test_authentication.py
@@ -8,7 +8,6 @@ from bs4 import BeautifulSoup
 from flask import current_app, get_flashed_messages, session
 
 from noggin.app import ipa_admin
-from noggin.representation.otptoken import OTPToken
 from noggin.tests.unit.utilities import (
     assert_form_field_error,
     assert_form_generic_error,
@@ -108,7 +107,6 @@ def test_login_with_otp(client, dummy_user_with_otp):
         follow_redirects=True,
     )
     page = BeautifulSoup(result.data, 'html.parser')
-    print(page.prettify())
     messages = page.select(".flash-messages .alert-success")
     assert len(messages) == 1
     assert messages[0].get_text(strip=True) == 'Welcome, dummy!×'

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -346,7 +346,7 @@ def test_change_post_password_with_otp_not_given(
 def test_change_post_password_with_otp_wrong_value(
     client,
     dummy_user,
-        logged_in_dummy_user_with_otp,
+    logged_in_dummy_user_with_otp,
     token_for_dummy_user,
     patched_lock_active,
     mocker,

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -295,9 +295,9 @@ def test_change_post_generic_error(
 
 @pytest.mark.vcr()
 def test_change_post_with_otp(
-    client, dummy_user, dummy_user_with_otp, token_for_dummy_user, patched_lock_active
+    client, dummy_user, logged_in_dummy_user_with_otp, token_for_dummy_user, patched_lock_active
 ):
-    otp = get_otp(otp_secret_from_uri(dummy_user_with_otp.uri))
+    otp = get_otp(otp_secret_from_uri(logged_in_dummy_user_with_otp.uri))
     with fml_testing.mock_sends(
         UserUpdateV1(
             {"msg": {"agent": "dummy", "user": "dummy", "fields": ["password"]}}
@@ -324,7 +324,7 @@ def test_change_post_with_otp(
 def test_change_post_password_with_otp_not_given(
     client,
     dummy_user,
-    dummy_user_with_otp,
+        logged_in_dummy_user_with_otp,
     token_for_dummy_user,
     patched_lock_active,
     mocker,
@@ -346,7 +346,7 @@ def test_change_post_password_with_otp_not_given(
 def test_change_post_password_with_otp_wrong_value(
     client,
     dummy_user,
-    dummy_user_with_otp,
+        logged_in_dummy_user_with_otp,
     token_for_dummy_user,
     patched_lock_active,
     mocker,

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -295,7 +295,11 @@ def test_change_post_generic_error(
 
 @pytest.mark.vcr()
 def test_change_post_with_otp(
-    client, dummy_user, logged_in_dummy_user_with_otp, token_for_dummy_user, patched_lock_active
+    client,
+    dummy_user,
+    logged_in_dummy_user_with_otp,
+    token_for_dummy_user,
+    patched_lock_active,
 ):
     otp = get_otp(otp_secret_from_uri(logged_in_dummy_user_with_otp.uri))
     with fml_testing.mock_sends(

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -324,7 +324,7 @@ def test_change_post_with_otp(
 def test_change_post_password_with_otp_not_given(
     client,
     dummy_user,
-        logged_in_dummy_user_with_otp,
+    logged_in_dummy_user_with_otp,
     token_for_dummy_user,
     patched_lock_active,
     mocker,

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -203,7 +203,7 @@ def test_change_get(client, dummy_user, token_for_dummy_user, patched_lock_activ
     page = BeautifulSoup(result.data, 'html.parser')
     form = page.select_one(f"form[action='{url}']")
     assert form is not None
-    assert len(form.select("input[type='password']")) == 2
+    assert len(form.select("input[type='password']")) == 3
 
 
 @pytest.mark.vcr()

--- a/noggin/tests/unit/controller/test_forgot_password.py
+++ b/noggin/tests/unit/controller/test_forgot_password.py
@@ -203,7 +203,7 @@ def test_change_get(client, dummy_user, token_for_dummy_user, patched_lock_activ
     page = BeautifulSoup(result.data, 'html.parser')
     form = page.select_one(f"form[action='{url}']")
     assert form is not None
-    assert len(form.select("input[type='password']")) == 3
+    assert len(form.select("input[type='password']")) == 2
 
 
 @pytest.mark.vcr()

--- a/noggin/tests/unit/controller/test_password_reset.py
+++ b/noggin/tests/unit/controller/test_password_reset.py
@@ -90,12 +90,6 @@ def test_password_form_with_otp(client, logged_in_dummy_user_with_otp):
     result = client.get("/user/dummy/settings/password")
 
     page = BeautifulSoup(result.data, "html.parser")
-
-    currentpasswordinput = page.select_one("#currentpasswordinput .form-text")
-    assert currentpasswordinput is not None
-    expected = "Just the password, don't add the OTP token if you have one"
-    assert expected in currentpasswordinput.get_text(strip=True)
-
     otpinput = page.select("#otpinput")
     assert len(otpinput) == 1
 

--- a/noggin/tests/unit/controller/test_password_reset.py
+++ b/noggin/tests/unit/controller/test_password_reset.py
@@ -84,7 +84,9 @@ def test_password_changes_user(client, logged_in_dummy_user):
 
 
 @pytest.mark.vcr()
-def test_password_form_with_otp(client, logged_in_dummy_user, logged_in_dummy_user_with_otp):
+def test_password_form_with_otp(
+    client, logged_in_dummy_user, logged_in_dummy_user_with_otp
+):
     """Verify that the password change form shows OTP form elements
        when a user has OTP enabled"""
     result = client.get("/user/dummy/settings/password")

--- a/noggin/tests/unit/controller/test_password_reset.py
+++ b/noggin/tests/unit/controller/test_password_reset.py
@@ -84,9 +84,7 @@ def test_password_changes_user(client, logged_in_dummy_user):
 
 
 @pytest.mark.vcr()
-def test_password_form_with_otp(
-    client, logged_in_dummy_user, logged_in_dummy_user_with_otp
-):
+def test_password_form_with_otp(client, logged_in_dummy_user_with_otp):
     """Verify that the password change form shows OTP form elements
        when a user has OTP enabled"""
     result = client.get("/user/dummy/settings/password")

--- a/noggin/tests/unit/controller/test_password_reset.py
+++ b/noggin/tests/unit/controller/test_password_reset.py
@@ -84,7 +84,7 @@ def test_password_changes_user(client, logged_in_dummy_user):
 
 
 @pytest.mark.vcr()
-def test_password_form_with_otp(client, logged_in_dummy_user, dummy_user_with_otp):
+def test_password_form_with_otp(client, logged_in_dummy_user, logged_in_dummy_user_with_otp):
     """Verify that the password change form shows OTP form elements
        when a user has OTP enabled"""
     result = client.get("/user/dummy/settings/password")

--- a/noggin/tests/unit/controller/test_user_otp.py
+++ b/noggin/tests/unit/controller/test_user_otp.py
@@ -11,7 +11,9 @@ from noggin.representation.otptoken import OTPToken
 from noggin.tests.unit.utilities import (
     assert_form_field_error,
     assert_form_generic_error,
-    assert_redirects_with_flash, get_otp, otp_secret_from_uri,
+    assert_redirects_with_flash,
+    get_otp,
+    otp_secret_from_uri,
 )
 
 
@@ -19,7 +21,8 @@ from noggin.tests.unit.utilities import (
 def dummy_user_with_2_otp(client, logged_in_dummy_user, logged_in_dummy_user_with_otp):
     ipa = logged_in_dummy_user
     result = ipa.otptoken_add(
-        o_ipatokenowner="dummy", o_description="dummy's other token",
+        o_ipatokenowner="dummy",
+        o_description="dummy's other token",
     )['result']
     token = OTPToken(result)
     yield logged_in_dummy_user_with_otp, token
@@ -172,20 +175,24 @@ def test_user_settings_otp_add_second(
     confirm_form = modal.select_one("form")
     assert confirm_form is not None
     assert (
-            confirm_form.select_one("input[name='confirm-description']")["value"]
-            == "pants token 2"
+        confirm_form.select_one("input[name='confirm-description']")["value"]
+        == "pants token 2"
     )
     otp_uri = page.select_one("input#otp-uri")
     parsed_otp_uri_query = parse_qs(urlparse(otp_uri["value"]).query)
     assert (
-            confirm_form.select_one("input[name='confirm-secret']")["value"]
-            == parsed_otp_uri_query["secret"][0]
+        confirm_form.select_one("input[name='confirm-secret']")["value"]
+        == parsed_otp_uri_query["secret"][0]
     )
 
 
 @pytest.mark.vcr()
 def test_user_settings_otp_add_second_confirm(
-    client, logged_in_dummy_user_with_otp, logged_in_dummy_user, cleanup_dummy_tokens, totp_token
+    client,
+    logged_in_dummy_user_with_otp,
+    logged_in_dummy_user,
+    cleanup_dummy_tokens,
+    totp_token,
 ):
     """Test posting to the create OTP endpoint"""
     result = client.post(

--- a/noggin/tests/unit/controller/test_user_otp.py
+++ b/noggin/tests/unit/controller/test_user_otp.py
@@ -21,8 +21,7 @@ from noggin.tests.unit.utilities import (
 def dummy_user_with_2_otp(client, logged_in_dummy_user, logged_in_dummy_user_with_otp):
     ipa = logged_in_dummy_user
     result = ipa.otptoken_add(
-        o_ipatokenowner="dummy",
-        o_description="dummy's other token",
+        o_ipatokenowner="dummy", o_description="dummy's other token",
     )['result']
     token = OTPToken(result)
     yield logged_in_dummy_user_with_otp, token

--- a/noggin/tests/unit/controller/test_user_otp.py
+++ b/noggin/tests/unit/controller/test_user_otp.py
@@ -187,11 +187,7 @@ def test_user_settings_otp_add_second(
 
 @pytest.mark.vcr()
 def test_user_settings_otp_add_second_confirm(
-    client,
-    logged_in_dummy_user_with_otp,
-    logged_in_dummy_user,
-    cleanup_dummy_tokens,
-    totp_token,
+    client, logged_in_dummy_user_with_otp, cleanup_dummy_tokens, totp_token,
 ):
     """Test posting to the create OTP endpoint"""
     result = client.post(
@@ -430,9 +426,7 @@ def test_user_settings_otp_disable(client, logged_in_dummy_user, dummy_user_with
 
 
 @pytest.mark.vcr()
-def test_user_settings_otp_disable_lasttoken(
-    client, logged_in_dummy_user, logged_in_dummy_user_with_otp
-):
+def test_user_settings_otp_disable_lasttoken(client, logged_in_dummy_user_with_otp):
     """Test trying to disable the last token"""
     result = client.post(
         "/user/dummy/settings/otp/disable/",

--- a/noggin/tests/unit/translations/test_translations.py
+++ b/noggin/tests/unit/translations/test_translations.py
@@ -18,7 +18,7 @@ def compile_catalogs():
 
 @pytest.mark.vcr()
 def test_translation_in_code_french(
-    client, logged_in_dummy_user, logged_in_dummy_user_with_otp, compile_catalogs
+    client, logged_in_dummy_user_with_otp, compile_catalogs
 ):
     """Test translations are working if the string is in the code"""
     headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}

--- a/noggin/tests/unit/translations/test_translations.py
+++ b/noggin/tests/unit/translations/test_translations.py
@@ -18,13 +18,13 @@ def compile_catalogs():
 
 @pytest.mark.vcr()
 def test_translation_in_code_french(
-    client, logged_in_dummy_user, dummy_user_with_otp, compile_catalogs
+    client, logged_in_dummy_user, logged_in_dummy_user_with_otp, compile_catalogs
 ):
     """Test translations are working if the string is in the code"""
     headers = {"Accept-Language": "fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3"}
     result = client.post(
         "/user/dummy/settings/otp/disable/",
-        data={"token": dummy_user_with_otp.uniqueid},
+        data={"token": logged_in_dummy_user_with_otp.uniqueid},
         headers=headers,
     )
     assert_redirects_with_flash(


### PR DESCRIPTION
Resolves #572 

Add a separate field in the login form for `one-time-password`. 
Including a new test case with login using password + OTP. 

![image](https://user-images.githubusercontent.com/9274112/114795130-eab13980-9d5b-11eb-8596-67aa35663d89.png)
