### PR TITLE
Be a less strict when verifying the token upon creation

### DIFF
--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -128,7 +128,7 @@ class UserSettingsConfirmOTPForm(ModestForm):
 
     def validate_code(form, field):
         totp = TOTP(form.secret.data)
-        if not totp.verify(field.data):
+        if not totp.verify(field.data, valid_window=1):
             raise ValidationError(_('The code is wrong, please try again.'))
 
 


### PR DESCRIPTION
Let's allow a validity window of 30s to verify the token when it's created, it's a little less annoying and it does the job.