### PR TITLE
Avoid confusion that users have to sign an agreement that they could not yet review (PR from clean branch)

### DIFF
--- a/noggin/templates/_agreements_form.html
+++ b/noggin/templates/_agreements_form.html
@@ -9,7 +9,7 @@
             {% if agreement.name in user.agreements %}
             <a data-bs-toggle="modal" data-bs-target="#agreement-modal-{{agreement.slug}}" class="btn btn-link" href="javascript:void(0)">{{ _("View agreement") }}</a>
             {% else %}
-            <a data-bs-toggle="modal" data-bs-target="#agreement-modal-{{agreement.slug}}" class="btn btn-primary" href="javascript:void(0)">{{ _("Sign") }}</a>
+            <a data-bs-toggle="modal" data-bs-target="#agreement-modal-{{agreement.slug}}" class="btn btn-primary" href="javascript:void(0)">{{ _("Review") }}</a>
             {% endif %}
           </div>
         </div>

--- a/noggin/templates/registration-agreements.html
+++ b/noggin/templates/registration-agreements.html
@@ -14,8 +14,8 @@
             <div class="card-body">
               <h4 class="card-title">{{_("Optional agreement signing")}}</h4>
               <p>{{ngettext(
-                "Hello %(name)s. Please sign the agreement below if you agree with it.",
-                "Hello %(name)s. Please sign the agreements below if you agree with them.",
+                "Hello %(name)s. Please review the agreement below and then sign it if you agree with its content.",
+                "Hello %(name)s. Please review the agreements below and then sign them if you agree with their content.",
                 agreementslist|length,
                 name=user.name
               )}}</p>

--- a/noggin/translations/messages.pot
+++ b/noggin/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-10 12:07+0100\n"
+"POT-Creation-Date: 2025-12-11 11:55+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -633,7 +633,7 @@ msgid "View agreement"
 msgstr ""
 
 #: noggin/templates/_agreements_form.html:12
-msgid "Sign"
+msgid "Review"
 msgstr ""
 
 #: noggin/templates/_agreements_form.html:32
@@ -878,8 +878,12 @@ msgstr ""
 
 #: noggin/templates/registration-agreements.html:16
 #, python-format
-msgid "Hello %(name)s. Please sign the agreement below if you agree with it."
-msgid_plural "Hello %(name)s. Please sign the agreements below if you agree with them."
+msgid ""
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
+msgid_plural ""
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 


### PR DESCRIPTION
This replaces the earlier PR #1559 with a clean branch but the same changes.

---------

Original PR text:

This PR solves this Discourse discussion: https://discussion.fedoraproject.org/t/signing-up-to-fedora-deters-users-click-sign-button-before-agreement-can-be-read-reviewed/176370

I have little experience with this type of implementation: it needs further review. Especially the line 9 (`{% if agreement.name in user.agreements %}`) of `.../noggin/templates/_agreements_form.html` makes me wonder if the button name "Review" of line 12 will fit all circumstances in which the line might be called. I also presume the buttons are autogenerated from the given names.

Based on the issue elaborated in the Discourse topic, this PR shall do just two things (with the screenshot of the Discourse topic in mind):

    change the "sign" button the user has to click before reviewing the actual content they have to sign (to avoid the confusion) to the name "review".
    Adjust the text presented to the user in order to fit the button & the need to first review and then sign in the next step (after reviewing).

Hope that safes some time :)