### PR TITLE
💄 User template: Move account creation date up in the profile

### DIFF
--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -18,6 +18,12 @@
             {% endif %}
           </div>
           <ul class="list-group list-group-flush" id="user_attributes">
+              {% if user.creation_time %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <strong title="{{_("Created on")}}"><i class="fa fa-fw fa-plus-circle"></i> {{_("Created on")}}</strong>
+                  {{ user.creation_time|dateformat }}
+                </li>
+              {% endif %}
               {% if user.pronouns %}
                 <li class="list-group-item d-flex justify-content-between">
                   <strong title="{{_('Pronouns')}}">
@@ -126,12 +132,6 @@
                 </li>
               {% endif %}
               {{ userlinks() if userlinks is defined }}
-              {% if user.creation_time %}
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                  <strong title="{{_("Created On")}}"><i class="fa fa-fw fa-plus-circle"></i> {{_("Created On")}}</strong>
-                  {{ user.creation_time|dateformat }}
-                </li>
-              {% endif %}
           </ul>
       </div>
       <div class="col-md-8">

--- a/tests/unit/controller/test_user.py
+++ b/tests/unit/controller/test_user.py
@@ -712,4 +712,4 @@ def test_user_private(client, logged_in_dummy_user, make_user):
     assert user_attributes is not None
     assert len(user_attributes.find_all("li")) == 1
     attr = user_attributes.select_one("li").select_one("strong")
-    assert attr["title"] == "Created On"
+    assert attr["title"] == "Created on"


### PR DESCRIPTION
This commit makes the account creation date appear higher up in the user profile. In FAS 2, this information was very visible and prominent in user profiles. It is annoying for me to scroll to the bottom of an account for this information. This is a minor UI tweak to make it easier to find. :D