### PR TITLE
Use flex utils rather than mediaobjects in the templates

### DIFF
--- a/noggin/templates/group.html
+++ b/noggin/templates/group.html
@@ -76,9 +76,11 @@
             {% for sponsor in sponsors|sort(attribute='username') %}
               <li class="col-lg-3 col-md-4 col-sm-6">
                 <div class="card card-body mb-4 px-2 py-3">
-                <div class="media align-items-center">
-                  <img src="{{ gravatar(sponsor.mail if sponsor.mail else 'default', 50) }}" alt="gravatar">
-                  <div class="media-body ms-2">
+                <div class="d-flex align-items-center">
+                  <div class="flex-shrink-0">
+                    <img src="{{ gravatar(sponsor.mail if sponsor.mail else 'default', 50) }}" alt="gravatar">
+                  </div>
+                  <div class="flex-grow-1 ms-2">
                       <div class="my-0 font-weight-bold">
                         <a href="{{ url_for('.user', username=sponsor.username) }}">
                           <span class="title">{{ sponsor.username }}</span>
@@ -125,9 +127,11 @@
             {% for member in members.items %}
               <li class="col-lg-3 col-md-4 col-sm-6">
               <div class="card card-body mb-4 px-2 py-3">
-                <div class="media align-items-center">
-                  <img src="{{ gravatar(member.mail if member.mail else 'default', 50) }}" alt="gravatar">
-                  <div class="media-body ms-2">
+                <div class="d-flex align-items-center">
+                  <div class="flex-shrink-0">
+                    <img src="{{ gravatar(member.mail if member.mail else 'default', 50) }}" alt="gravatar">
+                  </div>
+                  <div class="flex-grow-1 ms-2">
                       <div class="my-0 font-weight-bold">
                         <a href="{{ url_for('.user', username=member.username) }}">
                           <span class="title">{{ member.username }}</span>

--- a/noggin/templates/groups.html
+++ b/noggin/templates/groups.html
@@ -15,9 +15,9 @@
         <ul class="list-group">
           {% for group in groups.items %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div class="media align-items-center">
+              <div class="d-flex align-items-center">
                 <i class="fa fa-group fa-2x text-muted me-3"></i>
-                <div class="media-body">
+                <div class="flex-grow-1">
                     <div class="my-0 font-weight-bold">
                       <a href="{{ url_for('.group', groupname=group.name) }}">
                         <span class="title">{{ group.name }}</span>

--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -123,9 +123,9 @@
           </li>
           {% for agreement in user.agreements %}
             <li class="list-group-item d-flex justify-content-between align-items-center">
-              <div class="media align-items-center">
+              <div class="d-flex align-items-center">
                 <i class="fa fa-fw fa-check-circle fa-2x text-muted me-3"></i>
-                <div class="media-body">
+                <div class="flex-grow-1">
                     <div class="my-0 font-weight-bold">
                       <a href="{{ url_for('.user_settings_agreements', username=user.username) }}">
                         <span class="title">{{ agreement }}</span>
@@ -141,9 +141,9 @@
           {% endfor %}
           {% for group in groups %}
               <li class="list-group-item d-flex justify-content-between align-items-center">
-                <div class="media align-items-center">
+                <div class="d-flex align-items-center">
                   <i class="fa fa-fw fa-group fa-2x text-muted me-3"></i>
-                  <div class="media-body">
+                  <div class="flex-grow-1">
                       <div class="my-0 font-weight-bold">
                         <a href="{{ url_for('.group', groupname=group.name) }}">
                           <span class="title">{{ group.name }}</span>


### PR DESCRIPTION
Not sure what happened, but these changes were done in the big bootstrap PR, but i did something after resolving the conflicts in the github webui that blew them away. anyhoo, here they are in a seperate PR and commit.