### PR TITLE
IPA can return a DuplicateError on duplicate email addresses too

### DIFF
--- a/news/PR665.bug
+++ b/news/PR665.bug
@@ -1,0 +1,1 @@
+Don't tell users signing up that their username is already taken when it can be the email address

--- a/noggin/controller/registration.py
+++ b/noggin/controller/registration.py
@@ -116,7 +116,12 @@ def handle_register_form(form):
         user = User(user)
     except python_freeipa.exceptions.DuplicateEntry:
         raise FormError(
-            "username", _("This username is already taken, please choose another one.")
+            "non_field_errors",
+            _(
+                "The username '%(username)s' or the email address '%(email)s' are already taken.",
+                username=username,
+                email=form.mail.data,
+            ),
         )
     except python_freeipa.exceptions.ValidationError as e:
         # for example: invalid username. We don't know which field to link it to

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -441,10 +441,12 @@ def test_short_password_policy(
 def test_duplicate(client, post_data_step_1, cleanup_dummy_user, dummy_user):
     """Register a user that already exists"""
     result = client.post('/', data=post_data_step_1)
-    assert_form_field_error(
+    assert_form_generic_error(
         result,
-        field_name="register-username",
-        expected_message='This username is already taken, please choose another one.',
+        expected_message=(
+            "The username 'dummy' or the email address 'dummy@example.com' "
+            "are already taken."
+        ),
     )
 
 


### PR DESCRIPTION
This should prevent issues such as [Fedora Infra #10033](https://pagure.io/fedora-infrastructure/issue/10033) from happenning in the future.