### PR TITLE
FAS template: Update Common Issues footer link

### DIFF
--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -89,7 +89,7 @@
                         <dt class="text-uppercase h4"><strong>Support</strong></dt>
                         <dd><a href="https://fedoraproject.org/wiki/Communicating_and_getting_help">Get Help</a></dd>
                         <dd><a href="https://ask.fedoraproject.org/">Ask Fedora</a></dd>
-                        <dd><a href="https://fedoraproject.org/wiki/Common_F33_bugs">Common Bugs</a></dd>
+                        <dd><a href="https://discussion.fedoraproject.org/c/ask/common-issues/">Common Issues</a></dd>
                         <dd><a href="https://developer.fedoraproject.org/">Fedora Developer Portal</a></dd>
                     </dl>
                 </div>


### PR DESCRIPTION
This PR replaces the outdated "Common Bugs" link in the FAS template's footer block (pointing to Fedora 33 Common Bugs) with a "Common Issues" link that points to the relevant Fedora Discussions category, which is now the official list of common bugs.

Fixes #1334