### PR TITLE
Step down Flask version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -128,11 +128,11 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2021.10.8"
+version = "2022.5.18.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
@@ -352,7 +352,7 @@ Twisted = "*"
 
 [[package]]
 name = "filelock"
-version = "3.7.0"
+version = "3.7.1"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -1450,7 +1450,7 @@ deploy = ["gunicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9.0"
-content-hash = "1ac6e99480536c17d5feecc3a33053670e49b413ae261325d4d74143c3975b65"
+content-hash = "d27cd7e8b9b6c7ae8e306c9844a5a5e4fbbeddb922d3135f5a9113150c247949"
 
 [metadata.files]
 alabaster = [
@@ -1514,8 +1514,8 @@ blinker = [
     {file = "blinker-1.4.tar.gz", hash = "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"},
 ]
 certifi = [
-    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
-    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
+    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
 ]
 cffi = [
     {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
@@ -1696,8 +1696,8 @@ fedora-messaging = [
     {file = "fedora_messaging-3.0.2.tar.gz", hash = "sha256:94ea22c7e7bf78e988b9d2c4bed80d7b422122429f9dd65408a6b8a28dcf13f8"},
 ]
 filelock = [
-    {file = "filelock-3.7.0-py3-none-any.whl", hash = "sha256:c7b5fdb219b398a5b28c8e4c1893ef5f98ece6a38c6ab2c22e26ec161556fed6"},
-    {file = "filelock-3.7.0.tar.gz", hash = "sha256:b795f1b42a61bbf8ec7113c341dad679d772567b936fbd1bf43c9a238e673e20"},
+    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
+    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9.0"
 cryptography = ">=3.4.7"
-flask = "^2.1.0"
+flask = "^2.0.0"
 flask-wtf = ">=0.14.3, <2.0.0"
 python-freeipa = "^1.0.6"
 click = "^8.0"


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

```
(venv) [makehost@makehost noggin-source]$ dnf list --showduplicates python3-flask
Last metadata expiration check: 0:10:15 ago on Mon 30 May 2022 11:45:43 AM IST.
Installed Packages
python3-flask.noarch                                             1:2.0.3-1.fc36                                              @fedora
Available Packages
python3-flask.noarch                                             1:2.0.3-1.fc36                                              fedora
```