### PR TITLE
Skipping autocomplete in OTP fields

### DIFF
--- a/news/593.bug
+++ b/news/593.bug
@@ -1,0 +1,1 @@
+Skipped autocomplete in OTP fields

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -112,7 +112,7 @@ class UserSettingsAddOTPForm(ModestForm):
         description=_("please reauthenticate so we know it is you"),
     )
 
-    otp = PasswordField(
+    otp = StringField(
         _('One-Time Password'),
         validators=[Optional()],
         description=_("Enter your One-Time Password"),

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -9,7 +9,7 @@
       {{ macros.with_errors(login_form.password, class="validate", placeholder="Password", tabindex="2", label=False) }}
     </div>
     <div class="form-group mb-0">
-      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (if you have one)", tabindex="3", label=False) }}
+      {{ macros.with_errors(login_form.otp, class="validate", placeholder="One-Time Password (if you have one)", tabindex="3", autocomplete="off", label=False) }}
     </div>
     <div class="form-group mb-0 text-right">
     {% if lost_otp_token is not defined %}

--- a/noggin/templates/forgot-password-change.html
+++ b/noggin/templates/forgot-password-change.html
@@ -16,7 +16,7 @@
             <h5 id="pageheading">{{ _('Password Reset for %(username)s', username=username) }}</h5>
             <div class="form-group">{{ macros.with_errors(form.password, tabindex="1")}}</div>
             <div class="form-group">{{ macros.with_errors(form.password_confirm, tabindex="2")}}</div>
-            <div class="form-group">{{ macros.with_errors(form.otp, tabindex="3")}}</div>
+            <div class="form-group">{{ macros.with_errors(form.otp, tabindex="3", autocomplete="off")}}</div>
           </div>
           <div class="card-footer d-flex justify-content-between">
             <div>{{ macros.non_field_errors(form) }}</div>

--- a/noggin/templates/password-reset.html
+++ b/noggin/templates/password-reset.html
@@ -18,7 +18,7 @@
                 <div class="form-group">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
                 <div class="form-group">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
                 {% if tokens %}
-                  <div class="form-group">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+                  <div class="form-group">{{ macros.with_errors(password_reset_form.otp, tabindex="5", autocomplete="off")}}</div>
                 {% endif %}
               </div>
               <div class="card-footer d-flex justify-content-between">

--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -26,7 +26,7 @@
           {{ confirmotpform.description() }}
           <div class="form-group">
         {{ _("After enrolling the token in your application, verify it by generating your first code and entering it below:")}}
-          {{ macros.with_errors(confirmotpform.code, label=False, placeholder=_("Verification Code"))}}
+          {{ macros.with_errors(confirmotpform.code, label=False, placeholder=_("Verification Code"), autocomplete="off")}}
           </div>
           <div>{{ macros.non_field_errors(confirmotpform) }}</div>
           <div class="d-flex justify-content-between">

--- a/noggin/templates/user-settings-password.html
+++ b/noggin/templates/user-settings-password.html
@@ -10,7 +10,7 @@
     <div class="form-group">{{ macros.with_errors(password_reset_form.password, tabindex="3")}}</div>
     <div class="form-group">{{ macros.with_errors(password_reset_form.password_confirm, tabindex="4")}}</div>
     {% if using_otp %}
-    <div class="form-group" id="otpinput">{{ macros.with_errors(password_reset_form.otp, tabindex="5")}}</div>
+    <div class="form-group" id="otpinput">{{ macros.with_errors(password_reset_form.otp, tabindex="5", autocomplete="off")}}</div>
     {% endif %}
   </div>
   <div class="card-footer d-flex justify-content-between">


### PR DESCRIPTION
Resolves #593

- Transform otp field in `UserSettingsAddOTPForm`. 
- Added `autocomplete="off"` attribute in OTP fields.