### PR TITLE
fix(templates.py): fix the traceback when providing a https:// link

### DIFF
--- a/news/1592.bug
+++ b/news/1592.bug
@@ -1,0 +1,1 @@
+Add handling of http(s):// links in the IRC network and channel value from IPA.

--- a/noggin/utility/templates.py
+++ b/noggin/utility/templates.py
@@ -55,8 +55,8 @@ def format_chat(value, isnick):
         name = url.fragment
     scheme = url.scheme
     if scheme in ("http", "https"):
-        value = escape(value)
-        return Markup(f"""<a href="{value}">{value}</a>""")  # nosec B704
+        label = escape(value)
+        return Markup(f"""<a href="{value}">{label}</a>""")  # nosec B704
     if not scheme:
         scheme = "irc"
     try:

--- a/noggin/utility/templates.py
+++ b/noggin/utility/templates.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 
 from flask import current_app
 from flask_babel import lazy_gettext as _
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 def gravatar(email, size):
@@ -54,6 +54,9 @@ def format_chat(value, isnick):
     elif not name and url.fragment:
         name = url.fragment
     scheme = url.scheme
+    if scheme in ("http", "https"):
+        value = escape(value)
+        return Markup(f"""<a href="{value}">{value}</a>""")  # nosec B704
     if not scheme:
         scheme = "irc"
     try:

--- a/tests/unit/utility/test_templates.py
+++ b/tests/unit/utility/test_templates.py
@@ -80,6 +80,12 @@ def test_format_nickname_no_matrixto_args(request_context):
         assert str(format_nickname(value)) == expected_html
 
 
+def test_format_nickname_web_url(request_context):
+    value = "https://example.com/user"
+    expected_html = f'<a href="{value}">{value}</a>'
+    assert str(format_nickname(value)) == expected_html
+
+
 def test_format_nickname_invalid(request_context):
     with pytest.raises(ValueError) as e:
         format_nickname("invalid:/username")
@@ -164,4 +170,12 @@ def test_format_nickname_invalid_with_config(app, request_context, mocker):
 )
 def test_format_channel(request_context, value, expected):
     expected_html = '<a href="{href}" title="{title}">{name}</a>'.format(**expected)
+    assert str(format_channel(value)) == expected_html
+
+
+@pytest.mark.parametrize(
+    "value", ["http://example.com/channel", "https://example.com/channel"]
+)
+def test_format_channel_web_url(request_context, value):
+    expected_html = f'<a href="{value}">{value}</a>'
     assert str(format_channel(value)) == expected_html

--- a/tests/unit/utility/test_templates.py
+++ b/tests/unit/utility/test_templates.py
@@ -80,7 +80,7 @@ def test_format_nickname_no_matrixto_args(request_context):
         assert str(format_nickname(value)) == expected_html
 
 
-def test_format_nickname_web_url(request_context):
+def test_format_nickname_web_url():
     value = "https://example.com/user?a=1&b=2"
     escaped_value = "https://example.com/user?a=1&amp;b=2"
     expected_html = f'<a href="{value}">{escaped_value}</a>'
@@ -175,7 +175,7 @@ def test_format_channel(request_context, value, expected):
 
 
 @pytest.mark.parametrize("scheme", ["http", "https"])
-def test_format_channel_web_url(request_context, scheme):
+def test_format_channel_web_url(scheme):
     value = f"{scheme}://example.com/channel?a=1&b=2"
     escaped_value = f"{scheme}://example.com/channel?a=1&amp;b=2"
     expected_html = f'<a href="{value}">{escaped_value}</a>'

--- a/tests/unit/utility/test_templates.py
+++ b/tests/unit/utility/test_templates.py
@@ -81,8 +81,9 @@ def test_format_nickname_no_matrixto_args(request_context):
 
 
 def test_format_nickname_web_url(request_context):
-    value = "https://example.com/user"
-    expected_html = f'<a href="{value}">{value}</a>'
+    value = "https://example.com/user?a=1&b=2"
+    escaped_value = "https://example.com/user?a=1&amp;b=2"
+    expected_html = f'<a href="{value}">{escaped_value}</a>'
     assert str(format_nickname(value)) == expected_html
 
 
@@ -173,9 +174,9 @@ def test_format_channel(request_context, value, expected):
     assert str(format_channel(value)) == expected_html
 
 
-@pytest.mark.parametrize(
-    "value", ["http://example.com/channel", "https://example.com/channel"]
-)
-def test_format_channel_web_url(request_context, value):
-    expected_html = f'<a href="{value}">{value}</a>'
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_format_channel_web_url(request_context, scheme):
+    value = f"{scheme}://example.com/channel?a=1&b=2"
+    escaped_value = f"{scheme}://example.com/channel?a=1&amp;b=2"
+    expected_html = f'<a href="{value}">{escaped_value}</a>'
     assert str(format_channel(value)) == expected_html


### PR DESCRIPTION
this fixes https://github.com/fedora-infra/noggin/issues/1592

i currently just escape the url that we get from IPA, since the group info isn't something a user can change without going through the IPA UI - let me know if this should be done differently