### PR TITLE
Remove mention of Freenode

### DIFF
--- a/noggin/tests/unit/conftest.py
+++ b/noggin/tests/unit/conftest.py
@@ -174,7 +174,7 @@ def make_group(ipa_testing_config, app):
             fasgroup=True,
             fasurl=f"http://{name}.example.com",
             fasmailinglist=f"{name}@lists.example.com",
-            fasircchannel=f"irc:///freenode.net/#{name}",
+            fasircchannel=f"irc:///irc.example.org/#{name}",
         )
         created.append(name)
         return result

--- a/noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_recent_password_change.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_recent_password_change.yaml
@@ -382,7 +382,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_forbidden.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_forbidden.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_hidden_group.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_hidden_group.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_invalid.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_invalid.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_invalid_form.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_member_invalid_form.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_add_unknown_member.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_add_unknown_member.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_many_members.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_many_members.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_hidden_group.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_hidden_group.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_invalid.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_invalid.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_invalid_form.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_invalid_form.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_unknown.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_member_unknown.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_self.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_self.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor_last.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor_last.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor_unknown.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_group_remove_sponsor_unknown.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_groups_list.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_groups_list.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_group/test_groups_list_no_hidden.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_group/test_groups_list_no_hidden.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_password_reset/test_time_sensitive_password_policy.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_password_reset/test_time_sensitive_password_policy.yaml
@@ -382,7 +382,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_root/test_search_json.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_root/test_search_json.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_user/test_user_can_see_dummy_group.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_user/test_user_can_see_dummy_group.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_user/test_user_with_indirect_groups.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_user/test_user_with_indirect_groups.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:
@@ -652,7 +652,7 @@ interactions:
     body: '{"method": "group_add", "params": [["parent-group"], {"description": "The
       parent-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://parent-group.example.com",
-      "fasmailinglist": "parent-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#parent-group",
+      "fasmailinglist": "parent-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#parent-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/cassettes/test_user/test_user_with_no_groups.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_user/test_user_with_no_groups.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/controller/test_group.py
+++ b/noggin/tests/unit/controller/test_group.py
@@ -97,7 +97,7 @@ def test_group(client, dummy_user_as_group_manager, make_user):
     )
     assert (
         page.select_one("#group-ircchannel a").get_text(strip=True)
-        == "irc:///freenode.net/#dummy-group"
+        == "irc:///irc.example.org/#dummy-group"
     )
     assert (
         page.select_one("#group-urls a").get_text(strip=True)

--- a/noggin/tests/unit/representation/conftest.py
+++ b/noggin/tests/unit/representation/conftest.py
@@ -77,7 +77,7 @@ def dummy_group_dict():
             'posixgroup',
         ],
         'fasurl': ['http://example.com', "https://www.dummygroup.com.au"],
-        'fasircchannel': ["irc://freenode.net/#dummy-group"],
+        'fasircchannel': ["irc://irc.example.org/#dummy-group"],
         'fasmailinglist': ['dummygroup@lists.fedoraproject.org'],
     }
 

--- a/noggin/tests/unit/representation/test_group.py
+++ b/noggin/tests/unit/representation/test_group.py
@@ -11,7 +11,7 @@ def test_group(dummy_group_dict):
     assert group.dn == "cn=dummy-group,cn=groups,cn=accounts,dc=example,dc=com"
     assert group.mailing_list == 'dummygroup@lists.fedoraproject.org'
     assert group.urls == ['http://example.com', "https://www.dummygroup.com.au"]
-    assert group.irc_channel == 'irc://freenode.net/#dummy-group'
+    assert group.irc_channel == 'irc://irc.example.org/#dummy-group'
 
 
 def test_group_no_dn(dummy_group_dict):

--- a/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch.yaml
+++ b/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_no_raise_errors.yaml
+++ b/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_batch_no_raise_errors.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_fasagreement_add_group.yaml
+++ b/noggin/tests/unit/security/cassettes/test_ipa/test_ipa_client_fasagreement_add_group.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "The
       dummy-group group", "nonposix": false, "external": false, "all": true, "raw":
       false, "no_members": false, "fasgroup": true, "fasurl": "http://dummy-group.example.com",
-      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "fasmailinglist": "dummy-group@lists.example.com", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:

--- a/noggin/tests/unit/utility/cassettes/test_controllers/test_group_or_404.yaml
+++ b/noggin/tests/unit/utility/cassettes/test_controllers/test_group_or_404.yaml
@@ -433,7 +433,7 @@ interactions:
     body: '{"method": "group_add", "params": [["dummy-group"], {"description": "A
       dummy group", "nonposix": false, "external": false, "all": true, "raw": false,
       "no_members": false, "fasgroup": true, "fasurl": "http://dummygroup.org", "fasmailinglist":
-      "dummy@mailinglist.org", "fasircchannel": "irc:///freenode.net/#dummy-group",
+      "dummy@mailinglist.org", "fasircchannel": "irc:///irc.example.org/#dummy-group",
       "version": "2.235"}]}'
     headers:
       Accept:


### PR DESCRIPTION
While testd wouldn't change anything for anyone, the mention of
freenode in tests data make it harder to do search and replace
in the docs using Github search.