### PR TITLE
Remove Fedora-specific defaults from Noggin

### DIFF
--- a/news/PR949.bic
+++ b/news/PR949.bic
@@ -1,0 +1,1 @@
+Noggin no longer assumes it is being deployed in Fedora infrastructure by default.

--- a/noggin.cfg.example
+++ b/noggin.cfg.example
@@ -62,7 +62,7 @@ MAIL_DEFAULT_SENDER = "Noggin <noggin@example.com>"
 MAIL_SUPPRESS_SEND = True
 
 # Email domains that a user cannot use to register or change to
-# MAIL_DOMAIN_BLOCKLIST = ['fedoraproject.org']
+# MAIL_DOMAIN_BLOCKLIST = ['example.com', 'example.org']
 
 # Allowed format for usernames
 # ALLOWED_USERNAME_PATTERN = "^[a-z0-9][a-z0-9-]{3,30}[a-z0-9]$"
@@ -91,6 +91,16 @@ MAIL_SUPPRESS_SEND = True
 # Page size when paginating results
 # PAGE_SIZE = 30
 
+# Chat network settings
+CHAT_NETWORKS = {
+    "irc": {"default_server": "irc.libera.chat"},
+    "matrix": {"default_server": "matrix.org"},
+}
+# Link to matrix rooms and usernames using the element.io web client
+# instance at app.element.io. Set this variable to whatever Element instance
+# you use (e.g. chat.fedoraproject.org, chat.opensuse.org, etc.)
+CHAT_MATRIX_TO_ARGS = "web-instance[element.io]=app.element.io"
+
 # IPA role allowed to modify and delete stage users. The stage users admin page
 # will only be accessible to users that have this role.
 # STAGE_USERS_ROLE = "Stage User Managers"
@@ -114,5 +124,5 @@ MAIL_SUPPRESS_SEND = True
 # BASSET_URL = None
 # SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes
 
-# Set to False to disable Fedora Messaging integration
+# Set to True to enable Fedora Messaging integration
 # FEDORA_MESSAGING_ENABLED = True

--- a/noggin/defaults.py
+++ b/noggin/defaults.py
@@ -26,7 +26,7 @@ ALLOWED_USERNAME_MAX_SIZE = 32
 AVATAR_SERVICE_URL = "https://seccdn.libravatar.org/"
 AVATAR_DEFAULT_TYPE = "robohash"
 
-MAIL_DOMAIN_BLOCKLIST = ['fedoraproject.org']
+MAIL_DOMAIN_BLOCKLIST = ['example.com', 'example.org']
 
 HEALTHZ = {
     "live": "noggin.controller.root.liveness",
@@ -37,12 +37,12 @@ PAGE_SIZE = 30
 
 CHAT_NETWORKS = {
     "irc": {"default_server": "irc.libera.chat"},
-    "matrix": {"default_server": "fedora.im"},
+    "matrix": {"default_server": "matrix.org"},
 }
-# Link to matrix rooms and usernames using the element.io web client
-# instance at chat.fedoraproject.org. Set this variable to a falsy
-# value to use element.io.
-CHAT_MATRIX_TO_ARGS = "web-instance[element.io]=chat.fedoraproject.org"
+# Link to matrix rooms and usernames using a element.io web client
+# instance. Set this variable to whatever instance you have.
+# e.g. chat.fedoraproject.org, chat.opensuse.org
+CHAT_MATRIX_TO_ARGS = "web-instance[element.io]=app.element.io"
 
 STAGE_USERS_ROLE = "Stage User Managers"
 
@@ -52,5 +52,5 @@ ACCEPT_IMAGES_FROM = []
 BASSET_URL = None
 SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes
 
-# Cheat code to disable Fedora Messaging
-FEDORA_MESSAGING_ENABLED = True
+# Cheat code to toggle Fedora Messaging support
+FEDORA_MESSAGING_ENABLED = False

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,6 +36,8 @@ def app_config(ipa_cert):
         PASSWORD_POLICY={"min": 6},
         # Don't delete the role we may have in the dev env
         STAGE_USERS_ROLE="Testing Stage Users Admins",
+        # Turn on Fedora Messaging
+        FEDORA_MESSAGING_ENABLED=True,
     )
 
 

--- a/tests/unit/controller/test_registration.py
+++ b/tests/unit/controller/test_registration.py
@@ -578,7 +578,7 @@ def test_invalid_email(client, post_data_step_1):
 @pytest.mark.vcr()
 def test_blocklisted_email(client, post_data_step_1):
     """Register a user with an invalid email address"""
-    post_data_step_1["register-mail"] = "dude@fedoraproject.org"
+    post_data_step_1["register-mail"] = "dude@example.org"
     result = client.post('/', data=post_data_step_1)
     assert_form_field_error(
         result,

--- a/tests/unit/utility/test_templates.py
+++ b/tests/unit/utility/test_templates.py
@@ -27,10 +27,10 @@ from noggin.utility.templates import format_channel, format_nickname
             "matrix:/username",
             {
                 "href": (
-                    "https://matrix.to/#/@username:fedora.im"
-                    "?web-instance[element.io]=chat.fedoraproject.org"
+                    "https://matrix.to/#/@username:matrix.org"
+                    "?web-instance[element.io]=app.element.io"
                 ),
-                "title": "Matrix on fedora.im",
+                "title": "Matrix on matrix.org",
                 "name": "@username",
             },
         ),
@@ -39,7 +39,7 @@ from noggin.utility.templates import format_channel, format_nickname
             {
                 "href": (
                     "https://matrix.to/#/@username:unit.tests"
-                    "?web-instance[element.io]=chat.fedoraproject.org"
+                    "?web-instance[element.io]=app.element.io"
                 ),
                 "title": "Matrix on unit.tests",
                 "name": "@username:unit.tests",
@@ -123,9 +123,9 @@ def test_format_nickname_invalid_with_config(app, request_context, mocker):
         (
             "matrix:/channel",
             {
-                "href": "https://matrix.to/#/#channel:fedora.im",
-                "title": "Matrix on fedora.im",
-                "name": "#channel:fedora.im",
+                "href": "https://matrix.to/#/#channel:matrix.org",
+                "title": "Matrix on matrix.org",
+                "name": "#channel:matrix.org",
             },
         ),
         (


### PR DESCRIPTION
This makes it easier for third-party (non-Fedora) deployments of Noggin to work.