### PR TITLE
Fix the boolean values not showing up in the profile page

### DIFF
--- a/news/1202.bug
+++ b/news/1202.bug
@@ -1,0 +1,1 @@
+Fix the boolean values (checkboxes) not showing up in the profile page

--- a/noggin/representation/base.py
+++ b/noggin/representation/base.py
@@ -14,7 +14,7 @@ def attr_to_list(value):
 def attr_to_bool(value):
     if not value:
         return False
-    return value[0] == "TRUE"
+    return value[0] in (True, "TRUE")
 
 
 def attr_to_date(value):

--- a/tests/unit/representation/test_base.py
+++ b/tests/unit/representation/test_base.py
@@ -44,3 +44,13 @@ def test_pkey_missing_map():
 
     with pytest.raises(NotImplementedError):
         Dummy.get_ipa_pkey()
+
+
+@pytest.mark.parametrize("value", [True, "TRUE"])
+def test_bool(value):
+    class Dummy(Representation):
+        attr_names = {"boolean_attr": "boolean_attr"}
+        attr_types = {"boolean_attr": "bool"}
+
+    obj = Dummy({"boolean_attr": [value]})
+    assert obj.boolean_attr is True


### PR DESCRIPTION
Fix: #1202