### PR TITLE
Handle password changes for manually created users

### DIFF
--- a/news/719.bug
+++ b/news/719.bug
@@ -1,0 +1,1 @@
+Handle password changes for manually created users

--- a/noggin/tests/unit/controller/cassettes/test_forgot_password/test_ask_post_no_last_password_change.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_forgot_password/test_ask_post_no_last_password_change.yaml
@@ -1,0 +1,655 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:58 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=TwR%2bHdjcSy0nXEFTbaSPRPcnV8Cz8gx4hpQVBzkXXKX2Xb2ahfSN%2bh58y0I6nn9ctaJceS7M4BAtlyrxoxUnIxygR0RQPRHPwYnBhJ4yJGRH8PjlyRFG3niGNbKvPRXMX8DkUBQU3jA2aNtuKeaTETjOU8tW%2fIRa9dN58Z65wWLOeJplENTtRte9vmEwX55d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TwR%2bHdjcSy0nXEFTbaSPRPcnV8Cz8gx4hpQVBzkXXKX2Xb2ahfSN%2bh58y0I6nn9ctaJceS7M4BAtlyrxoxUnIxygR0RQPRHPwYnBhJ4yJGRH8PjlyRFG3niGNbKvPRXMX8DkUBQU3jA2aNtuKeaTETjOU8tW%2fIRa9dN58Z65wWLOeJplENTtRte9vmEwX55d
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@example.com",
+      "random": false, "noprivate": false, "all": true, "raw": false, "no_members":
+      false, "fascreationtime": "2021-09-30T07:56:58Z", "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '307'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TwR%2bHdjcSy0nXEFTbaSPRPcnV8Cz8gx4hpQVBzkXXKX2Xb2ahfSN%2bh58y0I6nn9ctaJceS7M4BAtlyrxoxUnIxygR0RQPRHPwYnBhJ4yJGRH8PjlyRFG3niGNbKvPRXMX8DkUBQU3jA2aNtuKeaTETjOU8tW%2fIRa9dN58Z65wWLOeJplENTtRte9vmEwX55d
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RT22rbQBD9FaNnX2TZctxCoIUGUwpxIclLmyJGuyN769WuuhfXbvC/d2cl30po
+        njR7ZubM7eglMWi9dMn73sulyVT4fE8++bre954smuRHv5dwYRsJewU1vuYWSjgB0ra+p4itkGn7
+        WrAufyJzTIJt3U43SYAbNFYrsrRZgRJ/wAmtQJ5xodAF3zXgiZbStRU7YEx75ei9MWVjhGKiAQl+
+        10FOsA26RkvB9h0aAtqOuoe16yNnBfZoBseDXS+M9s2y+urLL7i3hNfYLI1YCXWnnNm3y2jAK/HL
+        o+BxvopP2bys2CAbs8lgPEY2mM/YzSDP8mmazrIMsjwmBq4aFKyQYySjZKZuOa2vH4wVVbdkdXPa
+        Pme3Sq9CebIcWheJwqAMlFaCgTydLNJ8uF8uFp/vh493D4/H0NOa3ghd6xq5MGFTumtuRNAoRseI
+        sC9mMN7NiZbrJSkKDg7pXRQBSbI0G6fvJml6k8/y+bfkQJm+29WZqwYhL5rBHdSNxCHTdasuwZWv
+        y3AcihlPskmW5rPZNDqlDhuxa5Qtw6gUalSCXXeZW1TXQo64bYV/kqn/X4Um/DFotkhdV0H4SPsB
+        W5B8fmvzL7zBvYPyAqyRmHVVxJvGCiSbwGnb/42aoRbO14/ON45/CKlbkJ5m63ZJkwUD4smSj5wj
+        7xFV77kNeE5iFhqjaVLlpSQN87N90gcRAK+FupIGlQydhZuTfzqcD8dpcvgLAAD//wMAKvhF5F8E
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=TwR%2bHdjcSy0nXEFTbaSPRPcnV8Cz8gx4hpQVBzkXXKX2Xb2ahfSN%2bh58y0I6nn9ctaJceS7M4BAtlyrxoxUnIxygR0RQPRHPwYnBhJ4yJGRH8PjlyRFG3niGNbKvPRXMX8DkUBQU3jA2aNtuKeaTETjOU8tW%2fIRa9dN58Z65wWLOeJplENTtRte9vmEwX55d
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=aSyeWmbCNzlVkb3eoh0naF5FJfdzY5dY4E5uRp3qmScf95kbwzvc0Ex6JRdyiRLOjxJ5lvpSCG1zamT7Smydx5XBY88xMUygTD6I%2fKn4OLxN0s1WkQVxC8rYqCkbsMGBH2HaHvJJQiI7dNQUT4UH4CmCzZXRmixUx%2fJxbIYAHGUlNxMilIfF396ag%2fHL%2bNrK;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aSyeWmbCNzlVkb3eoh0naF5FJfdzY5dY4E5uRp3qmScf95kbwzvc0Ex6JRdyiRLOjxJ5lvpSCG1zamT7Smydx5XBY88xMUygTD6I%2fKn4OLxN0s1WkQVxC8rYqCkbsMGBH2HaHvJJQiI7dNQUT4UH4CmCzZXRmixUx%2fJxbIYAHGUlNxMilIfF396ag%2fHL%2bNrK
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aSyeWmbCNzlVkb3eoh0naF5FJfdzY5dY4E5uRp3qmScf95kbwzvc0Ex6JRdyiRLOjxJ5lvpSCG1zamT7Smydx5XBY88xMUygTD6I%2fKn4OLxN0s1WkQVxC8rYqCkbsMGBH2HaHvJJQiI7dNQUT4UH4CmCzZXRmixUx%2fJxbIYAHGUlNxMilIfF396ag%2fHL%2bNrK
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RT22rbQBD9FaNnXyTZctxCoA8NphTiQpKXhiJGq5G89WpX3Ytr1/jfu7OSbyU0
+        T5o9c+Z+dIg0Gids9HFwuDaZ9J/X6LNrmv3gxaCOfgwHUclNK2AvocG33Fxyy0GYzvcSsBqZMm+R
+        VfETmWUCTOe2qo083KI2SpKldA2S/wHLlQRxwblE6323gKO0FK4M3wFjyklL740uWs0l4y0IcLse
+        spxt0LZKcLbvUU/oOuofxqxPOSswJ9M7nsx6qZVrV9U3V3zFvSG8wXalec3lg7R63y2jBSf5L4e8
+        DPNV5YwtioqN0oRNR0mCbLSYs7tRlmazOJ6nKaRZCPS5GpBQY4khGQUzeV/S+obeqKm6Iauf0wxL
+        di9V7cuTZdHYkMgPykAqyRmI88lCmk+Pq+Xyy+P4+eHp+UQ9r+kd6lo1WHLtN6X65iYETQI7MPy+
+        mMZwN8u7XIcoz0uwSO8890iUxmkSf5jG8V02zxbfoyNFun5Xl1wNcHHVDO6gaQWOmWo6dfFSuqbw
+        xyFOMk2naZzN57PgFMpvxKxRdBkmBZeTAsy6j9yivBVywE0n/LNM3f8qSNOfQCi28YTKix9pR2By
+        ktBvpct/4A3uLRRXYOv/OtRbvCY2SBVVlYdbh8okJ88z3X9ITVJrF1UE5zuiOPrQLQhHM/c7pom9
+        AeGU0glBHNRa6f5NSi4v9lkllALKhssbgVAB34e/PPln48U4iaPjXwAAAP//AwAvg6jXZQQAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=aSyeWmbCNzlVkb3eoh0naF5FJfdzY5dY4E5uRp3qmScf95kbwzvc0Ex6JRdyiRLOjxJ5lvpSCG1zamT7Smydx5XBY88xMUygTD6I%2fKn4OLxN0s1WkQVxC8rYqCkbsMGBH2HaHvJJQiI7dNQUT4UH4CmCzZXRmixUx%2fJxbIYAHGUlNxMilIfF396ag%2fHL%2bNrK
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:56:59 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 07:57:00 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=WTK4AiOHvVVC156AYdOPrHR9krYYzRSE%2fX1ubdf92HvzMRZ8rIqSuytuMhF4EGbu1XoLM8%2bo8H9%2bZ7cCgtVIi3gD5bWIpCFQ1xsUnq4lQcuqN6gJbKsJUgxe1X1uy4rDcbn1d0QytCXBRU4gmvHeCartUlA7lgrLgnXS%2fOHImb3jsIiwYJ5cSh38MiWmLTsb;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WTK4AiOHvVVC156AYdOPrHR9krYYzRSE%2fX1ubdf92HvzMRZ8rIqSuytuMhF4EGbu1XoLM8%2bo8H9%2bZ7cCgtVIi3gD5bWIpCFQ1xsUnq4lQcuqN6gJbKsJUgxe1X1uy4rDcbn1d0QytCXBRU4gmvHeCartUlA7lgrLgnXS%2fOHImb3jsIiwYJ5cSh38MiWmLTsb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:57:00 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WTK4AiOHvVVC156AYdOPrHR9krYYzRSE%2fX1ubdf92HvzMRZ8rIqSuytuMhF4EGbu1XoLM8%2bo8H9%2bZ7cCgtVIi3gD5bWIpCFQ1xsUnq4lQcuqN6gJbKsJUgxe1X1uy4rDcbn1d0QytCXBRU4gmvHeCartUlA7lgrLgnXS%2fOHImb3jsIiwYJ5cSh38MiWmLTsb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yNMQvCMBCF/0q4WYKCg3RyUIpLHezWdgjmhINLWi6NUEr/uxccdPveu/ferSCY
+        Ms9QmfUfX44YvWI3bDsDb8cZiwKfQ1hgUC8pOVnUhQsyzuhNTiim/2Z6gNJEkVE0EzOzSvI/noTi
+        kybHZcL5QPHc3Ov61tj2+mihvEVJNMZyP9qTPexh+wAAAP//AwBhDOkysQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:57:00 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=WTK4AiOHvVVC156AYdOPrHR9krYYzRSE%2fX1ubdf92HvzMRZ8rIqSuytuMhF4EGbu1XoLM8%2bo8H9%2bZ7cCgtVIi3gD5bWIpCFQ1xsUnq4lQcuqN6gJbKsJUgxe1X1uy4rDcbn1d0QytCXBRU4gmvHeCartUlA7lgrLgnXS%2fOHImb3jsIiwYJ5cSh38MiWmLTsb
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 07:57:00 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_no_earlier_password_change.yaml
+++ b/noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_no_earlier_password_change.yaml
@@ -1,0 +1,1147 @@
+interactions:
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:22 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=96nBhKoIHeVNvHUgDZVsbwSZIVlN77gKPqQU%2fRu6ID7yKwPrWY5NbOM%2b9liZVbfRFZpK5V1FMwNz0en6mHTzhWcMMl5hH6cGXbwcuVEg1dAT3lfmLZ32FJqMhuMYoq8W5zciZUirIgcCJ%2bvE6ohDRWLq2D7h%2b293nxYzjdFlQ2ccEAF9nvm%2b7LmkZFsvE3XI;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=96nBhKoIHeVNvHUgDZVsbwSZIVlN77gKPqQU%2fRu6ID7yKwPrWY5NbOM%2b9liZVbfRFZpK5V1FMwNz0en6mHTzhWcMMl5hH6cGXbwcuVEg1dAT3lfmLZ32FJqMhuMYoq8W5zciZUirIgcCJ%2bvE6ohDRWLq2D7h%2b293nxYzjdFlQ2ccEAF9nvm%2b7LmkZFsvE3XI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:22 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@example.com",
+      "random": false, "noprivate": false, "all": true, "raw": false, "no_members":
+      false, "fascreationtime": "2021-09-30T08:25:22Z", "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '307'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=96nBhKoIHeVNvHUgDZVsbwSZIVlN77gKPqQU%2fRu6ID7yKwPrWY5NbOM%2b9liZVbfRFZpK5V1FMwNz0en6mHTzhWcMMl5hH6cGXbwcuVEg1dAT3lfmLZ32FJqMhuMYoq8W5zciZUirIgcCJ%2bvE6ohDRWLq2D7h%2b293nxYzjdFlQ2ccEAF9nvm%2b7LmkZFsvE3XI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RTXW/bMAz8K4Gfm8RW6ywZUGADVhTDgGZA25etg0FLjKNVljx9ZM2C/PeJstOk
+        Q4c+mboTSfGO3mUWXVA+ez/anYZcx8/37FNo2+3o3qHNfpyNMiFdp2CrocXXaKmll6Bcz90nrEFu
+        3GuXTf0TuecKXE9702UR7tA6oykytgEt/4CXRoM64lKjj9xLIFBZSjdOPgHnJmhP50dbd1ZqLjtQ
+        EJ4GyEv+iL4zSvLtgMYL/YuGg3PrQ80VuEMYiVu3vrYmdMvV11B/wa0jvMVuaWUj9ZX2dtuL0UHQ
+        8ldAKdJ8q4tFMc8ZG7OCvxsXBfLxombluGTlRZ7PGANWpsRYqwUNDQpMxSiZ60tB8p3FoKHujqJh
+        Tncm+KU2TWxPkUfnU6EwdE6ZCYmjc9BGSw7q2cREf7hZXl9/vpncXd3e9b5JoUNbx7HpTnHOzlle
+        zmblQG5Qv9yCQ8f/J0UZucVkp5d96i6rKgEe6VxVEclYzop8cZ7nc1Yy9i3bU+batCikjeaYQY8p
+        QdPjYMrE4d0alerpWuppDW6dSNfv8vPmne7EGyq0INUJjU/Qdgon3LSJ7uIfg3aDpPMqLj7SY8FV
+        tD6/jf0XfsSth/oEbJHEMqsqeZoa0drEmq7/3+jlpOrR/US+Yf4+pm5ABZpscJ9kiAEk/bKPQqAY
+        UanRQ3/hIUtZaK0h83RQinZYHONnyagAiFbqF2pRy/iyaC7xF5P5pMiz/V8AAAD//wMAWMy2U18E
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:22 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=96nBhKoIHeVNvHUgDZVsbwSZIVlN77gKPqQU%2fRu6ID7yKwPrWY5NbOM%2b9liZVbfRFZpK5V1FMwNz0en6mHTzhWcMMl5hH6cGXbwcuVEg1dAT3lfmLZ32FJqMhuMYoq8W5zciZUirIgcCJ%2bvE6ohDRWLq2D7h%2b293nxYzjdFlQ2ccEAF9nvm%2b7LmkZFsvE3XI
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:22 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:22 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=XgDaVWlHFzzdfBAR9swgG1EYwTywWxbNtEkS4jJYYbpMbHaGbbA%2b1FyF4lAxakPqs2IF8BzBk%2b63pScGRF7jObnyKQzSjj6PDCDAPIzp72tLWh%2f14KD31z1lsbQD0rGH4rqv5vmxZ%2bnsEfEI4EO0Bfk4TCII%2fy5svVE49xKfAEeiuxrAuH3BJRQrAX9Vx6Gx;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XgDaVWlHFzzdfBAR9swgG1EYwTywWxbNtEkS4jJYYbpMbHaGbbA%2b1FyF4lAxakPqs2IF8BzBk%2b63pScGRF7jObnyKQzSjj6PDCDAPIzp72tLWh%2f14KD31z1lsbQD0rGH4rqv5vmxZ%2bnsEfEI4EO0Bfk4TCII%2fy5svVE49xKfAEeiuxrAuH3BJRQrAX9Vx6Gx
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XgDaVWlHFzzdfBAR9swgG1EYwTywWxbNtEkS4jJYYbpMbHaGbbA%2b1FyF4lAxakPqs2IF8BzBk%2b63pScGRF7jObnyKQzSjj6PDCDAPIzp72tLWh%2f14KD31z1lsbQD0rGH4rqv5vmxZ%2bnsEfEI4EO0Bfk4TCII%2fy5svVE49xKfAEeiuxrAuH3BJRQrAX9Vx6Gx
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RT227bMAz9lcDPudhKnDUDCuxhRTAMaAa0fVkxBLTMOFpkydMlSxbk3yfKzm3o
+        0CdT55CUeHh8SAxaL13ysXe4DrkKn9fks6/rfe/Fokl+9HtJKWwjYa+gxrdooYQTIG3LvUSsQq7t
+        W8m6+InccQm2pZ1ukgA3aKxWFGlTgRJ/wAmtQF5wodAF7hbw1JbKtRU74Fx75ei8MUVjhOKiAQl+
+        10FO8A26RkvB9x0aEtoXdQdr16eeK7CnMBBPdj032jeL1TdffMW9JbzGZmFEJdSDcmbfitGAV+KX
+        R1HG+VaTWXaXMjZgGf8wyDLkg1nB8kHO8kmaThkDlsfC0KsGBRWWGJtRMVf3JcnXD0FFt1uKujlt
+        v+T3SlfheoocWhcb+e7mWBmRMDoHpZXgIM9LjPSnx8V8/uVx+Pzw9NzuTZTK10UYm3KyMRuzNJ9O
+        847corp1wenG/xcFGbnBuE4n2tJDslyW4JDOy2VAEpayLJ2N0/SO5Yx9T45UudY1lsKE5ehOjxFB
+        o8tgUofh7RqlbOlCqFEBdh1J23r57LxrT7yjQg1CXtG4g7qROOS6jrSy3Qqk5puQtwrmR3ow2CVZ
+        6Lc25T/wBvcOiiuwCX8dmi1eJ9ZIIurVMu46PoDsFPJs+x/SRKT2xRWRfMcUx1C6Belp4s4VJE8I
+        IOqqvJSUg8Zo053JyeUlPgtHLaCshbrRjC4I7wgrJn4yvBtmaXL8CwAA//8DAH9gIZFlBAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XgDaVWlHFzzdfBAR9swgG1EYwTywWxbNtEkS4jJYYbpMbHaGbbA%2b1FyF4lAxakPqs2IF8BzBk%2b63pScGRF7jObnyKQzSjj6PDCDAPIzp72tLWh%2f14KD31z1lsbQD0rGH4rqv5vmxZ%2bnsEfEI4EO0Bfk4TCII%2fy5svVE49xKfAEeiuxrAuH3BJRQrAX9Vx6Gx
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=I0%2fhO1hseFMdVhvjQFn93kBejM%2bSK38csn%2f%2bhY4nGyo8IyV4ZOx8Hojc8OAsVqZ8Z57%2bSBcf8ormRJ8oUw1w7DmvA4UKwF42caztGCSGw90%2bJDy9owYYxnNDLSlquGtWXT2IRcIeY9enlx248FY5tAGzuQp2Oi9gqH5s1xmTKeLnh6oXMdaugd%2fSNFGdMnDv;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=I0%2fhO1hseFMdVhvjQFn93kBejM%2bSK38csn%2f%2bhY4nGyo8IyV4ZOx8Hojc8OAsVqZ8Z57%2bSBcf8ormRJ8oUw1w7DmvA4UKwF42caztGCSGw90%2bJDy9owYYxnNDLSlquGtWXT2IRcIeY9enlx248FY5tAGzuQp2Oi9gqH5s1xmTKeLnh6oXMdaugd%2fSNFGdMnDv
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=I0%2fhO1hseFMdVhvjQFn93kBejM%2bSK38csn%2f%2bhY4nGyo8IyV4ZOx8Hojc8OAsVqZ8Z57%2bSBcf8ormRJ8oUw1w7DmvA4UKwF42caztGCSGw90%2bJDy9owYYxnNDLSlquGtWXT2IRcIeY9enlx248FY5tAGzuQp2Oi9gqH5s1xmTKeLnh6oXMdaugd%2fSNFGdMnDv
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4RT227bMAz9lcDPudhKnDUDCuxhRTAMaAa0fVkxBLTMOFpkydMlSxbk3yfKzm3o
+        0CdT55CUeHh8SAxaL13ysXe4DrkKn9fks6/rfe/Fokl+9HtJKWwjYa+gxrdooYQTIG3LvUSsQq7t
+        W8m6+InccQm2pZ1ukgA3aKxWFGlTgRJ/wAmtQF5wodAF7hbw1JbKtRU74Fx75ei8MUVjhOKiAQl+
+        10FO8A26RkvB9x0aEtoXdQdr16eeK7CnMBBPdj032jeL1TdffMW9JbzGZmFEJdSDcmbfitGAV+KX
+        R1HG+VaTWXaXMjZgGf8wyDLkg1nB8kHO8kmaThkDlsfC0KsGBRWWGJtRMVf3JcnXD0FFt1uKujlt
+        v+T3SlfheoocWhcb+e7mWBmRMDoHpZXgIM9LjPSnx8V8/uVx+Pzw9NzuTZTK10UYm3KyMRuzNJ9O
+        847corp1wenG/xcFGbnBuE4n2tJDslyW4JDOy2VAEpayLJ2N0/SO5Yx9T45UudY1lsKE5ehOjxFB
+        o8tgUofh7RqlbOlCqFEBdh1J23r57LxrT7yjQg1CXtG4g7qROOS6jrSy3Qqk5puQtwrmR3ow2CVZ
+        6Lc25T/wBvcOiiuwCX8dmi1eJ9ZIIurVMu46PoDsFPJs+x/SRKT2xRWRfMcUx1C6Belp4s4VJE8I
+        IOqqvJSUg8Zo053JyeUlPgtHLaCshbrRjC4I7wgrJn4yvBtmaXL8CwAA//8DAH9gIZFlBAAA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=I0%2fhO1hseFMdVhvjQFn93kBejM%2bSK38csn%2f%2bhY4nGyo8IyV4ZOx8Hojc8OAsVqZ8Z57%2bSBcf8ormRJ8oUw1w7DmvA4UKwF42caztGCSGw90%2bJDy9owYYxnNDLSlquGtWXT2IRcIeY9enlx248FY5tAGzuQp2Oi9gqH5s1xmTKeLnh6oXMdaugd%2fSNFGdMnDv
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=HoBKtWDRrIbSw2kfRWLdX%2fgbAtpgaeh7ywF66VGU6Z7BIdRjPamKgQsYhsz3C78Gwp9ulmWL1KFFnGHjC6PiepNHoiCSVYqZQfll7rZnxEyKtWI62ODtKhROFtcM99ouHfKNFPuJj%2fC0sONQ2VTzo1Tra7nnkMa%2f%2bdZcJ3LQ6LEdVHFxYOdCN7WIs8iYPaax;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=HoBKtWDRrIbSw2kfRWLdX%2fgbAtpgaeh7ywF66VGU6Z7BIdRjPamKgQsYhsz3C78Gwp9ulmWL1KFFnGHjC6PiepNHoiCSVYqZQfll7rZnxEyKtWI62ODtKhROFtcM99ouHfKNFPuJj%2fC0sONQ2VTzo1Tra7nnkMa%2f%2bdZcJ3LQ6LEdVHFxYOdCN7WIs8iYPaax
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_mod", "params": [["dummy"], {"random": false, "rights":
+      false, "all": true, "raw": false, "no_members": false, "userpassword": "TatDJYV1IvDPgmCNo3rbomH6",
+      "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '193'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=HoBKtWDRrIbSw2kfRWLdX%2fgbAtpgaeh7ywF66VGU6Z7BIdRjPamKgQsYhsz3C78Gwp9ulmWL1KFFnGHjC6PiepNHoiCSVYqZQfll7rZnxEyKtWI62ODtKhROFtcM99ouHfKNFPuJj%2fC0sONQ2VTzo1Tra7nnkMa%2f%2bdZcJ3LQ6LEdVHFxYOdCN7WIs8iYPaax
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5RUbW/aMBD+KyifC01cYGVSpbGtYy9amVTKh64TutgH8XDszC+UrOK/z3ZCoVKn
+        qp9yeZ67c+7xc3lINBonbPK283AcUukfP5OPrizrzo1Bnfw66SSMm0pALaHE52guueUgTMPdRGyF
+        VJnnklX+G6mlAkxDW1UlHq5QGyVDpPQKJP8LlisJ4oBzidZzTwEX2oZyZfgWKFVO2vC+1nmluaS8
+        AgFu20KW0zXaSglO6xb1Cc0XtS/GFPueSzD70BPXppho5arp8ofLv2FtAl5iNdV8xeWltLpuxKjA
+        Sf7HIWdxvmV/lJ2nhHRJRt90swxpd5STQXdABv00HRICZBALfa8SJKyQYWwWiqm8YEG+Ex+swukm
+        RO2c5oTRC6lW/vgQWTQ2Ngqz+znulWa4rbiOSoZ2D8liwcCi5SUuFh5JSEqydHSWpudkQMhtsmvr
+        /e3Y6p7RAuQKX1eKW6vBp8K+LAeDw35TNB5/rdmneUHL0YZ9GBW3k6zK1++ns5R9vr7pu/nlfDYf
+        jy+abq6VMEqwH42CVJJTEI9ujPS7q+lk8uWqN7u8njUG5Ey6Mvf3F3KyM3JG0sFwOGjJDcqndk7a
+        E/9f5P1ANUY1gwyvkKVQJTKuvctUe7GnATo9DCaUv0VToBANnXN56oUrImmapXxcoWNzv6BCCVwc
+        0biFshLYo6qMtDStl4Sia5+39FuM4YPBLPYe8rDVbo+usbaQH7DK/zxQb5AdVZcYJFTLRbRsPD5s
+        hc8zze8kzBO0Ppg7ki94e+dLNyBcmLf1RBDHBxBVTb4rxpccWSd069w1OXdJLEStVbhV6YQIW8oO
+        8aOWoQewkssnMoZT/cc1O5T0e+e9LE12/wAAAP//AwBTE1/CQQUAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=HoBKtWDRrIbSw2kfRWLdX%2fgbAtpgaeh7ywF66VGU6Z7BIdRjPamKgQsYhsz3C78Gwp9ulmWL1KFFnGHjC6PiepNHoiCSVYqZQfll7rZnxEyKtWI62ODtKhROFtcM99ouHfKNFPuJj%2fC0sONQ2VTzo1Tra7nnkMa%2f%2bdZcJ3LQ6LEdVHFxYOdCN7WIs8iYPaax
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=newpassword&old_password=TatDJYV1IvDPgmCNo3rbomH6
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/change_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOUQqAIAwG4PdO4Qma9Tw8Q9AJTC0D02hGdPtmCT2MwfbtZ+jzFlSD3mnLLa85
+        ONVLKcbTGEeE8I0ahEqmZO9y0KlBE13psMJ4HRcn6DuZz8C4Y7NzUT5SXH57aaretgh1y+nFQs2G
+        96kHAAD//wMAiLUc4ZsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:23 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=adminPassw0rd%21
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '36'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.noggin.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/login_password
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwMAAAAAAAAAAAA=
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:24 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=MagBearerToken=AkQn%2fYoDm1pxYE%2bFJ6Hdx%2bahb8IHvkQv%2bDTLK6Y3eyOldkSdvpCD339ppkHE0b3GHUwmcajmRHRf6HplJ3gW1V4lohG24YrsYe7WuAi37UsVX3YBgBj6UthtTS86e%2fEvAUsy0Efp2XyZ5s5g2GDYrUSEEXLwWM%2be14tIMzVOnrAGapaKCnwDtdBNfQMNYknF;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AkQn%2fYoDm1pxYE%2bFJ6Hdx%2bahb8IHvkQv%2bDTLK6Y3eyOldkSdvpCD339ppkHE0b3GHUwmcajmRHRf6HplJ3gW1V4lohG24YrsYe7WuAi37UsVX3YBgBj6UthtTS86e%2fEvAUsy0Efp2XyZ5s5g2GDYrUSEEXLwWM%2be14tIMzVOnrAGapaKCnwDtdBNfQMNYknF
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqFYqLs3NTSyqBLKVPAMcFYpTi8pSixSAuDgzP0/BRM9Cz9BA
+        T8ExwBMuZqRnZGypVKujoJRaVJRfBNSZV5qTA+RmpiDYBUWZecmZBYk5IIMTU3Iz8xz8/N3dPf30
+        QlyDQ5SAKqDGgeQhtijVAgAAAP//AwAPTtrhmQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:24 GMT
+      Keep-Alive:
+      - timeout=30, max=99
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AkQn%2fYoDm1pxYE%2bFJ6Hdx%2bahb8IHvkQv%2bDTLK6Y3eyOldkSdvpCD339ppkHE0b3GHUwmcajmRHRf6HplJ3gW1V4lohG24YrsYe7WuAi37UsVX3YBgBj6UthtTS86e%2fEvAUsy0Efp2XyZ5s5g2GDYrUSEEXLwWM%2be14tIMzVOnrAGapaKCnwDtdBNfQMNYknF
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0yNMQvCMBCF/0q4WYKCg3RyUIpLHezWdgjmhINLWi6NUEr/uxccdPveu/ferSCY
+        Ms9QmfUfX44YvWI3bDsDb8cZiwKfQ1hgUC8pOVnUhQsyzuhNTiim/2Z6gNJEkVE0EzOzSvI/noTi
+        kybHZcL5QPHc3Ov61tj2+mihvEVJNMZyP9qTPexh+wAAAP//AwBhDOkysQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:24 GMT
+      Keep-Alive:
+      - timeout=30, max=98
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=AkQn%2fYoDm1pxYE%2bFJ6Hdx%2bahb8IHvkQv%2bDTLK6Y3eyOldkSdvpCD339ppkHE0b3GHUwmcajmRHRf6HplJ3gW1V4lohG24YrsYe7WuAi37UsVX3YBgBj6UthtTS86e%2fEvAUsy0Efp2XyZ5s5g2GDYrUSEEXLwWM%2be14tIMzVOnrAGapaKCnwDtdBNfQMNYknF
+      Referer:
+      - https://ipa.noggin.test/ipa
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://ipa.noggin.test/ipa/session/json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKkotLs0pUbJSqEYw80pzcmp1FJRSi4ryi6B8IDczBcEuKMrMS84sSMwBCikl
+        puRm5jn4+bu7e/rphbgGhygBVZSlFhVn5ueB5E30LPQMDZRqAQAAAP//AwD+7nwEbgAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 30 Sep 2021 08:25:24 GMT
+      Keep-Alive:
+      - timeout=30, max=97
+      Server:
+      - Apache/2.4.46 (Fedora) OpenSSL/1.1.1g mod_wsgi/4.7.1 Python/3.9 mod_auth_gssapi/1.6.3
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/noggin/utility/token.py
+++ b/noggin/utility/token.py
@@ -34,3 +34,12 @@ def read_token(token, audience=None):
         algorithms=["HS256"],
         audience=audience.value,
     )
+
+
+def make_password_change_token(user):
+    lpc = user.last_password_change
+    if lpc is not None:
+        lpc = lpc.isoformat()
+    return make_token(
+        {"sub": user.username, "lpc": lpc}, audience=Audience.password_reset,
+    )


### PR DESCRIPTION
Manually created users have never changed their passwords, and thus don't have a `last_password_change` value.

Fixes: #719