### PR TITLE
Fix the block/macro syntax from the OpenSUSE theme 

### DIFF
--- a/noggin/themes/openSUSE/templates/main.html
+++ b/noggin/themes/openSUSE/templates/main.html
@@ -92,7 +92,7 @@
       <strong>{{_("Connect")}}</strong>
       <a href="https://connect.opensuse.org/pg/profile/{{ user.username }}">{{ user.username }}</a>
     </li>
-{% endblock %}
+{% endmacro %}
 
 {% macro front_page_blurb() %}
 <h2 class="display-4">{{_("Welcome to noggin!")}}</h2>


### PR DESCRIPTION
Replace 'endblock' to 'endmacro' to fix the OpenSUSE theme

Fixes #1346

Screenshots

![image](https://github.com/fedora-infra/noggin/assets/49605954/9c08a787-0a7e-4b70-a6b8-25b0cef992b1)

![image](https://github.com/fedora-infra/noggin/assets/49605954/cfbfbfc3-26d4-4964-8b19-59dc8fa5fa68)

![image](https://github.com/fedora-infra/noggin/assets/49605954/98ef8c0c-905d-498c-9ee0-d1a504e03e7c)

![image](https://github.com/fedora-infra/noggin/assets/49605954/3b58f291-ffda-4f55-91f2-2510f52069a2)
