### PR TITLE
The GPG key ID length is now between 16 and 40 chars long

### DIFF
--- a/news/556.feature
+++ b/news/556.feature
@@ -1,0 +1,1 @@
+The GPG key ID fields now refuse key IDs shorter than 16 characters, and allow up to 40 characters (the full fingerprint)

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -94,7 +94,8 @@ class UserSettingsKeysForm(BaseForm):
     )
 
     gpgkeys = FieldList(
-        StringField(validators=[Optional(), Length(max=16)]), label=_('GPG Keys')
+        StringField(validators=[Optional(), Length(min=16, max=40)]),
+        label=_('GPG Keys'),
     )
 
 

--- a/noggin/templates/user-settings-keys.html
+++ b/noggin/templates/user-settings-keys.html
@@ -5,7 +5,7 @@
               <form class="needs-validation" action="{{ url_for('.user_settings_keys', username=user.username) }}" method="post" novalidate>
                 {{ form.csrf_token }}
                 <div class="card-body">
-                  <div class="form-group">{{ macros.with_errors(form.gpgkeys, maxlength="16", class="text-monospace mb-1", placeholder=_("GPG Key ID")) }}</div>
+                  <div class="form-group">{{ macros.with_errors(form.gpgkeys, class="text-monospace mb-1", placeholder=_("GPG Key ID")) }}</div>
                   <div class="form-group">{{ macros.with_errors(form.sshpubkeys, class="text-monospace mb-1", placeholder=_("SSH Public Key")) }}</div>
                 </div>
                 <div class="card-footer d-flex justify-content-between">

--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -61,10 +61,12 @@
                 </li>
               {% endif %}
               {% if user.gpgkeys %}
-                <li class="list-group-item d-flex justify-content-between">
+                <li class="list-group-item">
                   <strong title='{{_("GPG Keys")}}'><i class="fa fa-fw fa-key"></i> {{_("GPG Keys")}}</strong>
-                  <div class="text-right">
-                    {% for pgpkey in user.gpgkeys %}<pre class="mb-1 bg-light border px-2 rounded"><i class="fa fa-fw fa-key text-muted"></i> {{ pgpkey }}</pre>{% endfor %}
+                  <div class="mt-1">
+                    {% for keyid in user.gpgkeys %}
+                      <pre class="mb-1 bg-light border px-2 py-1 rounded">{{ keyid }}</pre>
+                    {% endfor %}
                   </div>
                 </li>
               {% endif %}

--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -206,7 +206,7 @@ def logged_in_dummy_user(client, dummy_user, app):
 
 @pytest.fixture
 def dummy_user_with_gpg_key(client, dummy_user):
-    ipa_admin.user_mod(a_uid="dummy", fasgpgkeyid=["dummygpgkeyid"])
+    ipa_admin.user_mod(a_uid="dummy", fasgpgkeyid=["dummy-gpg-key-id"])
 
 
 @pytest.fixture

--- a/noggin/tests/unit/representation/conftest.py
+++ b/noggin/tests/unit/representation/conftest.py
@@ -10,7 +10,7 @@ def dummy_user_dict():
         'fascreationtime': ['20200122162312Z'],
         'fasgithubusername': ['dummy'],
         'fasgitlabusername': ['dummy'],
-        'fasgpgkeyid': ['key1', 'key2'],
+        'fasgpgkeyid': ['dummy-gpg-key-id-1', 'dummy-gpg-key-id-2'],
         'fasircnick': ['dummy', "dummy_"],
         'faslocale': ['en-US'],
         'fasrhbzemail': ['dummy@example.com'],

--- a/noggin/tests/unit/representation/test_user.py
+++ b/noggin/tests/unit/representation/test_user.py
@@ -16,7 +16,7 @@ def test_user(dummy_user_dict):
     assert user.timezone == "UTC"
     assert user.locale == "en-US"
     assert user.ircnick == ["dummy", "dummy_"]
-    assert user.gpgkeys == ["key1", "key2"]
+    assert user.gpgkeys == ["dummy-gpg-key-id-1", "dummy-gpg-key-id-2"]
     assert user.groups == ["ipausers"]
     assert user.github == "dummy"
     assert user.gitlab == "dummy"


### PR DESCRIPTION
This depends on fedora-infra/freeipa-fas#140.

Fixes: #556