### PR TITLE
fix(templates): update Libravatar URL to use Fedora auth

### DIFF
--- a/news/1572.bug
+++ b/news/1572.bug
@@ -1,0 +1,1 @@
+Update Libravatar URL to use Fedora authentication endpoint

--- a/noggin/templates/user-settings-profile.html
+++ b/noggin/templates/user-settings-profile.html
@@ -11,8 +11,7 @@
     <img src="{{ gravatar(user.mail if user.mail else 'default', 100) }}" class="pb-2" alt="user avatar"/>
     {% set buttontext = _('Change Avatar')%}
     {%- if OPENID is defined %}
-    <form method="GET" action="https://www.libravatar.org/openid/login/">
-      <input type="hidden" name="openid_identifier" value="{{ OPENID % (user.username) }}">
+    <form method="GET" action="https://www.libravatar.org/auth/login/fedora/">
       <input name="change-avatar" type="submit" value="{{ buttontext }}" class="btn btn-sm btn-outline-primary">
     </form>
     {%- else %}


### PR DESCRIPTION
Fixes #1572

**Description**
Updated the "Change Avatar" link in the user settings profile template to point to the Fedora authentication endpoint (`/auth/login/fedora/`) instead of the deprecated OpenID login.

**Changes**
* Updated the form action URL in `noggin/templates/user-settings-profile.html`.
* Removed the `openid_identifier` hidden input field as it is not required for the direct Fedora login endpoint.
* Added news file `news/1572.bug`.