### PR TITLE
Add Additional Email and use a Checkbox to Toggle Display of Fedora Project Email Alias

### DIFF
--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -109,7 +109,7 @@ def _user_mod(ipa, form, user, details, redirect_to):
                 raise FormError("non_field_errors", e.message)
         flash(
             Markup(  # nosec B704
-                f'Profile Updated: <a href="{url_for(".user", username=user.username)}">'
+                f'Profile Updated: <a href=\"{url_for(".user", username=user.username)}\">'
                 'view your profile</a>'
             ),
             'success',
@@ -190,6 +190,7 @@ def user_settings_email(ipa, username):
     user = User(user_or_404(ipa, username, all=True))
     form = UserSettingsEmailForm()
 
+    # Populate the web form with user settings
     if request.method == "GET":
         form.mail.data = user.primary_email
         form.rhbz_mail.data = user.rhbz_mail
@@ -269,12 +270,11 @@ def user_settings_email(ipa, username):
 
         with handle_form_errors(form):
             if display_fedora_email and not has_tag:
-                ipa.user_mod(user.username, setattr=[f"description={description_tag}"])
+                ipa.user_mod(user.username, addattr=[f"description={description_tag}"])
                 flash("Display preference updated.", "success")
                 mods_made = True
             elif not display_fedora_email and has_tag:
-                # Per instructions, set description to empty string on uncheck
-                ipa.user_mod(user.username, setattr=["description="])
+                ipa.user_mod(user.username, delattr=[f"description={description_tag}"])
                 flash("Display preference updated.", "success")
                 mods_made = True
 
@@ -503,7 +503,7 @@ def user_settings_otp_disable(ipa, username):
         except python_freeipa.exceptions.BadRequest as e:
             if (
                 e.message
-                == "Server is unwilling to perform: Can\'t disable last active token"
+                == "Server is unwilling to perform: Can't disable last active token"
             ):
                 flash(_('Sorry, You cannot disable your last active token.'), 'warning')
             else:
@@ -564,7 +564,7 @@ def user_settings_otp_delete(ipa, username):
         except python_freeipa.exceptions.BadRequest as e:
             if (
                 e.message
-                == "Server is unwilling to perform: Can\'t delete last active token"
+                == "Server is unwilling to perform: Can't delete last active token"
             ):
                 flash(_('Sorry, You cannot delete your last active token.'), 'warning')
             else:
@@ -592,7 +592,7 @@ def handle_agreement_form(ipa, user, form):
         current_app.logger.error(f"Cannot sign the agreement {agreement_name!r}: {e}")
         flash(
             _(
-                'Cannot sign the agreement "%s": %s',
+                'Cannot sign the agreement "%(name)s": %(error)s',
                 name=agreement_name,
                 error=e,
             ),
@@ -600,7 +600,7 @@ def handle_agreement_form(ipa, user, form):
         )
     else:
         flash(
-            _('You signed the "%s" agreement.', name=agreement_name),
+            _('You signed the "%(name)s" agreement.', name=agreement_name),
             "success",
         )
     return redirect(request.url)

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -4,6 +4,7 @@ from base64 import b32encode
 import jwt
 import python_freeipa
 from flask import (
+    abort,
     current_app,
     flash,
     g,
@@ -108,7 +109,7 @@ def _user_mod(ipa, form, user, details, redirect_to):
                 raise FormError("non_field_errors", e.message)
         flash(
             Markup(  # nosec B704
-                f'Profile Updated: <a href=\"{url_for(".user", username=user.username)}\">'
+                f'Profile Updated: <a href="{url_for(".user", username=user.username)}">'
                 'view your profile</a>'
             ),
             'success',
@@ -186,62 +187,111 @@ def _send_validation_email(user, attr, value):
 @with_ipa()
 @require_self
 def user_settings_email(ipa, username):
-    user = User(user_or_404(ipa, username))
-    form = UserSettingsEmailForm(obj=user)
-    attrs = ["mail", "rhbz_mail"]
+    user = User(user_or_404(ipa, username, all=True))
+    form = UserSettingsEmailForm()
+
+    if request.method == "GET":
+        form.mail.data = user.primary_email
+        form.rhbz_mail.data = user.rhbz_mail
+        if user.emails:
+            for email in user.emails[1:]:
+                form.extra_mails.append_entry(email)
+        if user.description and "display_fedoraproject_email=true" in user.description:
+            form.display_fedoraproject_email.data = True
 
     if form.validate_on_submit():
-        change_now = {}
-        needs_validation = {}
-        for attr in attrs:
-            value = getattr(form, attr).data
-            old_value = getattr(user, attr) or ""
-            option_name = user.get_attr_option(attr)
-            if value != old_value:
-                if not value:
-                    # email has been removed
-                    change_now[option_name] = value
-                else:
-                    needs_validation[attr] = value
-        should_redirect = False
-        if change_now:
-            should_redirect = _user_mod(
-                ipa,
-                form,
-                user,
-                change_now,
-                ".user_settings_email",
-            )
-        if needs_validation:
-            for attr, value in needs_validation.items():
-                try:
-                    _send_validation_email(user, attr, value)
-                except ConnectionRefusedError as e:
-                    current_app.logger.error(
-                        f"Impossible to send an address validation email: {e}"
-                    )
-                    form["non_field_errors"].errors.append(
-                        _(
-                            "We could not send you the address validation email, please retry later"
-                        )
-                    )
-                    break
+        mods_made = False
+        # We have to handle redirects manually so we can process all fields before returning
+        should_redirect = None
+
+        # Handle rhbz_mail separately, as it has its own attribute
+        rhbz_mail_val = form.rhbz_mail.data or ""
+        if rhbz_mail_val != (user.rhbz_mail or ""):
+            if not rhbz_mail_val:
+                with handle_form_errors(form):
+                    ipa.user_mod(user.username, o_fasrhbzemail="")
+                flash("Red Hat Bugzilla email removed.", "success")
+                mods_made = True
+            else:
+                _send_validation_email(user, "rhbz_mail", rhbz_mail_val)
                 flash(
-                    _(
-                        "The email address %(mail)s needs to be validated. Please check your "
-                        "inbox and click on the link to proceed. If you can't find the email "
-                        "in a couple minutes, check your spam folder.",
-                        mail=value,
-                    ),
+                    f"A validation email has been sent to {rhbz_mail_val} for your "
+                    "Red Hat Bugzilla email.",
                     "info",
                 )
-                should_redirect = redirect(
-                    url_for('.user_settings_email', username=user.username)
+                mods_made = True
+
+        # Handle mail attributes
+        old_emails = user.emails or []
+        new_emails_list = [form.mail.data] + [
+            e.data for e in form.extra_mails if e.data
+        ]
+
+        added_emails = [e for e in new_emails_list if e not in old_emails]
+        removed_emails = [e for e in old_emails if e not in new_emails_list]
+        reordered = (
+            not added_emails
+            and not removed_emails
+            and old_emails != new_emails_list
+        )
+
+        with handle_form_errors(form):
+            if removed_emails:
+                ipa.user_mod(user.username, delattr=[f"mail={email}" for email in removed_emails])
+                flash(f"Email(s) removed: {', '.join(removed_emails)}", "success")
+                mods_made = True
+
+            if reordered:
+                ipa.user_mod(user.username, o_mail=new_emails_list)
+                flash("Email order has been updated.", "success")
+                mods_made = True
+
+        for email in added_emails:
+            try:
+                _send_validation_email(user, "mail", email)
+                flash(f"A validation email has been sent to {email}", "info")
+                mods_made = True
+            except ConnectionRefusedError as e:
+                current_app.logger.error(
+                    f"Impossible to send an address validation email: {e}"
                 )
+                form["non_field_errors"].errors.append(
+                    _(
+                        "We could not send you the address validation email, please retry later"
+                    )
+                )
+                break
+
+        # Handle the display_fedoraproject_email checkbox
+        display_fedora_email = form.display_fedoraproject_email.data
+        description_tag = "display_fedoraproject_email=true"
+        has_tag = user.description and description_tag in user.description
+
+        with handle_form_errors(form):
+            if display_fedora_email and not has_tag:
+                ipa.user_mod(user.username, setattr=[f"description={description_tag}"])
+                flash("Display preference updated.", "success")
+                mods_made = True
+            elif not display_fedora_email and has_tag:
+                # Per instructions, set description to empty string on uncheck
+                ipa.user_mod(user.username, setattr=["description="])
+                flash("Display preference updated.", "success")
+                mods_made = True
+
+        if mods_made and not form.errors:
+            should_redirect = redirect(
+                url_for('.user_settings_email', username=user.username)
+            )
+
         if should_redirect:
             return should_redirect
-        if not change_now and not needs_validation:
+
+        if not mods_made and not form.errors:
             form["non_field_errors"].errors.append(_("No modifications."))
+
+    # Add an empty field for new emails on GET, or if POST fails validation
+    if not form.errors:
+        form.extra_mails.append_entry()
 
     return render_template(
         'user-settings-email.html', user=user, form=form, activetab="email"
@@ -282,22 +332,27 @@ def user_settings_email_validate(ipa, username):
     form = BaseForm()
 
     if form.validate_on_submit():
-        option_name = user.get_attr_option(token["attr"])
-        result = _user_mod(
-            ipa,
-            form,
-            user,
-            {option_name: value},
-            ".user_settings_email",
-        )
-        if result:
-            return result
+        with handle_form_errors(form):
+            if attr == "mail":
+                ipa.user_mod(user.username, addattr=[f"mail={value}"])
+                flash(_("Email address %(mail)s added.", mail=value), "success")
+            else:
+                # Fallback for rhbz_mail and other potential fields
+                option_name = user.get_attr_option(attr)
+                ipa.user_mod(user.username, **{option_name: value})
+                flash(
+                    _("Email address %(mail)s verified and updated.", mail=value),
+                    "success",
+                )
+        return redirect(url_for(".user_settings_email", username=user.username))
 
     return render_template(
         'user-settings-email-validation.html',
         form=form,
         user=user,
-        attr_label=UserSettingsEmailForm()[attr].label,
+        attr_label=UserSettingsEmailForm().mail.label
+        if attr == "mail"
+        else UserSettingsEmailForm()[attr].label,
         value=value,
     )
 
@@ -448,7 +503,7 @@ def user_settings_otp_disable(ipa, username):
         except python_freeipa.exceptions.BadRequest as e:
             if (
                 e.message
-                == "Server is unwilling to perform: Can't disable last active token"
+                == "Server is unwilling to perform: Can\'t disable last active token"
             ):
                 flash(_('Sorry, You cannot disable your last active token.'), 'warning')
             else:
@@ -509,7 +564,7 @@ def user_settings_otp_delete(ipa, username):
         except python_freeipa.exceptions.BadRequest as e:
             if (
                 e.message
-                == "Server is unwilling to perform: Can't delete last active token"
+                == "Server is unwilling to perform: Can\'t delete last active token"
             ):
                 flash(_('Sorry, You cannot delete your last active token.'), 'warning')
             else:
@@ -537,7 +592,7 @@ def handle_agreement_form(ipa, user, form):
         current_app.logger.error(f"Cannot sign the agreement {agreement_name!r}: {e}")
         flash(
             _(
-                'Cannot sign the agreement "%(name)s": %(error)s',
+                'Cannot sign the agreement "%s": %s',
                 name=agreement_name,
                 error=e,
             ),
@@ -545,7 +600,7 @@ def handle_agreement_form(ipa, user, form):
         )
     else:
         flash(
-            _('You signed the "%(name)s" agreement.', name=agreement_name),
+            _('You signed the "%s" agreement.', name=agreement_name),
             "success",
         )
     return redirect(request.url)

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -171,6 +171,23 @@ class UserSettingsEmailForm(BaseForm):
         ],
     )
 
+    extra_mails = FieldList(
+        EmailField(
+            _('Additional email'),
+            validators=[Optional(), Email(message=_('Email must be valid'))],
+        ),
+        label=_('Additional emails'),
+    )
+
+    display_fedoraproject_email = BooleanField(
+        _('Display Fedora Project email alias'),
+        description=_(
+            "When checked, Noggin will display your @fedoraproject.org address on your profile "
+            "and use it for Gravatar if you have one."
+        ),
+        validators=[Optional()],
+    )
+
     rhbz_mail = EmailField(_('Red Hat Bugzilla Email'), validators=[Optional()])
 
 

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -169,6 +169,7 @@ class UserSettingsEmailForm(BaseForm):
             DataRequired(message=_('Email must not be empty')),
             Email(message=_('Email must be valid')),
         ],
+        render_kw={'readonly': True}
     )
 
     extra_mails = FieldList(

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -169,9 +169,9 @@ class UserSettingsEmailForm(BaseForm):
             DataRequired(message=_('Email must not be empty')),
             Email(message=_('Email must be valid')),
         ],
-        render_kw={'readonly': True}
     )
 
