### PR TITLE
Revise the .gitleaks.toml to avoid false-alarms

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,11 +9,13 @@ paths = [
     """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_no_earlier_password_change.yaml""",
     """noggin/tests/unit/controller/cassettes/test_forgot_password/test_change_post_password_too_short.yaml""",
 ]
+
 # these commits all contain python files that use a password that is used for the tests.
 # the same password has been there for a while, but keeps getting flagged because the file
-# has been moved around and renamed. 
+# has been moved around and renamed.
 # 54f8749f986ebb755b1219160fdf4e6b5132e77f/tests/unit/controller/test_authentication.py#L148
 # we also now have a gitleaks:allow on this line too.
+
 commits = [
     "187716c9480916cf15a4f5f44e9465ae5455219e",
     "b7b306e6518c750583c98b3709ab6fc5df0c9f3d",
@@ -21,4 +23,6 @@ commits = [
     "3fc59f0905b6c97984d3d1f1f2baab90502e9cbd",
     "3dd46cf59d439c21ea2bd846b75f58fbe70c9658",
     "226f904f1886516d834044db054568a25042a2a9",
+    "c23a473b04588374aeef2c7f16b43239e70ee844",
+    "108a9b58b218dea01a9c5d003f6e681ba5c857c1",
 ]


### PR DESCRIPTION
I have persisted in keeping `c23a473b04588374aeef2c7f16b43239e70ee844` even when it was rebased at some point (so technically the commit is no longer a part of the repository) but the view is still available on GitHub, opening doors to more such false alarms. One redundant line is nothing in front of it. 