### PR TITLE
Configure nginx to listen on IPv6 interfaces

### DIFF
--- a/deployment/nginx.conf
+++ b/deployment/nginx.conf
@@ -1,11 +1,13 @@
 #server {
     #listen 80;
+    #listen [::]:80;
     #server_name localhost.localdomain;
     #return 301 https://localhost.localdomain$request_uri;
 #}
 
 #server {
     #listen 443 ssl;
+    #listen [::]:443 ssl;
 
     #server_name localhost.localdomain;
 


### PR DESCRIPTION
Following the setup documentation, I found that nginx does not listen on IPv6 addresses by default, but only IPv4.
This MR enables nginx to listen on both IPv4 and IPv6 incoming connections.