+    # Collect additional user emails
     extra_mails = FieldList(
         EmailField(
             _('Additional email'),
@@ -180,6 +180,7 @@ class UserSettingsEmailForm(BaseForm):
         label=_('Additional emails'),
     )
 
+    # Checkbox to display Fedora Project email alias
     display_fedoraproject_email = BooleanField(
         _('Display Fedora Project email alias'),
         description=_(

--- a/noggin/representation/user.py
+++ b/noggin/representation/user.py
@@ -10,6 +10,7 @@ class User(Representation):
         "displayname": "displayname",
         "gecos": "gecos",
         "mail": "mail",
+        "description": "description",
         "sshpubkeys": "ipasshpubkey",
         "last_password_change": "krblastpwdchange",
         "agreements": "memberof_fasagreement",
@@ -30,6 +31,8 @@ class User(Representation):
         "rss_url": "fasrssurl",
     }
     attr_types = {
+        "mail": "list",
+        "description": "list",
         "sshpubkeys": "list",
         "ircnick": "list",
         "website_url": "list",
@@ -66,6 +69,33 @@ class User(Representation):
         direct_groups = self.raw.get("memberof_group", [])
         indirect_groups = self.raw.get("memberofindirect_group", [])
         return CONVERTERS["list"](direct_groups + indirect_groups)
+
+    @property
+    def emails(self):
+        return self.mail
+
+    @property
+    def primary_email(self):
+        return self.emails[0] if self.emails else None
+
+    @property
+    def fedora_alias(self):
+        if not self.emails:
+            return None
+        for email in self.emails:
+            if email.endswith("@fedoraproject.org"):
+                return email
+        return None
+
+    @property
+    def display_email(self):
+        if (
+            self.fedora_alias
+            and self.description
+            and "display_fedoraproject_email=true" in self.description
+        ):
+            return self.fedora_alias
+        return self.primary_email
 
     def anonymize(self):
         not_hidden = [

--- a/noggin/templates/user-settings-email.html
+++ b/noggin/templates/user-settings-email.html
@@ -28,7 +28,7 @@
       <div class="mb-3">{{ macros.with_errors(form.display_fedoraproject_email) }}</div>
       {% if form.display_fedoraproject_email.data and not user.fedora_alias %}
         <div class="alert alert-warning">
-          {{ _('You have enabled displaying your Fedora Project email alias, but you do not have one. Please add %(username)s@fedoraproject.org to your emails.', username=user.username) }}
+          {{ _('You have enabled displaying your Fedora Project email alias, but you do not have one. Please add your @fedoraproject.org to your emails.') }}
         </div>
       {% endif %}
 

--- a/noggin/templates/user-settings-email.html
+++ b/noggin/templates/user-settings-email.html
@@ -6,7 +6,34 @@
 <form class="needs-validation" action="{{ url_for('.user_settings_email', username=user.username) }}" method="post" novalidate>
     {{ form.csrf_token }}
     <div class="card-body">
-      <div class="mb-3">{{ macros.with_errors(form.mail) }}</div>
+      <div class="mb-3">{{ macros.with_errors(form.mail, label=_('Primary E-mail Address')) }}</div>
+
+      <hr>
+
+      <div class="mb-3" id="extra-emails-fields">
+        <label class="form-label">{{ form.extra_mails.label }}</label>
+        <div id="extra-emails-container">
+          {% for subfield in form.extra_mails %}
+            <div class="input-group mb-3">
+              {{ macros.with_errors(subfield, placeholder=_("user@example.com"), hide_label=True) }}
+              <button class="btn btn-danger remove-field" type="button"><i class="fa fa-trash"></i></button>
+            </div>
+          {% endfor %}
+        </div>
+        <button type="button" class="btn btn-secondary btn-sm" id="add-email-btn">{{_('Add another email')}}</button>
+      </div>
+
+      <hr>
+
+      <div class="mb-3">{{ macros.with_errors(form.display_fedoraproject_email) }}</div>
+      {% if form.display_fedoraproject_email.data and not user.fedora_alias %}
+        <div class="alert alert-warning">
+          {{ _('You have enabled displaying your Fedora Project email alias, but you do not have one. Please add %(username)s@fedoraproject.org to your emails.', username=user.username) }}
+        </div>
+      {% endif %}
+
+      <hr>
+
       <div class="mb-3">{{ macros.with_errors(form.rhbz_mail) }}</div>
     </div>
     <div class="card-footer d-flex justify-content-between">
@@ -19,4 +46,34 @@
 {% block scripts %}
   {{ super () }}
   {{ macros.unsaved_changes() }}
+  <script nonce="{{ csp_nonce() }}">
+    document.addEventListener('DOMContentLoaded', function () {
+      const container = document.getElementById('extra-emails-container');
+      const addButton = document.getElementById('add-email-btn');
+      let fieldIndex = {{ form.extra_mails|length }};
+
+      addButton.addEventListener('click', function() {
+        const newFieldHTML = `
+        <div class="input-group mb-3">
+          <input class="form-control" id="extra_mails-${fieldIndex}" name="extra_mails-${fieldIndex}" type="email" value="" placeholder="user@example.com">
+          <button class="btn btn-danger remove-field" type="button"><i class="fa fa-trash"></i></button>
+        </div>`;
+        const newField = document.createElement('div');
+        // a bit of a hack to parse the html
+        newField.innerHTML = newFieldHTML;
+        container.appendChild(newField.firstElementChild);
+        fieldIndex++;
+      });
+
+      container.addEventListener('click', function(e) {
+        if (e.target && e.target.closest('.remove-field')) {
+          // Mark for deletion by clearing the value, the backend will handle it.
+          const fieldGroup = e.target.closest('.input-group');
+          const input = fieldGroup.querySelector('input');
+          input.value = "";
+          fieldGroup.style.display = 'none';
+        }
+      });
+    });
+  </script>
 {% endblock %}

--- a/noggin/templates/user-settings-email.html
+++ b/noggin/templates/user-settings-email.html
@@ -6,6 +6,7 @@
 <form class="needs-validation" action="{{ url_for('.user_settings_email', username=user.username) }}" method="post" novalidate>
     {{ form.csrf_token }}
     <div class="card-body">
+      {# Create the main body of the user seettings form. Render fields and buttons. #}
       <div class="mb-3">{{ macros.with_errors(form.mail, label=_('Primary E-mail Address')) }}</div>
 
       <hr>
@@ -46,6 +47,8 @@
 {% block scripts %}
   {{ super () }}
   {{ macros.unsaved_changes() }}
+
+  {# Add JavaScript to handle dynamic addition and removal of email fields #}
   <script nonce="{{ csp_nonce() }}">
     document.addEventListener('DOMContentLoaded', function () {
       const container = document.getElementById('extra-emails-container');
@@ -59,7 +62,7 @@
           <button class="btn btn-danger remove-field" type="button"><i class="fa fa-trash"></i></button>
         </div>`;
         const newField = document.createElement('div');
-        // a bit of a hack to parse the html
+        
         newField.innerHTML = newFieldHTML;
         container.appendChild(newField.firstElementChild);
         fieldIndex++;

--- a/noggin/templates/user-settings-profile.html
+++ b/noggin/templates/user-settings-profile.html
@@ -8,7 +8,7 @@
 {% endblock %}
 {% block settings_content %}
   <div class="card-body border-bottom">
-    <img src="{{ gravatar(user.mail if user.mail else 'default', 100) }}" class="pb-2" alt="user avatar"/>
+    <img src="{{ gravatar(user.display_email if user.display_email else 'default', 100) }}" class="pb-2" alt="user avatar"/>
     {% set buttontext = _('Change Avatar')%}
     {%- if OPENID is defined %}
     <form method="GET" action="https://www.libravatar.org/openid/login/">

--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -8,11 +8,11 @@
     <div class="row">
       <div class="col-md-4">
           <div class="text-center">
-            <img class="w-100 border d-none d-md-block" src="{{ gravatar(user.mail if user.mail else 'default', 400) }}" alt="gravatar"/>
-            <img class="w-50  border d-md-none" src="{{ gravatar(user.mail if user.mail else 'default', 400) }}" alt="gravatar"/>
+            <img class="w-100 border d-none d-md-block" src="{{ gravatar(user.display_email if user.display_email else 'default', 400) }}" alt="gravatar"/>
+            <img class="w-50  border d-md-none" src="{{ gravatar(user.display_email if user.display_email else 'default', 400) }}" alt="gravatar"/>
             <h3 class="mt-2 mb-0" id="user_fullname">{{ user.name if user.name else user.username }}</h3>
             <h5 class="mb-2" id="user_username">{{ user.username }}</h5>
-            <h5 class="mb-3" id="user_mail"><a href="mailto:{{ user.mail }}">{{ user.mail }}</a></h5>
+            <h5 class="mb-3" id="user_mail"><a href="mailto:{{ user.display_email }}">{{ user.display_email }}</a></h5>
             {% if user.username == current_user.username %}
             <a href="{{ url_for('.user_settings_profile', username=user.username) }}" class="btn btn-outline-primary btn-block my-3">{{_("Edit Profile")}}</a>
             {% endif %}

--- a/noggin/themes/default/templates/main.html
+++ b/noggin/themes/default/templates/main.html
@@ -17,7 +17,7 @@
             </li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <img src="{{ gravatar(current_user.mail if current_user.mail else 'default', 30) }}" class="bg-white"/>
+                        <img src="{{ gravatar(current_user.display_email if current_user.display_email else 'default', 30) }}" class="bg-white"/>
 
                 </a>
                 <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownMenuLink">

--- a/noggin/themes/fas/templates/main.html
+++ b/noggin/themes/fas/templates/main.html
@@ -28,7 +28,7 @@
             </li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <img src="{{ gravatar(current_user.mail if current_user.mail else 'default', 30) }}" class="bg-white"/>
+                        <img src="{{ gravatar(current_user.display_email if current_user.display_email else 'default', 30) }}" class="bg-white"/>
 
                 </a>
                 <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownMenuLink">

--- a/noggin/utility/controllers.py
+++ b/noggin/utility/controllers.py
@@ -60,6 +60,7 @@ def group_or_404(ipa, groupname):
 
 def user_or_404(ipa, username, **kwargs):
     try:
+        # Find a specific user in IPA
         users = ipa.user_find(o_uid=username, **kwargs)['result']
         if not users:
             abort(404)

--- a/noggin/utility/controllers.py
+++ b/noggin/utility/controllers.py
@@ -58,9 +58,12 @@ def group_or_404(ipa, groupname):
         return group[0]
 
 
-def user_or_404(ipa, username):
+def user_or_404(ipa, username, **kwargs):
     try:
-        user = ipa.user_show(a_uid=username)['result']
+        users = ipa.user_find(o_uid=username, **kwargs)['result']
+        if not users:
+            abort(404)
+        user = users[0]
     except python_freeipa.exceptions.NotFound:
         abort(404)
     if User(user).locked:


### PR DESCRIPTION
This pull request is for a feature that adds a check box in the user settings email to display the Fedora Project email alias.

When checked, the @fedoraproject.org email address is shown in the user profile and avatar/Gravatar, and when unchecked, the primary email is shown.

I did not add a new attribute in IPA. Instead, the user's choice is stored as a tag in the description attribute in IPA.

To turn on = ipa.user_mod(user.username, addattr=[f"description={description_tag}"])
Turn off = ipa.user_mod(user.username, delattr=[f"description={description_tag}"])

The user is also able to add and remove additional email addresses.

If the box is checked but the user has no @fedoraproject.org email in their list, we show a small warning sign, and nothing is changed.

