### PR TITLE
Fix noggin-aaa package name in installation docs

### DIFF
--- a/docs/installation/02-freeipa-client.rst
+++ b/docs/installation/02-freeipa-client.rst
@@ -279,7 +279,7 @@ Installing from PyPI
 
    .. code-block:: shell
 
-        pip3 install noggin noggin-messages
+        pip3 install noggin-aaa noggin-messages
 
 2. Download the ``noggin.cfg.example`` file from
    `here <https://github.com/fedora-infra/noggin/raw/v1.9.0/deployment/noggin.cfg.example>`__


### PR DESCRIPTION
Correct Python package name should be `noggin-aaa`: https://pypi.org/project/noggin-aaa/

From https://pypi.org/project/noggin/:
> noggin is a simple tool for logging and plotting measurements during an experiment. [...]