### PR TITLE
Issue a proper error message when the username is too short

### DIFF
--- a/news/866.bug
+++ b/news/866.bug
@@ -1,0 +1,1 @@
+Issue a proper error message when the username is too short

--- a/noggin.cfg.example
+++ b/noggin.cfg.example
@@ -68,6 +68,9 @@ MAIL_SUPPRESS_SEND = True
 # ALLOWED_USERNAME_PATTERN = "^[a-z0-9][a-z0-9-]{3,30}[a-z0-9]$"
 # This next value is used to build the error message
 # ALLOWED_USERNAME_HUMAN = ["a-z", "0-9", "-"]
+# Minimum and maximum username size
+# ALLOWED_USERNAME_MIN_SIZE = 5
+# ALLOWED_USERNAME_MAX_SIZE = 32
 
 # URL for the avatar service, typically either
 # AVATAR_SERVICE_URL = "https://seccdn.libravatar.org/"

--- a/noggin/defaults.py
+++ b/noggin/defaults.py
@@ -19,6 +19,9 @@ HIDE_GROUPS_IN = "hidden_groups"
 ALLOWED_USERNAME_PATTERN = "^[a-z0-9][a-z0-9-]{3,30}[a-z0-9]$"
 # This is used to build the error message
 ALLOWED_USERNAME_HUMAN = ["a-z", "0-9", "-"]
+# Minimum and maximum username size
+ALLOWED_USERNAME_MIN_SIZE = 5
+ALLOWED_USERNAME_MAX_SIZE = 32
 
 AVATAR_SERVICE_URL = "https://seccdn.libravatar.org/"
 AVATAR_DEFAULT_TYPE = "robohash"

--- a/noggin/form/validators.py
+++ b/noggin/form/validators.py
@@ -1,7 +1,7 @@
 from flask import current_app
 from flask_babel import lazy_gettext as _
 from wtforms.validators import Email as WTFormsEmailValidator
-from wtforms.validators import Length, Regexp, StopValidation, ValidationError
+from wtforms.validators import Length, StopValidation, ValidationError
 
 
 class Email(WTFormsEmailValidator):
@@ -37,15 +37,14 @@ def no_mixed_case(form, field):
         raise ValidationError(_("Mixed case is not allowed, try lower case."))
 
 
-def username_format(form, field):
-    # Don't use it directly to allow access to current_app
-    return Regexp(
-        current_app.config["ALLOWED_USERNAME_PATTERN"],
-        message=_(
-            "Only these characters are allowed: \"%(chars)s\".",
-            chars="\", \"".join(current_app.config["ALLOWED_USERNAME_HUMAN"]),
-        ),
-    )(form, field)
+def validator_proxy(factory):
+    """Proxy the validator through a factory to allow access to current_app."""
+
+    def _validate(form, field):
+        validator = factory()
+        return validator(form, field)
+
+    return _validate
 
 
 class StopOnError:

--- a/noggin/tests/unit/controller/test_registration.py
+++ b/noggin/tests/unit/controller/test_registration.py
@@ -149,7 +149,7 @@ def test_step_1_registration_closed(
     assert len(outbox) == 0
 
 
-@pytest.mark.parametrize("username", ["a", "ab", "a" * 33])
+@pytest.mark.parametrize("username", ["a", "ab", "abc", "abcd", "a" * 33])
 def test_step_1_bad_length(client, post_data_step_1, mocker, username):
     """Try to register a user with a username that has a bad length"""
     post_data_step_1["register-username"] = username
@@ -161,7 +161,7 @@ def test_step_1_bad_length(client, post_data_step_1, mocker, username):
     assert_form_field_error(
         result,
         "register-username",
-        "Field must be between 3 and 32 characters long.",
+        "Field must be between 5 and 32 characters long.",
     )
     record_signal.assert_not_called()
     assert len(outbox) == 0


### PR DESCRIPTION
The `Length` validator parameters did not match the allowed regexp for usernames.

Fixes: #866