### PR TITLE
Store the chosen IPA server in the session for both the user and admin client

### DIFF
--- a/news/1079.bug
+++ b/news/1079.bug
@@ -1,0 +1,3 @@
+Store the chosen IPA server in the session for both the user client and the
+admin client. This prevents admin commands from running on a server and user
+commands running on another.

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -64,7 +64,7 @@ def otp_sync():
     if form.validate_on_submit():
         with handle_form_errors(form):
             try:
-                ipa = untouched_ipa_client(current_app)
+                ipa = untouched_ipa_client(current_app, session)
                 ipa.otptoken_sync(
                     user=form.username.data,
                     password=form.password.data,

--- a/noggin/controller/password.py
+++ b/noggin/controller/password.py
@@ -38,7 +38,7 @@ from . import blueprint as bp
 
 def _validate_change_pw_form(form, username, ipa=None):
     if ipa is None:
-        ipa = untouched_ipa_client(current_app)
+        ipa = untouched_ipa_client(current_app, session)
 
     current_password = form.current_password.data
     password = form.password.data
@@ -236,7 +236,7 @@ def forgot_password_change():
             # example)
             ipa_admin.user_mod(username, userpassword=temp_password)
             # Change the password as the user, so it's not expired.
-            ipa = untouched_ipa_client(current_app)
+            ipa = untouched_ipa_client(current_app, session)
             ipa.change_password(
                 username,
                 new_password=password,

--- a/noggin/controller/registration.py
+++ b/noggin/controller/registration.py
@@ -264,7 +264,7 @@ def activate_account():
                 # First, set it as an admin. This will mark it as expired.
                 ipa_admin.user_mod(user.username, userpassword=password)
                 # And now we set it again as the user, so it is not expired any more.
-                ipa = untouched_ipa_client(current_app)
+                ipa = untouched_ipa_client(current_app, session)
                 ipa.change_password(
                     user.username, new_password=password, old_password=password
                 )

--- a/noggin/security/ipa_admin.py
+++ b/noggin/security/ipa_admin.py
@@ -1,9 +1,8 @@
-import random
 from functools import wraps
 
-from flask import current_app
+from flask import current_app, session
 
-from .ipa import Client
+from .ipa import choose_server, Client
 
 
 class IPAAdmin:
@@ -66,7 +65,7 @@ class IPAAdmin:
         username = current_app.extensions["ipa-admin"]["username"]
         password = current_app.extensions["ipa-admin"]["password"]
         client = Client(
-            random.choice(current_app.config['FREEIPA_SERVERS']),
+            choose_server(current_app, session),
             verify_ssl=current_app.config['FREEIPA_CACERT'],
         )
         client.login(username, password)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,7 @@ import tempfile
 
 import pytest
 import python_freeipa
+from flask import session
 from vcr import VCR
 
 from noggin.app import create_app, ipa_admin
@@ -158,7 +159,7 @@ def make_user(ipa_testing_config, app):
             o_loginshell='/bin/bash',
             fascreationtime=f"{now.isoformat()}Z",
         )
-        ipa = untouched_ipa_client(app)
+        ipa = untouched_ipa_client(app, session)
         ipa.change_password(name, password, password)
         created_users.append(name)
 

--- a/tests/unit/controller/test_forgot_password.py
+++ b/tests/unit/controller/test_forgot_password.py
@@ -6,7 +6,7 @@ import pytest
 import python_freeipa
 from bs4 import BeautifulSoup
 from fedora_messaging import testing as fml_testing
-from flask import current_app
+from flask import current_app, session
 
 from noggin.app import ipa_admin, mailer
 from noggin.representation.user import User
@@ -75,7 +75,7 @@ def dummy_user_no_password(ipa_testing_config, app):
         o_loginshell='/bin/bash',
         fascreationtime=f"{now.isoformat()}Z",
     )
-    # ipa = untouched_ipa_client(app)
+    # ipa = untouched_ipa_client(app, session)
     # ipa.change_password(name, password, password)
 
     yield
@@ -278,7 +278,7 @@ def test_change_too_old(client, token_for_dummy_user, patched_lock):
 def test_change_recent_password_change(
     client, dummy_user, dummy_group, token_for_dummy_user, patched_lock_active
 ):
-    ipa = untouched_ipa_client(current_app)
+    ipa = untouched_ipa_client(current_app, session)
     ipa.change_password("dummy", "dummy_password", "dummy_password")
     result = client.get(f'/forgot-password/change?token={token_for_dummy_user}')
     patched_lock_active["delete"].assert_called_once()


### PR DESCRIPTION
This prevents admin commands from running on a server and user commands running on another.

Fixes: #1079