### PR TITLE
Let users login even if they registered with a username that is now invalid

### DIFF
--- a/news/PR831.bug
+++ b/news/PR831.bug
@@ -1,0 +1,1 @@
+Let users login even if they registered with a username that is now invalid

--- a/noggin/form/login_user.py
+++ b/noggin/form/login_user.py
@@ -3,7 +3,7 @@ from wtforms import PasswordField, StringField
 from wtforms.validators import DataRequired, Optional
 
 from .base import ModestForm, SubmitButtonField
-from .validators import username_format
+from .validators import no_mixed_case
 
 
 class LoginUserForm(ModestForm):
@@ -11,7 +11,7 @@ class LoginUserForm(ModestForm):
         _('Username'),
         validators=[
             DataRequired(message=_('You must provide a user name')),
-            username_format,
+            no_mixed_case,
         ],
     )
 

--- a/noggin/form/validators.py
+++ b/noggin/form/validators.py
@@ -5,8 +5,8 @@ from wtforms.validators import Length, Regexp, StopValidation, ValidationError
 
 
 class Email(WTFormsEmailValidator):
-    """ Extend the WTForms email validator, adding the ability to blocklist
-        email addresses
+    """Extend the WTForms email validator, adding the ability to blocklist
+    email addresses
     """
 
     def __call__(self, form, field):
@@ -30,6 +30,11 @@ class PasswordLength:
             message=self.message,
         )
         validator(form, field)
+
+
+def no_mixed_case(form, field):
+    if field.data != field.data.lower():
+        raise ValidationError(_("Mixed case is not allowed, try lower case."))
 
 
 def username_format(form, field):


### PR DESCRIPTION
The username format restriction regex also applied to the login form, and we only want to apply it to the registration form to let existing users login when we restrict the username format further.