### PR TITLE
Tell gitleaks to ignore somethings

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,24 @@
+[allowlist]
+paths = [
+
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_password_policy_rejected.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_password_with_otp_not_given.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_password_with_otp_wrong_value.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_with_otp.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_no_earlier_password_change.yaml""",
+    """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_password_too_short.yaml""",
+]
+# these commits all contain python files that use a password that is used for the tests.
+# the same password has been there for a while, but keeps getting flagged because the file
+# has been moved around and renamed. 
+# 54f8749f986ebb755b1219160fdf4e6b5132e77f/tests/unit/controller/test_authentication.py#L148
+# we also now have a gitleaks:allow on this line too.
+commits = [
+    "187716c9480916cf15a4f5f44e9465ae5455219e",
+    "b7b306e6518c750583c98b3709ab6fc5df0c9f3d",
+    "ee0a0289a56bf7a97c52acc7c90892fcabce97a6",
+    "3fc59f0905b6c97984d3d1f1f2baab90502e9cbd",
+    "3dd46cf59d439c21ea2bd846b75f58fbe70c9658",
+    "226f904f1886516d834044db054568a25042a2a9",
+]

--- a/tests/unit/controller/test_authentication.py
+++ b/tests/unit/controller/test_authentication.py
@@ -145,7 +145,10 @@ def test_login_no_username(client):
     """Test not giving a username"""
     result = client.post(
         '/',
-        data={"login-password": "n:nPv{P].9}]!q$RE%w<38@", "login-submit": "1"},
+        data={
+            "login-password": "n:nPv{P].9}]!q$RE%w<38@",
+            "login-submit": "1",
+        },  # gitleaks:allow
         follow_redirects=True,
     )
     assert_form_field_error(


### PR DESCRIPTION
Our tests (and the VCR cassettes) have passwords that are used for testing purposes that gitleaks thinks are leaks. This tells gitleaks to ignore these findings.