### PR TITLE
[WIP] Passkey support

### DIFF
--- a/deployment/noggin.cfg.example
+++ b/deployment/noggin.cfg.example
@@ -124,5 +124,11 @@ CHAT_MATRIX_TO_ARGS = "web-instance[element.io]=app.element.io"
 # BASSET_URL = None
 # SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes
 
+# Kerberos delegation (required for passkey login)
+# Path to the service keytab. Setting this enables passkey login.
+# KERBEROS_KEYTAB = '/etc/noggin/noggin.keytab'
+# Service principal in the keytab. Derived from FQDN + FREEIPA_DOMAIN if not set.
+# KERBEROS_SERVICE_PRINCIPAL = 'HTTP/noggin.example.com@EXAMPLE.COM'
+
 # Set to True to enable Fedora Messaging integration
 # FEDORA_MESSAGING_ENABLED = True

--- a/docs/installation/01-freeipa-server.rst
+++ b/docs/installation/01-freeipa-server.rst
@@ -445,6 +445,21 @@ privileges need to be set up in the FreeIPA server.
         ipa role-add-member "Stage User Managers" --groups sysadmin
 
 
+Configuring FreeIPA server for passkey management
+--------------------------------------------------
+
+Noggin supports self-service management of FIDO2 passkeys. This requires
+FreeIPA v4.10 or later, which includes built-in passkey support and the
+self-service permission allowing users to manage their own passkeys.
+
+.. note::
+    The WebAuthn Relying Party (RP) ID is always the IPA primary domain
+    (the Kerberos realm in lowercase). Noggin must be served from a hostname
+    under this domain for passkey registration to work. For example, if the
+    IPA domain is ``example.com``, Noggin can be at ``accounts.example.com``
+    but not at ``accounts.otherdomain.com``.
+
+
 Discretion
 ==========
 

--- a/docs/installation/01-freeipa-server.rst
+++ b/docs/installation/01-freeipa-server.rst
@@ -460,6 +460,175 @@ self-service permission allowing users to manage their own passkeys.
     but not at ``accounts.otherdomain.com``.
 
 
+Configuring Kerberos delegation for passkey login
+-------------------------------------------------
+
+Noggin can authenticate users via their registered passkeys. After verifying
+the WebAuthn assertion locally, Noggin uses Kerberos protocol transition
+(S4U2Self) to obtain a Kerberos ticket on behalf of the user, and then
+constrained delegation (S4U2Proxy) to present that ticket to the FreeIPA HTTP
+service and obtain a user-scoped IPA session.
+
+This requires:
+
+- FreeIPA v4.10 or later
+- A Kerberos service principal and keytab for the Noggin service
+- Constrained delegation rules allowing Noggin's service principal to
+  delegate to the IPA HTTP service on behalf of users
+
+.. note::
+    FreeIPA's HTTP service principal is already configured with general
+    constrained delegation rules (the built-in ``ipa-http-delegation`` rule
+    that allows the IPA HTTP service to delegate to the LDAP service). Because
+    a Kerberos principal can only be governed by one delegation mechanism,
+    Resource-Based Constrained Delegation (RBCD) cannot be used to target the
+    IPA HTTP service. The setup below uses general constrained delegation
+    instead. For background on both mechanisms, see the
+    `FreeIPA RBCD design document <https://freeipa.readthedocs.io/en/latest/designs/rbcd.html>`_
+    and the
+    `Service Constraint Delegation design <https://www.freeipa.org/page/V4/Service_Constraint_Delegation>`_.
+
+
+Step 1: Create a service principal for Noggin
+`````````````````````````````````````````````
+
+The Noggin host must be enrolled as a FreeIPA client (via ``ipa-client-install``)
+or at least have a host entry in IPA. Then create an HTTP service principal for
+Noggin:
+
+.. code-block:: shell
+
+    kinit admin
+    ipa service-add HTTP/noggin.example.com
+
+Replace ``noggin.example.com`` with the fully qualified hostname where Noggin
+is deployed.
+
+
+Step 2: Obtain a keytab
+```````````````````````
+
+Generate a keytab file for the Noggin service principal. Run this command on
+the Noggin host (or any enrolled host, then copy the keytab securely):
+
+.. code-block:: shell
+
+    ipa-getkeytab -s ipa.example.com -p HTTP/noggin.example.com \
+        -k /etc/noggin/noggin.keytab
+
+Set appropriate permissions so only the Noggin service user can read the
+keytab:
+
+.. code-block:: shell
+
+    chown noggin:noggin /etc/noggin/noggin.keytab
+    chmod 600 /etc/noggin/noggin.keytab
+
+
+Step 3: Enable protocol transition (ok-to-auth-as-delegate)
+````````````````````````````````````````````````````````````
+
+For S4U2Self to produce forwardable tickets (required for the subsequent
+S4U2Proxy step), the Noggin service principal must have the
+``ok-to-auth-as-delegate`` flag set:
+
+.. code-block:: shell
+
+    ipa service-mod HTTP/noggin.example.com --ok-to-auth-as-delegate=True
+
+This flag allows the Noggin service to perform protocol transition — that is,
+to obtain a Kerberos ticket on behalf of a user who authenticated via a
+non-Kerberos mechanism (in this case, a passkey/WebAuthn assertion).
+
+.. warning::
+    The ``ok-to-auth-as-delegate`` flag grants the service the ability to
+    impersonate any user to itself. The constrained delegation rules (next
+    step) limit which target services the impersonated tickets can be
+    forwarded to.
+
+
+Step 4: Configure constrained delegation rules
+````````````````````````````````````````````````
+
+Create a constrained delegation target containing the IPA HTTP service
+principal, and a rule that grants the Noggin service principal permission
+to delegate to that target.
+
+First, create a delegation target for the IPA HTTP service:
+
+.. code-block:: shell
+
+    ipa servicedelegationtarget-add noggin-delegation-targets
+
+Add the IPA HTTP service principal(s) to the target. If you have multiple
+IPA servers, add all of them:
+
+.. code-block:: shell
+
+    ipa servicedelegationtarget-add-member noggin-delegation-targets \
+        --principals=HTTP/ipa.example.com@EXAMPLE.COM
+
+    # If you have multiple IPA servers:
+    ipa servicedelegationtarget-add-member noggin-delegation-targets \
+        --principals=HTTP/ipa2.example.com@EXAMPLE.COM
+
+Next, create a delegation rule and add the Noggin service as a member:
+
+.. code-block:: shell
+
+    ipa servicedelegationrule-add noggin-delegation
+    ipa servicedelegationrule-add-member noggin-delegation \
+        --principals=HTTP/noggin.example.com@EXAMPLE.COM
+
+Finally, link the rule to the target:
+
+.. code-block:: shell
+
+    ipa servicedelegationrule-add-target noggin-delegation \
+        --servicedelegationtargets=noggin-delegation-targets
+
+Replace ``EXAMPLE.COM`` with your Kerberos realm (typically the IPA domain
+in uppercase).
+
+
+Step 5: Verify the delegation setup
+````````````````````````````````````
+
+Test the full S4U2Self + S4U2Proxy chain from the Noggin host using ``kvno``:
+
+.. code-block:: shell
+
+    kvno -U testuser -k /etc/noggin/noggin.keytab \
+         -P HTTP/noggin.example.com HTTP/ipa.example.com
+
+This command authenticates as the Noggin service using its keytab, obtains
+an S4U2Self ticket on behalf of ``testuser``, and uses S4U2Proxy to request
+a ticket to the IPA HTTP service. A successful result confirms the delegation
+chain is correctly configured.
+
+
+Step 6: Configure Noggin
+`````````````````````````
+
+Add the following settings to Noggin's configuration file
+(``/etc/noggin/noggin.cfg``):
+
+.. code-block:: python
+
+    # Path to the Kerberos keytab for the Noggin service.
+    # Setting this enables passkey login.
+    KERBEROS_KEYTAB = '/etc/noggin/noggin.keytab'
+
+    # The service principal in the keytab. If not set, Noggin derives it
+    # from the machine's FQDN and the FREEIPA_DOMAIN setting:
+    # HTTP/<fqdn>@<FREEIPA_DOMAIN in uppercase>
+    # KERBEROS_SERVICE_PRINCIPAL = 'HTTP/noggin.example.com@EXAMPLE.COM'
+
+When ``KERBEROS_KEYTAB`` is set to a valid keytab path, the passkey login
+button appears on the login page. When it is ``None`` (the default), passkey
+login is disabled and the button is hidden.
+
+
 Discretion
 ==========
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -122,6 +122,36 @@ Next time you log in to Noggin, you will need to enter in your password followed
 chosen authenticator app.
 
 
+Passkeys (FIDO2)
+================
+
+What are passkeys?
+******************
+Passkeys are a modern, phishing-resistant authentication method based on the FIDO2/WebAuthn standard.
+They allow you to authenticate using hardware security keys (such as YubiKey) or platform authenticators
+built into your device (such as fingerprint readers or face recognition).
+
+Passkeys registered in Noggin are stored in FreeIPA and can also be used for system-level authentication
+via SSSD, if configured by your administrator.
+
+How do I add a passkey?
+***********************
+To add a passkey, go to the **Passkeys** tab in your user settings and click the **Add Passkey** button.
+
+Your browser will prompt you to insert and activate your security key, or to use your platform authenticator.
+Follow the prompts to complete registration.
+
+Once registered, the passkey will appear in the list showing its key type (e.g. ES256, EdDSA, RS256)
+and a truncated credential identifier.
+
+.. note::
+    Your browser must support WebAuthn to register passkeys. All modern browsers (Chrome, Firefox, Safari, Edge)
+    support this standard.
+
+How do I remove a passkey?
+**************************
+To remove a passkey, go to the **Passkeys** tab in your user settings and click the trash icon next to
+the passkey you want to remove.
 
 
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -153,5 +153,19 @@ How do I remove a passkey?
 To remove a passkey, go to the **Passkeys** tab in your user settings and click the trash icon next to
 the passkey you want to remove.
 
+How do I sign in with a passkey?
+********************************
+If your Noggin deployment has Kerberos delegation configured (see the
+:doc:`installation guide </installation/01-freeipa-server>`), you can sign in using a registered passkey
+instead of a password.
+
+On the login page, enter your username and click the **Sign in with Passkey** button. Your browser will
+prompt you to activate your security key or platform authenticator. After successful verification, you
+will be logged in and redirected to your profile.
+
+.. note::
+    The passkey login button is only visible when the Noggin administrator has configured Kerberos
+    delegation. If you do not see the button, contact your administrator.
+
 
 

--- a/news/+passkeys.feature.md
+++ b/news/+passkeys.feature.md
@@ -1,0 +1,1 @@
+Add passkey (FIDO2) self-management to user settings

--- a/noggin/controller/authentication.py
+++ b/noggin/controller/authentication.py
@@ -1,7 +1,10 @@
+import time
+
 import python_freeipa
 from flask import (
     current_app,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -13,8 +16,20 @@ from flask_babel import _
 from noggin.app import ipa_admin
 from noggin.form.sync_token import SyncTokenForm
 from noggin.security.ipa import NoIPAServer, maybe_ipa_login, untouched_ipa_client
+from noggin.security.kerberos import (
+    KerberosAuthError,
+    KerberosConfigError,
+    ipa_login_with_kerberos,
+)
 from noggin.utility.controllers import get_username_from_email
 from noggin.utility.forms import FormError, handle_form_errors
+from noggin.utility.passkey import (
+    b64url_decode,
+    b64url_encode,
+    generate_challenge,
+    parse_passkey_attr,
+    verify_assertion,
+)
 
 from . import blueprint as bp
 
@@ -91,3 +106,161 @@ def otp_sync():
                 raise FormError("non_field_errors", _("No IPA server available"))
 
     return render_template('sync-token.html', sync_form=form)
+
+
+@bp.route('/passkey/login-begin', methods=['POST'])
+def passkey_login_begin():
+    if not current_app.config.get('KERBEROS_KEYTAB'):
+        return jsonify({'error': 'Passkey login is not available.'}), 400
+
+    data = request.get_json()
+    if not data or not data.get('username'):
+        return jsonify({'error': 'Username is required.'}), 400
+
+    username = data['username']
+
+    try:
+        username = get_username_from_email(ipa_admin, username)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
+
+    try:
+        user_data = ipa_admin.user_show(a_uid=username, o_all=True)['result']
+    except python_freeipa.exceptions.NotFound:
+        return jsonify({'error': _('User not found.')}), 400
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.error(
+            "IPA error looking up user %s for passkey login", username
+        )
+        return jsonify({'error': _('Could not look up user.')}), 500
+
+    raw_passkeys = user_data.get('ipapasskey', [])
+    passkeys = [pk for raw in raw_passkeys if (pk := parse_passkey_attr(raw))]
+
+    if not passkeys:
+        return jsonify({'error': _('No passkeys registered for this user.')}), 400
+
+    rp_id = current_app.config.get('PASSKEY_RP_ID') or current_app.config[
+        'FREEIPA_DOMAIN'
+    ]
+
+    challenge = generate_challenge()
+    session['noggin_passkey_auth_challenge'] = b64url_encode(challenge)
+    session['noggin_passkey_auth_username'] = username
+    session['noggin_passkey_auth_time'] = time.time()
+
+    allow_credentials = [
+        {
+            'type': 'public-key',
+            'id': b64url_encode(pk.credential_id),
+        }
+        for pk in passkeys
+    ]
+
+    return jsonify(
+        {
+            'challenge': b64url_encode(challenge),
+            'rpId': rp_id,
+            'timeout': 300000,
+            'allowCredentials': allow_credentials,
+            'userVerification': 'preferred',
+        }
+    )
+
+
+@bp.route('/passkey/login-complete', methods=['POST'])
+def passkey_login_complete():
+    if not current_app.config.get('KERBEROS_KEYTAB'):
+        return jsonify({'error': 'Passkey login is not available.'}), 400
+
+    stored_challenge_b64 = session.pop('noggin_passkey_auth_challenge', None)
+    stored_username = session.pop('noggin_passkey_auth_username', None)
+    challenge_time = session.pop('noggin_passkey_auth_time', None)
+
+    if not stored_challenge_b64 or not stored_username:
+        return jsonify({'error': _('Challenge missing or expired.')}), 400
+
+    if challenge_time is not None and (time.time() - challenge_time) > 300:
+        return jsonify({'error': _('Challenge expired. Please try again.')}), 400
+
+    stored_challenge = b64url_decode(stored_challenge_b64)
+
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': _('Missing request body.')}), 400
+
+    response = data.get('response', {})
+    credential_id_b64 = data.get('id')
+    if (
+        not credential_id_b64
+        or not response.get('clientDataJSON')
+        or not response.get('authenticatorData')
+        or not response.get('signature')
+    ):
+        return jsonify({'error': _('Missing assertion data.')}), 400
+
+    try:
+        user_data = ipa_admin.user_show(
+            a_uid=stored_username, o_all=True
+        )['result']
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.error(
+            "IPA error looking up user %s during passkey login", stored_username
+        )
+        return jsonify({'error': _('Could not look up user.')}), 500
+
+    raw_passkeys = user_data.get('ipapasskey', [])
+    passkeys = [pk for raw in raw_passkeys if (pk := parse_passkey_attr(raw))]
+
+    credential_id = b64url_decode(credential_id_b64)
+    matched_passkey = None
+    for pk in passkeys:
+        if pk.credential_id == credential_id:
+            matched_passkey = pk
+            break
+
+    if not matched_passkey:
+        return jsonify({'error': _('Unknown credential.')}), 400
+
+    rp_id = current_app.config.get('PASSKEY_RP_ID') or current_app.config[
+        'FREEIPA_DOMAIN'
+    ]
+
+    try:
+        verify_assertion(
+            client_data_json_b64=response['clientDataJSON'],
+            authenticator_data_b64=response['authenticatorData'],
+            signature_b64=response['signature'],
+            expected_challenge=stored_challenge,
+            expected_rp_id=rp_id,
+            expected_origin=request.host_url.rstrip('/'),
+            public_key_der=matched_passkey.public_key_der,
+            credential_id=credential_id,
+        )
+    except ValueError as e:
+        current_app.logger.warning("Passkey assertion verification failed: %s", e)
+        return jsonify({'error': _('Passkey verification failed.')}), 400
+
+    try:
+        ipa_login_with_kerberos(current_app, session, stored_username)
+    except KerberosConfigError as e:
+        current_app.logger.error("Kerberos config error: %s", e)
+        return jsonify({'error': _('Passkey login is not available.')}), 500
+    except KerberosAuthError as e:
+        current_app.logger.error(
+            "Kerberos auth failed for user %s: %s", stored_username, e
+        )
+        return jsonify({'error': _('Could not establish session.')}), 500
+
+    flash(
+        _('Welcome, %(username)s!', username=stored_username),
+        'success',
+    )
+
+    next_url = request.args.get("next")
+    if next_url and not next_url.startswith("/"):
+        next_url = None
+    if next_url is None:
+        next_url = url_for('.user', username=stored_username)
+
+    return jsonify({'ok': True, 'redirect': next_url})

--- a/noggin/controller/root.py
+++ b/noggin/controller/root.py
@@ -56,6 +56,7 @@ def root():
         register_form=register_form,
         login_form=login_form,
         activetab=activetab,
+        passkey_login_enabled=bool(current_app.config.get('KERBEROS_KEYTAB')),
     )
 
 

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -1,9 +1,11 @@
 import os
+import time
 from base64 import b32encode
 
 import jwt
 import python_freeipa
 from flask import (
+    abort,
     current_app,
     flash,
     g,

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -7,6 +7,7 @@ from flask import (
     current_app,
     flash,
     g,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -29,6 +30,7 @@ from noggin.form.edit_user import (
     UserSettingsKeysForm,
     UserSettingsOTPNameChange,
     UserSettingsOTPStatusChange,
+    UserSettingsPasskeyDeleteForm,
     UserSettingsProfileForm,
 )
 from noggin.representation.agreement import Agreement
@@ -39,6 +41,16 @@ from noggin.security.ipa import maybe_ipa_login
 from noggin.utility import messaging
 from noggin.utility.controllers import require_self, user_or_404, with_ipa
 from noggin.utility.forms import FormError, handle_form_errors
+from noggin.utility.passkey import (
+    SUPPORTED_PUB_KEY_CRED_PARAMS,
+    b64url_decode,
+    b64url_encode,
+    compute_user_handle,
+    format_passkey_attr,
+    generate_challenge,
+    parse_passkey_attr,
+    verify_registration,
+)
 from noggin.utility.token import Audience, make_token, read_token
 from noggin_messages import UserUpdateV1
 
@@ -569,3 +581,197 @@ def user_settings_agreements(ipa, username):
         agreementslist=agreements,
         raw=ipa.fasagreement_find(all=True),
     )
+
+
+@bp.route('/user/<username>/settings/passkeys/', methods=['GET'])
+@with_ipa()
+@require_self
+def user_settings_passkeys(ipa, username):
+    try:
+        user_data = ipa.user_show(a_uid=username, o_all=True)['result']
+    except python_freeipa.exceptions.NotFound:
+        abort(404)
+    user = User(user_data)
+    if user.locked:
+        abort(404)
+
+    raw_passkeys = user_data.get('ipapasskey', [])
+
+    passkeys = []
+    for raw_val in raw_passkeys:
+        parsed = parse_passkey_attr(raw_val)
+        if parsed:
+            passkeys.append(parsed)
+        else:
+            current_app.logger.warning(
+                'Skipping unparseable passkey for user %s: %s…', username, raw_val[:40]
+            )
+
+    rp_id = current_app.config['PASSKEY_RP_ID'] or current_app.config['FREEIPA_DOMAIN']
+    rp_name = current_app.config['PASSKEY_RP_NAME']
+
+    return render_template(
+        'user-settings-passkeys.html',
+        user=user,
+        activetab="passkeys",
+        passkeys=passkeys,
+        rp_id=rp_id,
+        rp_name=rp_name,
+    )
+
+
+@bp.route('/user/<username>/settings/passkeys/register-begin', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_passkey_register_begin(ipa, username):
+    try:
+        user_data = ipa.user_show(a_uid=username, o_all=True)['result']
+    except python_freeipa.exceptions.NotFound:
+        abort(404)
+    user = User(user_data)
+    if user.locked:
+        abort(404)
+
+    rp_id = current_app.config['PASSKEY_RP_ID'] or current_app.config['FREEIPA_DOMAIN']
+    rp_name = current_app.config['PASSKEY_RP_NAME']
+
+    challenge = generate_challenge()
+
+    session['noggin_passkey_challenge'] = b64url_encode(challenge)
+    session['noggin_passkey_challenge_username'] = username
+    session['noggin_passkey_challenge_time'] = time.time()
+
+    raw_passkeys = user_data.get('ipapasskey', [])
+    exclude_credentials = []
+    for raw_val in raw_passkeys:
+        parsed = parse_passkey_attr(raw_val)
+        if parsed:
+            exclude_credentials.append(
+                {
+                    'type': 'public-key',
+                    'id': b64url_encode(parsed.credential_id),
+                }
+            )
+        else:
+            current_app.logger.warning(
+                'Skipping unparseable passkey for user %s: %s…', username, raw_val[:40]
+            )
+
+    user_handle = compute_user_handle(username, current_app.config['SECRET_KEY'])
+
+    return jsonify(
+        {
+            'challenge': b64url_encode(challenge),
+            'rp': {'id': rp_id, 'name': rp_name},
+            'user': {
+                'id': b64url_encode(user_handle),
+                'name': username,
+                'displayName': user.name or username,
+            },
+            'excludeCredentials': exclude_credentials,
+            'pubKeyCredParams': SUPPORTED_PUB_KEY_CRED_PARAMS,
+            'authenticatorSelection': {
+                'residentKey': 'preferred',
+                'userVerification': 'preferred',
+            },
+            'timeout': 300000,
+            'attestation': 'none',
+        }
+    )
+
+
+@bp.route('/user/<username>/settings/passkeys/register-complete', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_passkey_register_complete(ipa, username):
+    stored_challenge_b64 = session.pop('noggin_passkey_challenge', None)
+    stored_username = session.pop('noggin_passkey_challenge_username', None)
+
+    if not stored_challenge_b64 or stored_username != username:
+        return jsonify({'error': 'Challenge missing or expired'}), 400
+
+    challenge_time = session.pop('noggin_passkey_challenge_time', None)
+    if challenge_time is not None and (time.time() - challenge_time) > 300:
+        return jsonify({'error': 'Challenge expired. Please try again.'}), 400
+
+    stored_challenge = b64url_decode(stored_challenge_b64)
+
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'Invalid request body'}), 400
+
+    try:
+        client_data_json_b64 = data['response']['clientDataJSON']
+        attestation_object_b64 = data['response']['attestationObject']
+    except (KeyError, TypeError):
+        return jsonify({'error': 'Missing attestation data'}), 400
+
+    rp_id = current_app.config['PASSKEY_RP_ID'] or current_app.config['FREEIPA_DOMAIN']
+
+    try:
+        result = verify_registration(
+            client_data_json_b64=client_data_json_b64,
+            attestation_object_b64=attestation_object_b64,
+            expected_challenge=stored_challenge,
+            expected_rp_id=rp_id,
+            expected_origin=request.host_url.rstrip('/'),
+        )
+    except ValueError as e:
+        current_app.logger.warning(
+            'Passkey registration verification failed for %s: %s', username, e
+        )
+        return jsonify({'error': 'Registration verification failed.'}), 400
+
+    # Check for duplicate credential ID
+    user_data = ipa.user_show(a_uid=username, o_all=True)['result']
+    existing_passkeys = user_data.get('ipapasskey', [])
+    new_cred_id = result.credential_id
+    for raw_val in existing_passkeys:
+        parsed = parse_passkey_attr(raw_val)
+        if parsed and parsed.credential_id == new_cred_id:
+            return jsonify({'error': 'This authenticator is already registered.'}), 409
+
+    max_passkeys = current_app.config.get('MAX_PASSKEYS', 20)
+    if len(existing_passkeys) >= max_passkeys:
+        return jsonify({'error': 'Maximum number of passkeys reached.'}), 400
+
+    passkey_value = format_passkey_attr(result.credential_id, result.public_key_cose)
+
+    try:
+        ipa.passkey_add(username, passkey_value)
+    except python_freeipa.exceptions.FreeIPAError as e:
+        current_app.logger.exception('Failed to add passkey for user %s', username)
+        return jsonify({'error': 'Failed to save passkey. Please try again.'}), 500
+
+    return jsonify({'ok': True})
+
+
+@bp.route('/user/<username>/settings/passkeys/delete/', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_passkey_delete(ipa, username):
+    form = UserSettingsPasskeyDeleteForm()
+
+    if form.validate_on_submit():
+        passkey_value = form.passkey.data
+        if not passkey_value or not passkey_value.startswith('passkey:'):
+            flash(_('Invalid passkey value.'), 'danger')
+            return redirect(url_for('.user_settings_passkeys', username=username))
+        try:
+            ipa.passkey_del(username, passkey_value)
+        except (
+            python_freeipa.exceptions.BadRequest,
+            python_freeipa.exceptions.FreeIPAError,
+        ) as e:
+            flash(_('Cannot delete the passkey.'), 'danger')
+            current_app.logger.exception(
+                'Error deleting passkey for user %s: %s…', username, passkey_value[:40]
+            )
+        else:
+            flash(_('The passkey has been removed.'), 'success')
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+
+    return redirect(url_for('.user_settings_passkeys', username=username))

--- a/noggin/defaults.py
+++ b/noggin/defaults.py
@@ -64,6 +64,9 @@ PASSKEY_RP_NAME = "Noggin"
 PASSKEY_RP_ID = None  # Falls back to FREEIPA_DOMAIN when None
 MAX_PASSKEYS = 20
 
+KERBEROS_KEYTAB = None  # Path to service keytab; None disables passkey login
+KERBEROS_SERVICE_PRINCIPAL = None  # e.g. "HTTP/noggin.example.com@EXAMPLE.COM"
+
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB; Flask default is unlimited
 
 # Cheat code to toggle Fedora Messaging support

--- a/noggin/defaults.py
+++ b/noggin/defaults.py
@@ -60,6 +60,12 @@ ACCEPT_IMAGES_FROM = []
 BASSET_URL = None
 SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes
 
+PASSKEY_RP_NAME = "Noggin"
+PASSKEY_RP_ID = None  # Falls back to FREEIPA_DOMAIN when None
+MAX_PASSKEYS = 20
+
+MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB; Flask default is unlimited
+
 # Cheat code to toggle Fedora Messaging support
 FEDORA_MESSAGING_ENABLED = False
 

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -245,6 +245,13 @@ class UserSettingsOTPNameChange(BaseForm):
     )
 
 
+class UserSettingsPasskeyDeleteForm(BaseForm):
+    passkey = HiddenField(
+        'passkey',
+        validators=[DataRequired(message=_('Passkey must not be empty'))],
+    )
+
+
 class UserSettingsAgreementSign(BaseForm):
     agreement = HiddenField(
         'agreement', validators=[DataRequired(message=_('Agreement must not be empty'))]

--- a/noggin/security/ipa.py
+++ b/noggin/security/ipa.py
@@ -56,6 +56,36 @@ class Client(IPAClient):
         except RequestException:
             raise BadRequest(message="Something went wrong trying to sync OTP token.")
 
+    def passkey_add(self, username, passkey_value):
+        """
+        Add a passkey to a user via the user_add_passkey IPA command.
+
+        :param username: the user to add the passkey to
+        :type username: string
+        :param passkey_value: the passkey mapping data
+        :type passkey_value: string
+        """
+        data = self._request(
+            'user_add_passkey', username, {'ipapasskey': [passkey_value]}
+        )
+        raise_on_failed(data['result'])
+        return data['result']
+
+    def passkey_del(self, username, passkey_value):
+        """
+        Remove a passkey from a user via the user_remove_passkey IPA command.
+
+        :param username: the user to remove the passkey from
+        :type username: string
+        :param passkey_value: the passkey mapping data to remove
+        :type passkey_value: string
+        """
+        data = self._request(
+            'user_remove_passkey', username, {'ipapasskey': [passkey_value]}
+        )
+        raise_on_failed(data['result'])
+        return data['result']
+
     def fasagreement_find(self, **kwargs):
         """
         Search agreements

--- a/noggin/security/kerberos.py
+++ b/noggin/security/kerberos.py
@@ -1,0 +1,163 @@
+import base64
+import logging
+import socket
+
+import gssapi
+import gssapi.raw
+import requests
+from cryptography.fernet import Fernet
+
+from .ipa import Client, NoIPAServer, choose_server
+
+logger = logging.getLogger(__name__)
+
+
+class KerberosConfigError(Exception):
+    """Kerberos is not configured or the keytab is unusable."""
+
+    pass
+
+
+class KerberosAuthError(Exception):
+    """Kerberos authentication (S4U2Self/S4U2Proxy or SPNEGO) failed."""
+
+    pass
+
+
+def load_service_credentials(app):
+    """Load GSSAPI credentials from the configured service keytab.
+
+    Reads ``KERBEROS_KEYTAB`` and ``KERBEROS_SERVICE_PRINCIPAL`` from the app
+    config.  If ``KERBEROS_SERVICE_PRINCIPAL`` is not set, it is derived from
+    the machine FQDN and the FreeIPA domain.
+
+    Returns a ``gssapi.Credentials`` object suitable for S4U2Self.
+
+    Raises ``KerberosConfigError`` if the keytab is missing or unreadable.
+    """
+    keytab = app.config.get('KERBEROS_KEYTAB')
+    if not keytab:
+        raise KerberosConfigError("KERBEROS_KEYTAB is not configured")
+
+    principal = app.config.get('KERBEROS_SERVICE_PRINCIPAL')
+    if not principal:
+        fqdn = socket.getfqdn()
+        realm = app.config['FREEIPA_DOMAIN'].upper()
+        principal = f"HTTP/{fqdn}@{realm}"
+
+    try:
+        name = gssapi.Name(principal, gssapi.NameType.kerberos_principal)
+        creds = gssapi.Credentials(
+            name=name,
+            usage='both',
+            store={'client_keytab': keytab, 'keytab': keytab},
+        )
+        return creds
+    except gssapi.exceptions.GSSError as e:
+        logger.error("Failed to load Kerberos credentials from %s: %s", keytab, e)
+        raise KerberosConfigError(
+            f"Cannot load Kerberos credentials: {e}"
+        ) from e
+
+
+def impersonate_user(service_creds, username, target_principal):
+    """Perform S4U2Self + S4U2Proxy to obtain a SPNEGO token for the user.
+
+    Uses the service credentials to impersonate ``username`` (S4U2Self / protocol
+    transition), then initiates a security context to ``target_principal``
+    (S4U2Proxy / constrained delegation).
+
+    Returns the SPNEGO output token bytes.
+
+    Raises ``KerberosAuthError`` on any GSSAPI failure.
+    """
+    try:
+        user_name = gssapi.Name(username, gssapi.NameType.user)
+        impersonated_creds = service_creds.impersonate(name=user_name)
+
+        target_name = gssapi.Name(
+            target_principal, gssapi.NameType.kerberos_principal
+        )
+        ctx = gssapi.SecurityContext(
+            name=target_name,
+            creds=impersonated_creds,
+            usage='initiate',
+        )
+        token = ctx.step()
+        if token is None:
+            raise KerberosAuthError("GSSAPI security context produced no token")
+        return bytes(token)
+    except gssapi.exceptions.GSSError as e:
+        logger.error(
+            "S4U2Self/S4U2Proxy failed for user %s to %s: %s",
+            username,
+            target_principal,
+            e,
+        )
+        raise KerberosAuthError(
+            f"Kerberos delegation failed for user {username}"
+        ) from e
+
+
+def ipa_login_with_kerberos(app, session, username):
+    """Establish an IPA session for ``username`` via Kerberos delegation.
+
+    Performs the full S4U2Self + S4U2Proxy flow, then authenticates to the
+    IPA server's ``/ipa/session/login_kerberos`` endpoint using SPNEGO.
+    The resulting session cookie is encrypted and stored in the Flask session,
+    exactly like ``maybe_ipa_login()`` does for password-based login.
+
+    Returns a ``Client`` object with a valid IPA session, or raises
+    ``KerberosConfigError`` / ``KerberosAuthError`` on failure.
+    """
+    service_creds = load_service_credentials(app)
+
+    try:
+        server = choose_server(app, session)
+    except NoIPAServer:
+        raise KerberosAuthError("No IPA server available")
+
+    realm = app.config['FREEIPA_DOMAIN'].upper()
+    target_principal = f"HTTP/{server}@{realm}"
+
+    spnego_token = impersonate_user(service_creds, username, target_principal)
+
+    url = f"https://{server}/ipa/session/login_kerberos"
+    headers = {
+        'Authorization': f'Negotiate {base64.b64encode(spnego_token).decode("ascii")}',
+        'Referer': f'https://{server}/ipa',
+    }
+
+    try:
+        resp = requests.post(
+            url,
+            headers=headers,
+            verify=app.config['FREEIPA_CACERT'],
+        )
+    except requests.RequestException as e:
+        logger.error("HTTP request to IPA login_kerberos failed: %s", e)
+        raise KerberosAuthError("Could not contact the IPA server") from e
+
+    if resp.status_code != 200:
+        logger.error(
+            "IPA login_kerberos returned %d for user %s",
+            resp.status_code,
+            username,
+        )
+        raise KerberosAuthError("IPA Kerberos login failed")
+
+    ipa_session_cookie = resp.cookies.get('ipa_session')
+    if not ipa_session_cookie:
+        logger.error("IPA login_kerberos response has no ipa_session cookie")
+        raise KerberosAuthError("IPA did not return a session")
+
+    fernet = Fernet(app.config['FERNET_SECRET'])
+    encrypted_session = fernet.encrypt(ipa_session_cookie.encode('utf-8'))
+    session['noggin_session'] = encrypted_session
+    session['noggin_username'] = username
+
+    client = Client(server, verify_ssl=app.config['FREEIPA_CACERT'])
+    client._current_host = server
+    client._session.cookies['ipa_session'] = ipa_session_cookie
+
+    return client

--- a/noggin/static/js/passkey-login.js
+++ b/noggin/static/js/passkey-login.js
@@ -1,0 +1,134 @@
+$(document).ready(function () {
+  var btn = $("#passkey-login-btn");
+
+  if (!window.PublicKeyCredential) {
+    btn
+      .prop("disabled", true)
+      .attr("title", "Your browser does not support WebAuthn");
+    return;
+  }
+
+  btn.prop("disabled", false);
+
+  btn.click(function (e) {
+    e.preventDefault();
+    btn.prop("disabled", true).text("Authenticating…");
+    $("#passkey-login-error").addClass("d-none");
+
+    var username = $("#login-username").val();
+    if (!username) {
+      showError("Please enter your username first.");
+      btn.prop("disabled", false).text("Sign in with Passkey");
+      return;
+    }
+
+    $.ajax({
+      url: PASSKEY_LOGIN_BEGIN_URL,
+      method: "POST",
+      contentType: "application/json",
+      headers: { "X-CSRFToken": PASSKEY_LOGIN_CSRF_TOKEN },
+      data: JSON.stringify({ username: username }),
+      success: function (options) {
+        var publicKeyOptions = {
+          challenge: base64urlToBuffer(options.challenge),
+          rpId: options.rpId,
+          timeout: options.timeout,
+          userVerification: options.userVerification,
+          allowCredentials: (options.allowCredentials || []).map(function (c) {
+            return { type: c.type, id: base64urlToBuffer(c.id) };
+          }),
+        };
+
+        navigator.credentials
+          .get({ publicKey: publicKeyOptions })
+          .then(function (assertion) {
+            var payload = {
+              id: bufferToBase64url(assertion.rawId),
+              response: {
+                clientDataJSON: bufferToBase64url(
+                  assertion.response.clientDataJSON
+                ),
+                authenticatorData: bufferToBase64url(
+                  assertion.response.authenticatorData
+                ),
+                signature: bufferToBase64url(assertion.response.signature),
+              },
+            };
+
+            $.ajax({
+              url: PASSKEY_LOGIN_COMPLETE_URL,
+              method: "POST",
+              contentType: "application/json",
+              headers: { "X-CSRFToken": PASSKEY_LOGIN_CSRF_TOKEN },
+              data: JSON.stringify(payload),
+              success: function (result) {
+                if (result.redirect) {
+                  window.location.href = result.redirect;
+                } else {
+                  window.location.reload();
+                }
+              },
+              error: function (xhr) {
+                var msg = "Authentication failed";
+                try {
+                  msg = JSON.parse(xhr.responseText).error || msg;
+                } catch (e) {}
+                showError(msg);
+                btn.prop("disabled", false).text("Sign in with Passkey");
+              },
+            });
+          })
+          .catch(function (err) {
+            var msg;
+            switch (err.name) {
+              case "NotAllowedError":
+                msg = "Authentication was cancelled or timed out.";
+                break;
+              case "SecurityError":
+                msg = "Security error. Please ensure you're using HTTPS.";
+                break;
+              default:
+                msg = err.message;
+            }
+            showError(msg);
+            btn.prop("disabled", false).text("Sign in with Passkey");
+          });
+      },
+      error: function (xhr) {
+        var msg = "Could not start passkey authentication";
+        try {
+          msg = JSON.parse(xhr.responseText).error || msg;
+        } catch (e) {}
+        showError(msg);
+        btn.prop("disabled", false).text("Sign in with Passkey");
+      },
+    });
+  });
+
+  function showError(msg) {
+    $("#passkey-login-error").text(msg).removeClass("d-none");
+  }
+
+  function base64urlToBuffer(b64url) {
+    var b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+    while (b64.length % 4) b64 += "=";
+    var binary = atob(b64);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  function bufferToBase64url(buffer) {
+    var bytes = new Uint8Array(buffer);
+    var binary = "";
+    for (var i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+  }
+});

--- a/noggin/static/js/passkey.js
+++ b/noggin/static/js/passkey.js
@@ -1,0 +1,132 @@
+$(document).ready(function () {
+  var btn = $("#register-passkey-btn");
+
+  if (!window.PublicKeyCredential) {
+    btn
+      .prop("disabled", true)
+      .attr("title", "Your browser does not support WebAuthn");
+    return;
+  }
+
+  btn.click(function () {
+    btn.prop("disabled", true).text("Registering…");
+    $("#passkey-error").addClass("d-none");
+    $("#passkey-success").addClass("d-none");
+
+    $.ajax({
+      url: PASSKEY_REGISTER_BEGIN_URL,
+      method: "POST",
+      contentType: "application/json",
+      headers: { "X-CSRFToken": CSRF_TOKEN },
+      data: JSON.stringify({}),
+      success: function (options) {
+        var publicKeyOptions = {
+          challenge: base64urlToBuffer(options.challenge),
+          rp: options.rp,
+          user: {
+            id: base64urlToBuffer(options.user.id),
+            name: options.user.name,
+            displayName: options.user.displayName,
+          },
+          pubKeyCredParams: options.pubKeyCredParams,
+          excludeCredentials: (options.excludeCredentials || []).map(
+            function (c) {
+              return { type: c.type, id: base64urlToBuffer(c.id) };
+            }
+          ),
+          authenticatorSelection: options.authenticatorSelection,
+          timeout: options.timeout,
+          attestation: options.attestation,
+        };
+
+        navigator.credentials
+          .create({ publicKey: publicKeyOptions })
+          .then(function (credential) {
+            var payload = {
+              id: bufferToBase64url(credential.rawId),
+              response: {
+                clientDataJSON: bufferToBase64url(
+                  credential.response.clientDataJSON
+                ),
+                attestationObject: bufferToBase64url(
+                  credential.response.attestationObject
+                ),
+              },
+            };
+
+            $.ajax({
+              url: PASSKEY_REGISTER_COMPLETE_URL,
+              method: "POST",
+              contentType: "application/json",
+              headers: { "X-CSRFToken": CSRF_TOKEN },
+              data: JSON.stringify(payload),
+              success: function () {
+                window.location.reload();
+              },
+              error: function (xhr) {
+                var msg = "Registration failed";
+                try {
+                  msg = JSON.parse(xhr.responseText).error || msg;
+                } catch (e) {}
+                showError(msg);
+                btn.prop("disabled", false).text("Add Passkey");
+              },
+            });
+          })
+          .catch(function (err) {
+            var msg;
+            switch (err.name) {
+              case "NotAllowedError":
+                msg = "Registration was cancelled or timed out.";
+                break;
+              case "InvalidStateError":
+                msg = "This authenticator is already registered.";
+                break;
+              case "SecurityError":
+                msg = "Security error. Please ensure you're using HTTPS.";
+                break;
+              default:
+                msg = err.message;
+            }
+            showError(msg);
+            btn.prop("disabled", false).text("Add Passkey");
+          });
+      },
+      error: function (xhr) {
+        var msg = "Could not start registration";
+        try {
+          msg = JSON.parse(xhr.responseText).error || msg;
+        } catch (e) {}
+        showError(msg);
+        btn.prop("disabled", false).text("Add Passkey");
+      },
+    });
+  });
+
+  function showError(msg) {
+    $("#passkey-error").text(msg).removeClass("d-none");
+  }
+
+  function base64urlToBuffer(b64url) {
+    var b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+    while (b64.length % 4) b64 += "=";
+    var binary = atob(b64);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  function bufferToBase64url(buffer) {
+    var bytes = new Uint8Array(buffer);
+    var binary = "";
+    for (var i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+  }
+});

--- a/noggin/templates/_login_form.html
+++ b/noggin/templates/_login_form.html
@@ -31,3 +31,14 @@
     {{ login_form.submit(color="primary", tabindex="4") }}
   </div>
 </form>
+{% if passkey_login_enabled %}
+<div class="card-body pt-0">
+  <div class="d-flex align-items-center my-2">
+    <hr class="flex-grow-1"><span class="mx-2 text-muted small">{{ _("or") }}</span><hr class="flex-grow-1">
+  </div>
+  <button id="passkey-login-btn" class="btn btn-outline-secondary w-100" disabled>
+    <i class="fa fa-key"></i> {{ _("Sign in with Passkey") }}
+  </button>
+  <div id="passkey-login-error" class="alert alert-danger mt-2 d-none"></div>
+</div>
+{% endif %}

--- a/noggin/templates/index.html
+++ b/noggin/templates/index.html
@@ -45,4 +45,12 @@
     <script async defer type="module" nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/vendor/altcha-2.2.4/altcha.min.js') }}"></script>
     <script async defer nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/vendor/altcha-2.2.4/worker.min.js') }}"></script>
     <script async defer nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/vendor/altcha-2.2.4/i18n-all.min.js') }}"></script>
+    {% if passkey_login_enabled %}
+    <script nonce="{{ csp_nonce() }}">
+      var PASSKEY_LOGIN_BEGIN_URL = {{ url_for('.passkey_login_begin')|tojson }};
+      var PASSKEY_LOGIN_COMPLETE_URL = {{ url_for('.passkey_login_complete')|tojson }};
+      var PASSKEY_LOGIN_CSRF_TOKEN = {{ csrf_token()|tojson }};
+    </script>
+    <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/passkey-login.js') }}"></script>
+    {% endif %}
 {% endblock %}

--- a/noggin/templates/user-settings-passkeys.html
+++ b/noggin/templates/user-settings-passkeys.html
@@ -1,0 +1,55 @@
+{% extends "user-settings.html" %}
+
+{% import '_form_macros.html' as macros %}
+{% block settings_content %}
+
+<div class="card-body">
+  <div class="d-flex">
+    <h5 id="pageheading">{{ _("Passkeys") }}</h5>
+    <button id="register-passkey-btn" class="btn btn-primary btn-sm ms-auto">
+      {{_("Add Passkey")}}
+    </button>
+  </div>
+  <div id="passkey-error" class="alert alert-danger mt-2 d-none"></div>
+  <div id="passkey-success" class="alert alert-success mt-2 d-none"></div>
+</div>
+
+<div class="list-group list-group-flush mt-3">
+{% for pk in passkeys %}
+  <div class="list-group-item">
+    <div class="row align-items-center">
+      <div class="col">
+        <div class="font-weight-bold">
+          <i class="fa fa-key"></i> {{ pk.key_type }}
+        </div>
+        <div class="text-monospace small text-muted">{{ pk.display_id }}...</div>
+      </div>
+      <div class="col-auto">
+        <form action="{{ url_for('.user_settings_passkey_delete', username=user.username) }}" method="post" class="d-inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn btn-sm btn-outline-danger" name="passkey" value="{{ pk.raw_value }}">
+            <i class="fa fa-trash"></i>
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+{% else %}
+  <div class="list-group-item text-center bg-light text-muted font-weight-bold">
+    <div>{{ _("You have no passkeys") }}</div>
+    <div><small>{{ _("Add a passkey to enable passwordless authentication.") }}</small></div>
+  </div>
+{% endfor %}
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script nonce="{{ csp_nonce() }}">
+    var PASSKEY_REGISTER_BEGIN_URL = {{ url_for('.user_settings_passkey_register_begin', username=user.username)|tojson }};
+    var PASSKEY_REGISTER_COMPLETE_URL = {{ url_for('.user_settings_passkey_register_complete', username=user.username)|tojson }};
+    var CSRF_TOKEN = {{ csrf_token()|tojson }};
+  </script>
+  <script nonce="{{ csp_nonce() }}" src="{{ url_for('static', filename='js/passkey.js') }}"></script>
+{% endblock %}

--- a/noggin/templates/user-settings.html
+++ b/noggin/templates/user-settings.html
@@ -28,6 +28,9 @@
               <a class="nav-link {{'active' if activetab == 'otp'}}" href="{{ url_for('.user_settings_otp', username=user.username) }}">{{_("OTP")}}</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link {{'active' if activetab == 'passkeys'}}" href="{{ url_for('.user_settings_passkeys', username=user.username) }}">{{_("Passkeys")}}</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link {{'active' if activetab == 'password'}}" href="{{ url_for('.user_settings_password', username=user.username) }}">{{_("Password")}}</a>
             </li>
             <li class="nav-item">

--- a/noggin/utility/passkey.py
+++ b/noggin/utility/passkey.py
@@ -8,8 +8,8 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa, utils
 from fido2 import cbor
 from fido2.webauthn import AuthenticatorData
 
@@ -46,6 +46,11 @@ class ParsedPasskey:
 class RegistrationResult:
     credential_id: bytes
     public_key_cose: bytes
+
+
+@dataclass
+class AssertionResult:
+    credential_id: bytes
 
 
 def parse_passkey_attr(attr_value: str) -> Optional[ParsedPasskey]:
@@ -249,3 +254,102 @@ def verify_registration(
         credential_id=credential_id,
         public_key_cose=public_key_cose,
     )
+
+
+def _verify_signature(public_key_der: bytes, signed_data: bytes, signature: bytes):
+    """Verify a WebAuthn assertion signature using the stored SPKI DER public key.
+
+    Raises ValueError if the signature is invalid or the key type is unsupported.
+    """
+    pub_key = serialization.load_der_public_key(public_key_der)
+
+    try:
+        if isinstance(pub_key, ec.EllipticCurvePublicKey):
+            der_sig = _raw_ecdsa_to_der(signature, pub_key.key_size)
+            pub_key.verify(
+                der_sig,
+                signed_data,
+                ec.ECDSA(hashes.SHA256()),
+            )
+        elif isinstance(pub_key, ed25519.Ed25519PublicKey):
+            pub_key.verify(signature, signed_data)
+        elif isinstance(pub_key, rsa.RSAPublicKey):
+            pub_key.verify(
+                signature,
+                signed_data,
+                padding.PKCS1v15(),
+                hashes.SHA256(),
+            )
+        else:
+            raise ValueError(f"Unsupported key type: {type(pub_key)}")
+    except Exception as e:
+        if isinstance(e, ValueError):
+            raise
+        raise ValueError(f"Signature verification failed: {e}") from e
+
+
+def _raw_ecdsa_to_der(raw_sig: bytes, key_size_bits: int) -> bytes:
+    """Convert a raw ECDSA signature (r||s) to DER-encoded format.
+
+    WebAuthn uses raw concatenated (r||s) format, while the cryptography
+    library expects DER-encoded signatures.
+    """
+    byte_len = (key_size_bits + 7) // 8
+    if len(raw_sig) != 2 * byte_len:
+        raise ValueError(
+            f"Invalid raw ECDSA signature length: {len(raw_sig)} "
+            f"(expected {2 * byte_len})"
+        )
+    r = int.from_bytes(raw_sig[:byte_len], 'big')
+    s = int.from_bytes(raw_sig[byte_len:], 'big')
+    return utils.encode_dss_signature(r, s)
+
+
+def verify_assertion(
+    client_data_json_b64: str,
+    authenticator_data_b64: str,
+    signature_b64: str,
+    expected_challenge: bytes,
+    expected_rp_id: str,
+    expected_origin: str,
+    public_key_der: bytes,
+    credential_id: bytes,
+) -> AssertionResult:
+    """Verify a WebAuthn assertion response (login).
+
+    Follows W3C WebAuthn section 7.2.  Unlike registration, assertion
+    verification MUST check the cryptographic signature.
+
+    Raises ValueError on any verification failure.
+    """
+    cdj_bytes = b64url_decode(client_data_json_b64)
+    cdj = json.loads(cdj_bytes)
+
+    if cdj.get('type') != 'webauthn.get':
+        raise ValueError('clientData type must be webauthn.get')
+
+    expected_challenge_b64url = b64url_encode(expected_challenge)
+    if cdj.get('challenge') != expected_challenge_b64url:
+        raise ValueError('Challenge mismatch')
+
+    got_origin = cdj.get('origin', '').rstrip('/')
+    if got_origin != expected_origin.rstrip('/'):
+        raise ValueError('Origin mismatch')
+
+    auth_data_bytes = b64url_decode(authenticator_data_b64)
+    ad = AuthenticatorData(auth_data_bytes)
+
+    rp_id_hash = hashlib.sha256(expected_rp_id.encode()).digest()
+    if ad.rp_id_hash != rp_id_hash:
+        raise ValueError('RP ID hash mismatch')
+
+    if not ad.flags & AuthenticatorData.FLAG.UP:
+        raise ValueError('User presence flag not set')
+
+    client_data_hash = hashlib.sha256(cdj_bytes).digest()
+    signed_data = auth_data_bytes + client_data_hash
+
+    sig_bytes = b64url_decode(signature_b64)
+    _verify_signature(public_key_der, signed_data, sig_bytes)
+
+    return AssertionResult(credential_id=credential_id)

--- a/noggin/utility/passkey.py
+++ b/noggin/utility/passkey.py
@@ -1,0 +1,251 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+from fido2 import cbor
+from fido2.webauthn import AuthenticatorData
+
+logger = logging.getLogger(__name__)
+
+# COSE key type identifiers (RFC 9053)
+COSE_KTY_OKP = 1
+COSE_KTY_EC2 = 2
+COSE_KTY_RSA = 3
+
+# COSE elliptic curve identifiers
+COSE_CRV_P256 = 1
+COSE_CRV_ED25519 = 6
+
+# Supported WebAuthn public key credential parameters
+SUPPORTED_PUB_KEY_CRED_PARAMS = [
+    {'type': 'public-key', 'alg': -7},    # ES256
+    {'type': 'public-key', 'alg': -8},    # EdDSA
+    {'type': 'public-key', 'alg': -257},  # RS256
+]
+
+
+@dataclass
+class ParsedPasskey:
+    raw_value: str
+    credential_id: bytes
+    credential_id_b64: str
+    public_key_der: bytes
+    key_type: str
+    display_id: str
+
+
+@dataclass
+class RegistrationResult:
+    credential_id: bytes
+    public_key_cose: bytes
+
+
+def parse_passkey_attr(attr_value: str) -> Optional[ParsedPasskey]:
+    """Parse one ipapasskey attribute value.
+
+    Format: passkey:<base64-credentialId>,<base64-spkiDer>[,<base64-userId>]
+
+    The public key field is SPKI DER (SubjectPublicKeyInfo), as validated by
+    FreeIPA via synta.PublicKey.from_pem().  The optional userId field is
+    ignored (only used by discoverable credentials).
+    """
+    if not attr_value.startswith("passkey:"):
+        return None
+    rest = attr_value[len("passkey:") :]
+    parts = rest.split(",")
+    if len(parts) < 2:
+        return None
+    cred_id_b64 = parts[0]
+    pub_key_b64 = parts[1]
+    try:
+        credential_id = base64.b64decode(cred_id_b64, validate=True)
+        public_key_der = base64.b64decode(pub_key_b64, validate=True)
+    except (ValueError, binascii.Error):
+        logger.warning("Failed to parse passkey attribute: %s", attr_value[:40])
+        return None
+
+    if not credential_id or not public_key_der:
+        return None
+
+    key_type = detect_key_type(public_key_der)
+    display_id = credential_id.hex()[:16]
+
+    return ParsedPasskey(
+        raw_value=attr_value,
+        credential_id=credential_id,
+        credential_id_b64=cred_id_b64,
+        public_key_der=public_key_der,
+        key_type=key_type,
+        display_id=display_id,
+    )
+
+
+def format_passkey_attr(credential_id: bytes, public_key_cose: bytes) -> str:
+    """Format credential data as an ipapasskey attribute value.
+
+    Converts the COSE key to SPKI DER before encoding, matching the format
+    that FreeIPA validates (base64 of SubjectPublicKeyInfo DER).
+    """
+    spki_der = cose_to_spki_der(public_key_cose)
+    cred_b64 = base64.b64encode(credential_id).decode('ascii')
+    key_b64 = base64.b64encode(spki_der).decode('ascii')
+    return f"passkey:{cred_b64},{key_b64}"
+
+
+def detect_key_type(der_bytes: bytes) -> str:
+    """Determine the algorithm from SPKI DER-encoded public key bytes."""
+    try:
+        pub_key = serialization.load_der_public_key(der_bytes)
+        if isinstance(pub_key, ec.EllipticCurvePublicKey):
+            if isinstance(pub_key.curve, ec.SECP256R1):
+                return "ES256"
+            return f"EC/{pub_key.curve.name}"
+        elif isinstance(pub_key, ed25519.Ed25519PublicKey):
+            return "EdDSA"
+        elif isinstance(pub_key, rsa.RSAPublicKey):
+            return "RS256"
+    except Exception as e:
+        logger.debug("Could not determine key type: %s", e)
+    return "unknown"
+
+
+def cose_to_spki_der(cose_bytes: bytes) -> bytes:
+    """Convert a COSE_Key CBOR blob to DER-encoded SubjectPublicKeyInfo.
+
+    FreeIPA stores passkey public keys as base64-encoded SPKI DER (the content
+    of a PEM ``BEGIN PUBLIC KEY`` block), validated via synta.PublicKey.from_pem.
+    """
+    decoded = cbor.decode(cose_bytes)
+    kty = decoded.get(1)
+
+    if kty == COSE_KTY_EC2:
+        crv = decoded.get(-1)
+        if crv != COSE_CRV_P256:
+            raise ValueError(f"Unsupported EC2 curve: {crv}")
+        x_bytes = decoded.get(-2)
+        y_bytes = decoded.get(-3)
+        if x_bytes is None or y_bytes is None:
+            raise ValueError("EC2 key missing x or y coordinate")
+        x_int = int.from_bytes(x_bytes, 'big')
+        y_int = int.from_bytes(y_bytes, 'big')
+        pub_numbers = ec.EllipticCurvePublicNumbers(x_int, y_int, ec.SECP256R1())
+        pub_key = pub_numbers.public_key()
+    elif kty == COSE_KTY_OKP:
+        crv = decoded.get(-1)
+        if crv != COSE_CRV_ED25519:
+            raise ValueError(f"Unsupported OKP curve: {crv}")
+        x_bytes = decoded.get(-2)
+        if x_bytes is None:
+            raise ValueError("OKP key missing x coordinate")
+        pub_key = ed25519.Ed25519PublicKey.from_public_bytes(x_bytes)
+    elif kty == COSE_KTY_RSA:
+        n_bytes = decoded.get(-1)
+        e_bytes = decoded.get(-2)
+        if n_bytes is None or e_bytes is None:
+            raise ValueError("RSA key missing n or e")
+        if len(n_bytes) < 256:
+            raise ValueError("RSA modulus too small (minimum 2048 bits)")
+        n_int = int.from_bytes(n_bytes, 'big')
+        e_int = int.from_bytes(e_bytes, 'big')
+        pub_numbers = rsa.RSAPublicNumbers(e_int, n_int)
+        pub_key = pub_numbers.public_key()
+    else:
+        raise ValueError(f"Unsupported COSE key type: {kty}")
+
+    return pub_key.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def generate_challenge() -> bytes:
+    """Generate a 32-byte random challenge for WebAuthn."""
+    return os.urandom(32)
+
+
+def compute_user_handle(username: str, secret: bytes) -> bytes:
+    """Compute a stable user handle from the username.
+
+    Uses HMAC-SHA256 keyed by the application secret to produce a
+    non-reversible, stable 32-byte user handle.
+    """
+    return hmac.new(secret, username.encode(), hashlib.sha256).digest()
+
+
+def b64url_decode(s: str) -> bytes:
+    """Decode base64url with or without padding."""
+    s += '=' * (4 - len(s) % 4)
+    return base64.urlsafe_b64decode(s)
+
+
+def b64url_encode(data: bytes) -> str:
+    """Encode bytes as base64url without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')
+
+
+def verify_registration(
+    client_data_json_b64: str,
+    attestation_object_b64: str,
+    expected_challenge: bytes,
+    expected_rp_id: str,
+    expected_origin: str,
+) -> RegistrationResult:
+    """Verify a WebAuthn registration response.
+
+    Follows W3C WebAuthn section 7.1 (simplified — no attestation
+    signature verification, matching ahdapa's approach).
+
+    Raises ValueError on any verification failure.
+    """
+    cdj_bytes = b64url_decode(client_data_json_b64)
+    cdj = json.loads(cdj_bytes)
+
+    if cdj.get('type') != 'webauthn.create':
+        raise ValueError('clientData type must be webauthn.create')
+
+    expected_challenge_b64url = b64url_encode(expected_challenge)
+    if cdj.get('challenge') != expected_challenge_b64url:
+        raise ValueError('Challenge mismatch')
+
+    got_origin = cdj.get('origin', '').rstrip('/')
+    if got_origin != expected_origin.rstrip('/'):
+        raise ValueError('Origin mismatch')
+
+    att_bytes = b64url_decode(attestation_object_b64)
+    att_obj = cbor.decode(att_bytes)
+
+    auth_data_bytes = att_obj.get('authData')
+    if not auth_data_bytes or not isinstance(auth_data_bytes, bytes):
+        raise ValueError('Missing authData in attestationObject')
+
+    ad = AuthenticatorData(auth_data_bytes)
+
+    rp_id_hash = hashlib.sha256(expected_rp_id.encode()).digest()
+    if ad.rp_id_hash != rp_id_hash:
+        raise ValueError('RP ID hash mismatch')
+
+    if not ad.flags & AuthenticatorData.FLAG.UP:
+        raise ValueError('User presence flag not set')
+
+    if not ad.is_attested():
+        raise ValueError('No attested credential data')
+
+    cred_data = ad.credential_data
+    if cred_data is None:
+        raise ValueError('Failed to parse attested credential data')
+
+    credential_id = bytes(cred_data.credential_id)
+    public_key_cose = cbor.encode(dict(cred_data.public_key))
+
+    return RegistrationResult(
+        credential_id=credential_id,
+        public_key_cose=public_key_cose,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "srvlookup (>=2.0.0,<4.0.0)",
     "altcha (>=1.0.0,<2.0.0)",
     "fido2 (>=1.1.0,<2.0.0)",
+    "gssapi (>=1.7.0,<2.0.0)",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pyotp (>=2.2.7,<3.0.0)",
     "srvlookup (>=2.0.0,<4.0.0)",
     "altcha (>=1.0.0,<2.0.0)",
+    "fido2 (>=1.1.0,<2.0.0)",
 ]
 
 [project.urls]

--- a/tests/unit/controller/test_passkey_login.py
+++ b/tests/unit/controller/test_passkey_login.py
@@ -1,0 +1,421 @@
+import base64
+import json
+import time
+from unittest import mock
+
+import pytest
+import python_freeipa
+
+from noggin.utility.passkey import AssertionResult, b64url_encode
+
+from ..utilities import make_srv
+
+
+def _make_user_show_result(username="dummy", passkeys=None):
+    result = {
+        'uid': [username],
+        'cn': [f'{username.title()} User'],
+        'givenname': [username.title()],
+        'sn': ['User'],
+        'mail': [f'{username}@unit.tests'],
+        'nsaccountlock': False,
+    }
+    if passkeys is not None:
+        result['ipapasskey'] = passkeys
+    return result
+
+
+def _make_passkey_value(cred_id=b'\x01\x02\x03\x04', spki_der=b'\x30\x59' + b'\x00' * 89):
+    cred_b64 = base64.b64encode(cred_id).decode('ascii')
+    key_b64 = base64.b64encode(spki_der).decode('ascii')
+    return f"passkey:{cred_b64},{key_b64}"
+
+
+SAMPLE_CRED_ID = b'\xaa\xbb\xcc\xdd' * 4
+SAMPLE_SPKI_DER = b'\x30\x59' + b'\x00' * 89
+SAMPLE_PASSKEY = _make_passkey_value(SAMPLE_CRED_ID, SAMPLE_SPKI_DER)
+
+
+@pytest.fixture
+def passkey_client(app, ipa_cert, srvlookup_mock, mocker):
+    """Test client with KERBEROS_KEYTAB enabled."""
+    mocker.patch.dict(app.config, {'KERBEROS_KEYTAB': '/etc/noggin/test.keytab'})
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+@pytest.fixture
+def mock_ipa_admin(passkey_client, mocker):
+    """Mock ipa_admin for user lookups."""
+    mock_admin = mock.MagicMock()
+    mocker.patch('noggin.controller.authentication.ipa_admin', mock_admin)
+    return mock_admin
+
+
+# ---------------------------------------------------------------------------
+# POST /passkey/login-begin
+# ---------------------------------------------------------------------------
+
+
+class TestPasskeyLoginBegin:
+
+    def test_returns_valid_json(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'dummy'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 200
+
+        data = result.get_json()
+        assert 'challenge' in data
+        assert 'rpId' in data
+        assert 'allowCredentials' in data
+        assert len(data['allowCredentials']) == 1
+        assert data['allowCredentials'][0]['type'] == 'public-key'
+        assert 'timeout' in data
+
+    def test_stores_challenge_in_session(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'dummy'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 200
+
+        with passkey_client.session_transaction() as sess:
+            assert 'noggin_passkey_auth_challenge' in sess
+            assert sess['noggin_passkey_auth_username'] == 'dummy'
+            assert 'noggin_passkey_auth_time' in sess
+
+    def test_missing_username(self, passkey_client, mock_ipa_admin):
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': ''}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'error' in result.get_json()
+
+    def test_missing_body(self, passkey_client, mock_ipa_admin):
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps(None),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+
+    def test_user_not_found(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.side_effect = python_freeipa.exceptions.NotFound(
+            message='User not found', code='4001'
+        )
+
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'nonexistent'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'not found' in result.get_json()['error'].lower()
+
+    def test_user_no_passkeys(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[])
+        }
+
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'dummy'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'no passkeys' in result.get_json()['error'].lower()
+
+    def test_ipa_error(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.side_effect = python_freeipa.exceptions.FreeIPAError(
+            message='Server error', code='5000'
+        )
+
+        result = passkey_client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'dummy'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 500
+
+    def test_disabled_when_no_keytab(self, client):
+        """Passkey login returns 400 when KERBEROS_KEYTAB is not set."""
+        result = client.post(
+            '/passkey/login-begin',
+            data=json.dumps({'username': 'dummy'}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'not available' in result.get_json()['error'].lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /passkey/login-complete
+# ---------------------------------------------------------------------------
+
+
+class TestPasskeyLoginComplete:
+
+    def test_missing_challenge(self, passkey_client, mock_ipa_admin):
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'x',
+                    'authenticatorData': 'y',
+                    'signature': 'z',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'error' in data
+
+    def test_expired_challenge(self, passkey_client, mock_ipa_admin):
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time() - 301
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'x',
+                    'authenticatorData': 'y',
+                    'signature': 'z',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'expired' in result.get_json()['error'].lower()
+
+    def test_missing_request_body(self, passkey_client, mock_ipa_admin):
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps(None),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+
+    def test_missing_assertion_data(self, passkey_client, mock_ipa_admin):
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({'id': 'abc', 'response': {}}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'missing' in result.get_json()['error'].lower()
+
+    def test_unknown_credential(self, passkey_client, mock_ipa_admin):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        unknown_cred = b'\xff' * 16
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(unknown_cred),
+                'response': {
+                    'clientDataJSON': 'x',
+                    'authenticatorData': 'y',
+                    'signature': 'z',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'unknown' in result.get_json()['error'].lower()
+
+    def test_verification_failure(self, passkey_client, mock_ipa_admin, mocker):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        mocker.patch(
+            'noggin.controller.authentication.verify_assertion',
+            side_effect=ValueError('Challenge mismatch'),
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'authenticatorData': 'fake-ad',
+                    'signature': 'fake-sig',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'verification failed' in result.get_json()['error'].lower()
+
+    def test_successful_login(self, passkey_client, mock_ipa_admin, mocker):
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        mocker.patch(
+            'noggin.controller.authentication.verify_assertion',
+            return_value=AssertionResult(credential_id=SAMPLE_CRED_ID),
+        )
+
+        mock_krb_login = mocker.patch(
+            'noggin.controller.authentication.ipa_login_with_kerberos',
+            return_value=mock.MagicMock(),
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'authenticatorData': 'fake-ad',
+                    'signature': 'fake-sig',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 200
+        data = result.get_json()
+        assert data['ok'] is True
+        assert 'redirect' in data
+        mock_krb_login.assert_called_once()
+
+    def test_kerberos_auth_failure(self, passkey_client, mock_ipa_admin, mocker):
+        from noggin.security.kerberos import KerberosAuthError
+
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        mocker.patch(
+            'noggin.controller.authentication.verify_assertion',
+            return_value=AssertionResult(credential_id=SAMPLE_CRED_ID),
+        )
+
+        mocker.patch(
+            'noggin.controller.authentication.ipa_login_with_kerberos',
+            side_effect=KerberosAuthError("delegation failed"),
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'authenticatorData': 'fake-ad',
+                    'signature': 'fake-sig',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 500
+        assert 'session' in result.get_json()['error'].lower()
+
+    def test_kerberos_config_error(self, passkey_client, mock_ipa_admin, mocker):
+        from noggin.security.kerberos import KerberosConfigError
+
+        mock_ipa_admin.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        mocker.patch(
+            'noggin.controller.authentication.verify_assertion',
+            return_value=AssertionResult(credential_id=SAMPLE_CRED_ID),
+        )
+
+        mocker.patch(
+            'noggin.controller.authentication.ipa_login_with_kerberos',
+            side_effect=KerberosConfigError("keytab missing"),
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with passkey_client.session_transaction() as sess:
+            sess['noggin_passkey_auth_challenge'] = challenge_b64
+            sess['noggin_passkey_auth_username'] = 'dummy'
+            sess['noggin_passkey_auth_time'] = time.time()
+
+        result = passkey_client.post(
+            '/passkey/login-complete',
+            data=json.dumps({
+                'id': b64url_encode(SAMPLE_CRED_ID),
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'authenticatorData': 'fake-ad',
+                    'signature': 'fake-sig',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 500
+        assert 'not available' in result.get_json()['error'].lower()
+
+    def test_disabled_when_no_keytab(self, client):
+        result = client.post(
+            '/passkey/login-complete',
+            data=json.dumps({}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        assert 'not available' in result.get_json()['error'].lower()

--- a/tests/unit/controller/test_user_passkey.py
+++ b/tests/unit/controller/test_user_passkey.py
@@ -1,0 +1,559 @@
+import base64
+import json
+import time
+from unittest import mock
+
+import pytest
+import python_freeipa
+from bs4 import BeautifulSoup
+
+from noggin.utility.passkey import (
+    RegistrationResult,
+    b64url_encode,
+    format_passkey_attr,
+    parse_passkey_attr,
+)
+
+from ..utilities import assert_redirects_with_flash
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user_show_result(username="dummy", passkeys=None, locked=False):
+    """Build a minimal user_show result dict suitable for the controller."""
+    result = {
+        'uid': [username],
+        'cn': [f'{username.title()} User'],
+        'givenname': [username.title()],
+        'sn': ['User'],
+        'mail': [f'{username}@unit.tests'],
+        'nsaccountlock': locked,
+    }
+    if passkeys is not None:
+        result['ipapasskey'] = passkeys
+    return result
+
+
+def _make_whoami_result(username="dummy"):
+    """Build a minimal user_find(whoami=True) result list."""
+    return [_make_user_show_result(username)]
+
+
+def _make_passkey_value(cred_id=b'\x01\x02\x03\x04', spki_der=b'\x30\x59' + b'\x00' * 89):
+    """Build a passkey attribute value string for testing.
+
+    Uses raw base64 encoding of credential ID and SPKI DER bytes.
+    """
+    cred_b64 = base64.b64encode(cred_id).decode('ascii')
+    key_b64 = base64.b64encode(spki_der).decode('ascii')
+    return f"passkey:{cred_b64},{key_b64}"
+
+
+SAMPLE_CRED_ID = b'\xaa\xbb\xcc\xdd' * 4
+SAMPLE_SPKI_DER = b'\x30\x59' + b'\x00' * 89
+SAMPLE_PASSKEY = _make_passkey_value(SAMPLE_CRED_ID, SAMPLE_SPKI_DER)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_ipa(client, mocker):
+    """Provide a mock IPA client and set up the session as if the user is logged in.
+
+    Patches ``maybe_ipa_session`` so the ``@with_ipa()`` decorator receives our
+    mock instead of trying to contact a real FreeIPA server.
+    """
+    mock_client = mock.MagicMock()
+
+    # Default behaviour: user_find(whoami=True) returns dummy user
+    mock_client.user_find.return_value = {'result': _make_whoami_result()}
+
+    # Default: user_show returns dummy user with no passkeys
+    mock_client.user_show.return_value = {'result': _make_user_show_result()}
+
+    # Patch maybe_ipa_session to return our mock
+    mocker.patch(
+        'noggin.utility.controllers.maybe_ipa_session', return_value=mock_client
+    )
+
+    # Set session variables that with_ipa and require_self need
+    with client.session_transaction() as sess:
+        sess['noggin_session'] = b'fake-encrypted-session'
+        sess['noggin_username'] = 'dummy'
+        sess['noggin_ipa_server_hostname'] = 'ipa.tinystage.test'
+
+    yield mock_client
+
+
+# ---------------------------------------------------------------------------
+# GET /user/<username>/settings/passkeys/
+# ---------------------------------------------------------------------------
+
+class TestPasskeysPage:
+
+    def test_empty_passkey_list(self, client, mock_ipa):
+        """Logged-in user sees the page with an empty passkey list."""
+        result = client.get('/user/dummy/settings/passkeys/')
+        assert result.status_code == 200
+
+        page = BeautifulSoup(result.data, 'html.parser')
+        assert page.title
+        assert 'dummy' in page.title.string
+
+        pageheading = page.select_one('#pageheading')
+        assert pageheading is not None
+        assert pageheading.get_text(strip=True) == 'Passkeys'
+
+        # Should show the "no passkeys" message
+        list_items = page.select('div.list-group .list-group-item')
+        assert len(list_items) == 1
+        text = list_items[0].get_text(strip=True)
+        assert 'You have no passkeys' in text
+
+    def test_passkeys_displayed(self, client, mock_ipa):
+        """Logged-in user sees passkeys when they exist."""
+        mock_ipa.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        result = client.get('/user/dummy/settings/passkeys/')
+        assert result.status_code == 200
+
+        page = BeautifulSoup(result.data, 'html.parser')
+        list_items = page.select('div.list-group .list-group-item')
+        # Should have one real passkey item, not the "no passkeys" message
+        assert len(list_items) >= 1
+        full_text = ' '.join(item.get_text(strip=True) for item in list_items)
+        assert 'You have no passkeys' not in full_text
+
+        # The display_id should appear on the page (hex prefix of credential_id)
+        display_id = SAMPLE_CRED_ID.hex()[:16]
+        assert display_id in page.get_text()
+
+    def test_cannot_view_other_user(self, client, mock_ipa):
+        """Cannot view another user's passkeys; redirects with flash."""
+        result = client.get('/user/otheruser/settings/passkeys/')
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/otheruser/',
+            expected_message='You do not have permission to edit this account.',
+            expected_category='danger',
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST /user/<username>/settings/passkeys/register-begin
+# ---------------------------------------------------------------------------
+
+class TestRegisterBegin:
+
+    def test_returns_valid_json(self, client, mock_ipa):
+        """POST register-begin returns valid JSON with challenge, rp, user info."""
+        result = client.post('/user/dummy/settings/passkeys/register-begin')
+        assert result.status_code == 200
+
+        data = result.get_json()
+        assert data is not None
+
+        # Check required fields
+        assert 'challenge' in data
+        assert isinstance(data['challenge'], str)
+        assert len(data['challenge']) > 0
+
+        assert 'rp' in data
+        assert data['rp']['id'] == 'tinystage.test'
+        assert data['rp']['name'] == 'Noggin'
+
+        assert 'user' in data
+        assert data['user']['name'] == 'dummy'
+        assert 'id' in data['user']
+        assert 'displayName' in data['user']
+
+        assert 'pubKeyCredParams' in data
+        assert 'authenticatorSelection' in data
+        assert 'timeout' in data
+        assert 'attestation' in data
+
+    def test_stores_challenge_in_session(self, client, mock_ipa):
+        """POST register-begin stores challenge data in the session."""
+        result = client.post('/user/dummy/settings/passkeys/register-begin')
+        assert result.status_code == 200
+
+        data = result.get_json()
+
+        with client.session_transaction() as sess:
+            assert 'noggin_passkey_challenge' in sess
+            assert sess['noggin_passkey_challenge'] == data['challenge']
+            assert sess['noggin_passkey_challenge_username'] == 'dummy'
+            assert 'noggin_passkey_challenge_time' in sess
+
+    def test_exclude_credentials_with_existing_passkeys(self, client, mock_ipa):
+        """register-begin includes excludeCredentials when user has passkeys."""
+        mock_ipa.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[SAMPLE_PASSKEY])
+        }
+
+        result = client.post('/user/dummy/settings/passkeys/register-begin')
+        assert result.status_code == 200
+
+        data = result.get_json()
+        assert 'excludeCredentials' in data
+        assert len(data['excludeCredentials']) == 1
+        assert data['excludeCredentials'][0]['type'] == 'public-key'
+
+
+# ---------------------------------------------------------------------------
+# POST /user/<username>/settings/passkeys/register-complete
+# ---------------------------------------------------------------------------
+
+class TestRegisterComplete:
+
+    def test_missing_challenge_returns_400(self, client, mock_ipa):
+        """register-complete returns 400 when no challenge is in the session."""
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({'response': {'clientDataJSON': 'x', 'attestationObject': 'y'}}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'error' in data
+
+    def test_username_mismatch_returns_400(self, client, mock_ipa):
+        """register-complete returns 400 when the stored username doesn't match."""
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'otheruser'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({'response': {'clientDataJSON': 'x', 'attestationObject': 'y'}}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'error' in data
+
+    def test_expired_challenge_returns_400(self, client, mock_ipa):
+        """register-complete returns 400 when the challenge has expired (>300s)."""
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            # Set the time to 301 seconds ago
+            sess['noggin_passkey_challenge_time'] = time.time() - 301
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({'response': {'clientDataJSON': 'x', 'attestationObject': 'y'}}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'expired' in data['error'].lower()
+
+    def test_missing_request_body_returns_400(self, client, mock_ipa):
+        """register-complete returns 400 when the request body is null/empty."""
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        # JSON null yields get_json() == None in the handler
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps(None),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert data is not None
+        assert 'error' in data
+
+    def test_missing_attestation_data_returns_400(self, client, mock_ipa):
+        """register-complete returns 400 when attestation fields are missing."""
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({'response': {}}),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'error' in data
+
+    def test_successful_registration(self, client, mock_ipa, mocker):
+        """register-complete succeeds when verify_registration passes."""
+        fake_cred_id = b'\x11\x22\x33\x44' * 4
+        fake_cose_key = b'\xaa\xbb\xcc\xdd' * 8
+
+        # Mock verify_registration to return a successful result
+        mock_verify = mocker.patch(
+            'noggin.controller.user.verify_registration',
+            return_value=RegistrationResult(
+                credential_id=fake_cred_id,
+                public_key_cose=fake_cose_key,
+            ),
+        )
+
+        # Mock format_passkey_attr to return a predictable value
+        mocker.patch(
+            'noggin.controller.user.format_passkey_attr',
+            return_value='passkey:fakedata',
+        )
+
+        # user_show for duplicate check returns no existing passkeys
+        mock_ipa.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[])
+        }
+
+        # passkey_add succeeds
+        mock_ipa.passkey_add.return_value = {'result': {}}
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'attestationObject': 'fake-att',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 200
+        data = result.get_json()
+        assert data['ok'] is True
+
+        # Verify that passkey_add was called
+        mock_ipa.passkey_add.assert_called_once_with('dummy', 'passkey:fakedata')
+
+        # Verify that verify_registration was called with the right params
+        mock_verify.assert_called_once()
+
+    def test_ipa_error_returns_500(self, client, mock_ipa, mocker):
+        """register-complete returns 500 with a generic message on IPA error."""
+        fake_cred_id = b'\x11\x22\x33\x44' * 4
+        fake_cose_key = b'\xaa\xbb\xcc\xdd' * 8
+
+        mocker.patch(
+            'noggin.controller.user.verify_registration',
+            return_value=RegistrationResult(
+                credential_id=fake_cred_id,
+                public_key_cose=fake_cose_key,
+            ),
+        )
+        mocker.patch(
+            'noggin.controller.user.format_passkey_attr',
+            return_value='passkey:fakedata',
+        )
+
+        mock_ipa.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[])
+        }
+        mock_ipa.passkey_add.side_effect = python_freeipa.exceptions.FreeIPAError(
+            message='Internal server details that should not be leaked',
+            code='4242',
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'attestationObject': 'fake-att',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 500
+        data = result.get_json()
+        assert 'error' in data
+        # The response should NOT leak internal IPA error details
+        assert 'Internal server details' not in data['error']
+        assert 'try again' in data['error'].lower()
+
+    def test_duplicate_credential_returns_409(self, client, mock_ipa, mocker):
+        """register-complete returns 409 when the credential is already registered."""
+        # Use the same credential ID as what's already stored
+        existing_cred_id = b'\x11\x22\x33\x44' * 4
+        existing_passkey = _make_passkey_value(existing_cred_id)
+
+        mocker.patch(
+            'noggin.controller.user.verify_registration',
+            return_value=RegistrationResult(
+                credential_id=existing_cred_id,
+                public_key_cose=b'\xaa' * 32,
+            ),
+        )
+
+        # user_show returns user with an existing passkey whose credential_id matches
+        mock_ipa.user_show.return_value = {
+            'result': _make_user_show_result(passkeys=[existing_passkey])
+        }
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'attestationObject': 'fake-att',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 409
+        data = result.get_json()
+        assert 'already registered' in data['error'].lower()
+
+    def test_verification_failure_returns_400(self, client, mock_ipa, mocker):
+        """register-complete returns 400 when verify_registration raises ValueError."""
+        mocker.patch(
+            'noggin.controller.user.verify_registration',
+            side_effect=ValueError('Challenge mismatch'),
+        )
+
+        challenge_b64 = b64url_encode(b'\x00' * 32)
+        with client.session_transaction() as sess:
+            sess['noggin_passkey_challenge'] = challenge_b64
+            sess['noggin_passkey_challenge_username'] = 'dummy'
+            sess['noggin_passkey_challenge_time'] = time.time()
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/register-complete',
+            data=json.dumps({
+                'response': {
+                    'clientDataJSON': 'fake-cdj',
+                    'attestationObject': 'fake-att',
+                },
+            }),
+            content_type='application/json',
+        )
+        assert result.status_code == 400
+        data = result.get_json()
+        assert 'error' in data
+
+
+# ---------------------------------------------------------------------------
+# POST /user/<username>/settings/passkeys/delete/
+# ---------------------------------------------------------------------------
+
+class TestPasskeyDelete:
+
+    def test_successful_deletion(self, client, mock_ipa):
+        """POST delete with a valid passkey value flashes success and redirects."""
+        mock_ipa.passkey_del.return_value = {'result': {}}
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/delete/',
+            data={'passkey': SAMPLE_PASSKEY},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/dummy/settings/passkeys/',
+            expected_message='The passkey has been removed.',
+            expected_category='success',
+        )
+        mock_ipa.passkey_del.assert_called_once_with('dummy', SAMPLE_PASSKEY)
+
+    def test_empty_passkey_flashes_danger(self, client, mock_ipa):
+        """POST delete with an empty passkey field flashes a validation error."""
+        result = client.post(
+            '/user/dummy/settings/passkeys/delete/',
+            data={'passkey': ''},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/dummy/settings/passkeys/',
+            expected_message='Passkey must not be empty',
+            expected_category='danger',
+        )
+
+    def test_missing_passkey_field_flashes_danger(self, client, mock_ipa):
+        """POST delete with no passkey field flashes a validation error."""
+        result = client.post(
+            '/user/dummy/settings/passkeys/delete/',
+            data={},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/dummy/settings/passkeys/',
+            expected_message='Passkey must not be empty',
+            expected_category='danger',
+        )
+
+    def test_ipa_error_flashes_danger(self, client, mock_ipa):
+        """POST delete flashes danger when IPA raises FreeIPAError."""
+        mock_ipa.passkey_del.side_effect = python_freeipa.exceptions.FreeIPAError(
+            message='Something went wrong', code='4242'
+        )
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/delete/',
+            data={'passkey': SAMPLE_PASSKEY},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/dummy/settings/passkeys/',
+            expected_message='Cannot delete the passkey.',
+            expected_category='danger',
+        )
+
+    def test_ipa_bad_request_flashes_danger(self, client, mock_ipa):
+        """POST delete flashes danger when IPA raises BadRequest."""
+        mock_ipa.passkey_del.side_effect = python_freeipa.exceptions.BadRequest(
+            message='Bad request', code='4242'
+        )
+
+        result = client.post(
+            '/user/dummy/settings/passkeys/delete/',
+            data={'passkey': SAMPLE_PASSKEY},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/dummy/settings/passkeys/',
+            expected_message='Cannot delete the passkey.',
+            expected_category='danger',
+        )
+
+    def test_no_permission_for_other_user(self, client, mock_ipa):
+        """Cannot delete another user's passkey; redirects with flash."""
+        result = client.post(
+            '/user/otheruser/settings/passkeys/delete/',
+            data={'passkey': SAMPLE_PASSKEY},
+        )
+        assert_redirects_with_flash(
+            result,
+            expected_url='/user/otheruser/',
+            expected_message='You do not have permission to edit this account.',
+            expected_category='danger',
+        )

--- a/tests/unit/security/test_kerberos.py
+++ b/tests/unit/security/test_kerberos.py
@@ -1,0 +1,226 @@
+from unittest import mock
+
+import pytest
+
+from noggin.security.kerberos import (
+    KerberosAuthError,
+    KerberosConfigError,
+    ipa_login_with_kerberos,
+    impersonate_user,
+    load_service_credentials,
+)
+
+
+@pytest.fixture
+def kerberos_config(client, mocker):
+    """Patch app config with Kerberos keytab settings."""
+    mocker.patch.dict(
+        'flask.current_app.config',
+        {
+            'KERBEROS_KEYTAB': '/etc/noggin/noggin.keytab',
+            'KERBEROS_SERVICE_PRINCIPAL': 'HTTP/noggin.example.com@EXAMPLE.COM',
+            'FREEIPA_DOMAIN': 'example.com',
+            'FREEIPA_CACERT': '/etc/ipa/ca.crt',
+            'FERNET_SECRET': b'G8ObvrpEEwbjWUO9rU1qAkDQRafAFd39heVKYf6TZi8=',
+        },
+    )
+
+
+class TestLoadServiceCredentials:
+
+    def test_no_keytab_configured(self, client, mocker):
+        mocker.patch.dict('flask.current_app.config', {'KERBEROS_KEYTAB': None})
+        from flask import current_app
+
+        with pytest.raises(KerberosConfigError, match="not configured"):
+            load_service_credentials(current_app)
+
+    def test_keytab_load_success(self, client, kerberos_config, mocker):
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mock_creds = mock.MagicMock()
+        mock_gssapi.Credentials.return_value = mock_creds
+
+        from flask import current_app
+
+        result = load_service_credentials(current_app)
+        assert result is mock_creds
+        mock_gssapi.Credentials.assert_called_once()
+
+    def test_keytab_load_gssapi_error(self, client, kerberos_config, mocker):
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mock_gssapi.exceptions.GSSError = type('GSSError', (Exception,), {})
+        mock_gssapi.Credentials.side_effect = mock_gssapi.exceptions.GSSError(
+            "keytab not found"
+        )
+
+        from flask import current_app
+
+        with pytest.raises(KerberosConfigError, match="Cannot load"):
+            load_service_credentials(current_app)
+
+    def test_principal_derived_from_fqdn(self, client, mocker):
+        mocker.patch.dict(
+            'flask.current_app.config',
+            {
+                'KERBEROS_KEYTAB': '/etc/noggin/noggin.keytab',
+                'KERBEROS_SERVICE_PRINCIPAL': None,
+                'FREEIPA_DOMAIN': 'example.com',
+            },
+        )
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mocker.patch('noggin.security.kerberos.socket.getfqdn', return_value='noggin.example.com')
+        mock_creds = mock.MagicMock()
+        mock_gssapi.Credentials.return_value = mock_creds
+
+        from flask import current_app
+
+        load_service_credentials(current_app)
+
+        call_args = mock_gssapi.Name.call_args
+        assert call_args[0][0] == 'HTTP/noggin.example.com@EXAMPLE.COM'
+
+
+class TestImpersonateUser:
+
+    def test_success(self, mocker):
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mock_gssapi.exceptions.GSSError = type('GSSError', (Exception,), {})
+        mock_service_creds = mock.MagicMock()
+        mock_impersonated = mock.MagicMock()
+        mock_service_creds.impersonate.return_value = mock_impersonated
+
+        mock_ctx = mock.MagicMock()
+        mock_ctx.step.return_value = b'\x60\x82token-bytes'
+        mock_gssapi.SecurityContext.return_value = mock_ctx
+
+        result = impersonate_user(
+            mock_service_creds, 'testuser', 'HTTP/ipa.example.com@EXAMPLE.COM'
+        )
+        assert result == b'\x60\x82token-bytes'
+        mock_service_creds.impersonate.assert_called_once()
+
+    def test_gssapi_error(self, mocker):
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mock_gssapi.exceptions.GSSError = type('GSSError', (Exception,), {})
+        mock_service_creds = mock.MagicMock()
+        mock_service_creds.impersonate.side_effect = mock_gssapi.exceptions.GSSError(
+            "permission denied"
+        )
+
+        with pytest.raises(KerberosAuthError, match="delegation failed"):
+            impersonate_user(
+                mock_service_creds, 'testuser', 'HTTP/ipa.example.com@EXAMPLE.COM'
+            )
+
+    def test_no_token_produced(self, mocker):
+        mock_gssapi = mocker.patch('noggin.security.kerberos.gssapi')
+        mock_gssapi.exceptions.GSSError = type('GSSError', (Exception,), {})
+        mock_service_creds = mock.MagicMock()
+        mock_impersonated = mock.MagicMock()
+        mock_service_creds.impersonate.return_value = mock_impersonated
+
+        mock_ctx = mock.MagicMock()
+        mock_ctx.step.return_value = None
+        mock_gssapi.SecurityContext.return_value = mock_ctx
+
+        with pytest.raises(KerberosAuthError, match="no token"):
+            impersonate_user(
+                mock_service_creds, 'testuser', 'HTTP/ipa.example.com@EXAMPLE.COM'
+            )
+
+
+class TestIpaLoginWithKerberos:
+
+    def _mock_common(self, mocker):
+        """Set up common mocks for ipa_login_with_kerberos tests."""
+        mocker.patch(
+            'noggin.security.kerberos.load_service_credentials',
+            return_value=mock.MagicMock(),
+        )
+        mocker.patch(
+            'noggin.security.kerberos.choose_server',
+            return_value='ipa.example.com',
+        )
+        mocker.patch(
+            'noggin.security.kerberos.impersonate_user',
+            return_value=b'spnego-token',
+        )
+
+    def test_successful_login(self, client, kerberos_config, mocker):
+        self._mock_common(mocker)
+
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.cookies.get.return_value = 'fake-ipa-session-cookie'
+        mocker.patch(
+            'noggin.security.kerberos.requests.post',
+            return_value=mock_response,
+        )
+
+        from flask import current_app
+
+        sess = {}
+        result = ipa_login_with_kerberos(current_app, sess, 'testuser')
+        assert result is not None
+        assert sess['noggin_username'] == 'testuser'
+        assert 'noggin_session' in sess
+
+    def test_no_ipa_server(self, client, kerberos_config, mocker):
+        mocker.patch(
+            'noggin.security.kerberos.load_service_credentials',
+            return_value=mock.MagicMock(),
+        )
+        mocker.patch(
+            'noggin.security.kerberos.choose_server',
+            side_effect=__import__(
+                'noggin.security.ipa', fromlist=['NoIPAServer']
+            ).NoIPAServer(),
+        )
+
+        from flask import current_app
+
+        with pytest.raises(KerberosAuthError, match="No IPA server"):
+            ipa_login_with_kerberos(current_app, {}, 'testuser')
+
+    def test_http_error(self, client, kerberos_config, mocker):
+        self._mock_common(mocker)
+
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 401
+        mocker.patch(
+            'noggin.security.kerberos.requests.post',
+            return_value=mock_response,
+        )
+
+        from flask import current_app
+
+        with pytest.raises(KerberosAuthError, match="login failed"):
+            ipa_login_with_kerberos(current_app, {}, 'testuser')
+
+    def test_no_session_cookie(self, client, kerberos_config, mocker):
+        self._mock_common(mocker)
+
+        mock_response = mock.MagicMock()
+        mock_response.status_code = 200
+        mock_response.cookies.get.return_value = None
+        mocker.patch(
+            'noggin.security.kerberos.requests.post',
+            return_value=mock_response,
+        )
+
+        from flask import current_app
+
+        with pytest.raises(KerberosAuthError, match="did not return a session"):
+            ipa_login_with_kerberos(current_app, {}, 'testuser')
+
+    def test_request_exception(self, client, kerberos_config, mocker):
+        self._mock_common(mocker)
+        mocker.patch(
+            'noggin.security.kerberos.requests.post',
+            side_effect=__import__('requests').RequestException("timeout"),
+        )
+
+        from flask import current_app
+
+        with pytest.raises(KerberosAuthError, match="Could not contact"):
+            ipa_login_with_kerberos(current_app, {}, 'testuser')

--- a/tests/unit/utility/test_passkey.py
+++ b/tests/unit/utility/test_passkey.py
@@ -1,0 +1,379 @@
+import base64
+import hashlib
+import json
+import struct
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
+from fido2 import cbor
+
+from noggin.utility.passkey import (
+    b64url_decode,
+    b64url_encode,
+    compute_user_handle,
+    cose_to_spki_der,
+    detect_key_type,
+    format_passkey_attr,
+    parse_passkey_attr,
+    verify_registration,
+)
+
+# ── Test fixtures ────────────────────────────────────────────────────────
+
+
+# P-256 generator point (a valid point on the curve)
+_P256_GX = bytes.fromhex(
+    '6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296'
+)
+_P256_GY = bytes.fromhex(
+    '4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5'
+)
+
+
+def _make_cose_key(kty=2, alg=-7, crv=1):
+    """Build a COSE_Key CBOR blob for testing."""
+    if kty == 2:  # EC2
+        key = {1: kty, 3: alg, -1: crv, -2: _P256_GX, -3: _P256_GY}
+    elif kty == 1:  # OKP
+        key = {1: kty, 3: alg, -1: crv, -2: b'\x01' * 32}
+    elif kty == 3:  # RSA
+        key = {1: kty, 3: alg, -1: b'\x01' * 256, -2: b'\x01\x00\x01'}
+    else:
+        key = {1: kty, 3: alg}
+    return cbor.encode(key)
+
+
+def _make_ec_spki_der():
+    """Build an EC P-256 SPKI DER from known COSE key bytes."""
+    cose = _make_cose_key(kty=2, alg=-7, crv=1)
+    return cose_to_spki_der(cose)
+
+
+def _make_ed25519_spki_der():
+    """Build an Ed25519 SPKI DER from known COSE key bytes."""
+    cose = _make_cose_key(kty=1, alg=-8, crv=6)
+    return cose_to_spki_der(cose)
+
+
+def _make_rsa_spki_der():
+    """Build an RSA SPKI DER from known COSE key bytes."""
+    cose = _make_cose_key(kty=3, alg=-257)
+    return cose_to_spki_der(cose)
+
+
+CRED_ID = b'\x03' * 32
+CRED_ID_B64 = base64.b64encode(CRED_ID).decode()
+ES256_COSE = _make_cose_key(kty=2, alg=-7, crv=1)
+ES256_SPKI = _make_ec_spki_der()
+ES256_SPKI_B64 = base64.b64encode(ES256_SPKI).decode()
+PASSKEY_VALUE = f"passkey:{CRED_ID_B64},{ES256_SPKI_B64}"
+
+RP_ID = "example.com"
+ORIGIN = "https://accounts.example.com"
+CHALLENGE = b'\x04' * 32
+
+
+def _build_auth_data(
+    rp_id=RP_ID, flags=0x41, counter=0, cred_id=CRED_ID, cose_key=None
+):
+    """Build raw authData bytes."""
+    if cose_key is None:
+        cose_key = ES256_COSE
+    rp_id_hash = hashlib.sha256(rp_id.encode()).digest()
+    return (
+        rp_id_hash
+        + bytes([flags])
+        + struct.pack('>I', counter)
+        + b'\x00' * 16  # AAGUID
+        + struct.pack('>H', len(cred_id))
+        + cred_id
+        + cose_key
+    )
+
+
+def _build_auth_data_minimal(rp_id=RP_ID, flags=0x01, counter=0):
+    """Build raw authData bytes without attested credential data."""
+    rp_id_hash = hashlib.sha256(rp_id.encode()).digest()
+    return rp_id_hash + bytes([flags]) + struct.pack('>I', counter)
+
+
+def _build_attestation(
+    rp_id=RP_ID,
+    challenge=CHALLENGE,
+    origin=ORIGIN,
+    cdj_type='webauthn.create',
+    flags=0x41,
+    include_cred_data=True,
+):
+    """Build base64url-encoded clientDataJSON and attestationObject."""
+    challenge_b64url = b64url_encode(challenge)
+    cdj = json.dumps(
+        {'type': cdj_type, 'challenge': challenge_b64url, 'origin': origin}
+    )
+    cdj_b64url = b64url_encode(cdj.encode())
+
+    if include_cred_data:
+        auth_data = _build_auth_data(rp_id=rp_id, flags=flags)
+    else:
+        auth_data = _build_auth_data_minimal(rp_id=rp_id, flags=flags)
+    att_obj = cbor.encode({'fmt': 'none', 'attStmt': {}, 'authData': auth_data})
+    att_obj_b64url = b64url_encode(att_obj)
+
+    return cdj_b64url, att_obj_b64url
+
+
+# ── cose_to_spki_der ───────────────────────────────────────────────────
+
+
+def test_cose_to_spki_der_es256():
+    cose = _make_cose_key(kty=2, alg=-7, crv=1)
+    spki = cose_to_spki_der(cose)
+    assert spki[0] == 0x30  # DER SEQUENCE tag
+    assert len(spki) == 91  # P-256 SPKI is always 91 bytes
+    key = serialization.load_der_public_key(spki)
+    assert isinstance(key, ec.EllipticCurvePublicKey)
+    assert isinstance(key.curve, ec.SECP256R1)
+
+
+def test_cose_to_spki_der_eddsa():
+    cose = _make_cose_key(kty=1, alg=-8, crv=6)
+    spki = cose_to_spki_der(cose)
+    assert spki[0] == 0x30
+    assert len(spki) == 44  # Ed25519 SPKI is always 44 bytes
+    key = serialization.load_der_public_key(spki)
+    assert isinstance(key, ed25519.Ed25519PublicKey)
+
+
+def test_cose_to_spki_der_rs256():
+    cose = _make_cose_key(kty=3, alg=-257)
+    spki = cose_to_spki_der(cose)
+    assert spki[0] == 0x30
+    key = serialization.load_der_public_key(spki)
+    assert isinstance(key, rsa.RSAPublicKey)
+
+
+def test_cose_to_spki_der_unsupported_kty():
+    cose = cbor.encode({1: 99, 3: -7})
+    with pytest.raises(ValueError, match="Unsupported COSE key type"):
+        cose_to_spki_der(cose)
+
+
+def test_cose_to_spki_der_unsupported_ec_curve():
+    cose = _make_cose_key(kty=2, alg=-7, crv=99)
+    with pytest.raises(ValueError, match="Unsupported EC2 curve"):
+        cose_to_spki_der(cose)
+
+
+def test_cose_to_spki_der_unsupported_okp_curve():
+    cose = _make_cose_key(kty=1, alg=-8, crv=99)
+    with pytest.raises(ValueError, match="Unsupported OKP curve"):
+        cose_to_spki_der(cose)
+
+
+# ── parse_passkey_attr ───────────────────────────────────────────────────
+
+
+def test_parse_passkey_attr_valid():
+    result = parse_passkey_attr(PASSKEY_VALUE)
+    assert result is not None
+    assert result.credential_id == CRED_ID
+    assert result.credential_id_b64 == CRED_ID_B64
+    assert result.public_key_der == ES256_SPKI
+    assert result.key_type == "ES256"
+    assert result.display_id == CRED_ID.hex()[:16]
+    assert result.raw_value == PASSKEY_VALUE
+
+
+def test_parse_passkey_attr_with_userid():
+    userid_b64 = base64.b64encode(b'\x05' * 16).decode()
+    value = f"passkey:{CRED_ID_B64},{ES256_SPKI_B64},{userid_b64}"
+    result = parse_passkey_attr(value)
+    assert result is not None
+    assert result.credential_id == CRED_ID
+    assert result.key_type == "ES256"
+    assert result.raw_value == value
+
+
+def test_parse_passkey_attr_invalid_prefix():
+    assert parse_passkey_attr("notpasskey:abc,def") is None
+
+
+def test_parse_passkey_attr_no_comma():
+    assert parse_passkey_attr("passkey:abc") is None
+
+
+def test_parse_passkey_attr_invalid_base64():
+    assert parse_passkey_attr("passkey:!!!,!!!") is None
+
+
+def test_parse_passkey_attr_empty_after_prefix():
+    assert parse_passkey_attr("passkey:") is None
+
+
+# ── format_passkey_attr ──────────────────────────────────────────────────
+
+
+def test_format_passkey_attr():
+    result = format_passkey_attr(CRED_ID, ES256_COSE)
+    assert result.startswith("passkey:")
+    parts = result[len("passkey:") :].split(",")
+    assert len(parts) == 2
+    cred_id_decoded = base64.b64decode(parts[0])
+    assert cred_id_decoded == CRED_ID
+    spki_decoded = base64.b64decode(parts[1])
+    assert spki_decoded[0] == 0x30  # DER SEQUENCE
+
+
+def test_format_parse_roundtrip():
+    formatted = format_passkey_attr(CRED_ID, ES256_COSE)
+    parsed = parse_passkey_attr(formatted)
+    assert parsed is not None
+    assert parsed.credential_id == CRED_ID
+    assert parsed.key_type == "ES256"
+
+
+# ── detect_key_type ──────────────────────────────────────────────────────
+
+
+def test_detect_key_type_es256():
+    spki = _make_ec_spki_der()
+    assert detect_key_type(spki) == "ES256"
+
+
+def test_detect_key_type_eddsa():
+    spki = _make_ed25519_spki_der()
+    assert detect_key_type(spki) == "EdDSA"
+
+
+def test_detect_key_type_rs256():
+    spki = _make_rsa_spki_der()
+    assert detect_key_type(spki) == "RS256"
+
+
+def test_detect_key_type_invalid_der():
+    assert detect_key_type(b'\xff\xff') == "unknown"
+
+
+# ── compute_user_handle ──────────────────────────────────────────────────
+
+
+TEST_SECRET = b'test-secret-key-for-unit-tests'
+
+
+def test_compute_user_handle_length():
+    handle = compute_user_handle("testuser", TEST_SECRET)
+    assert len(handle) == 32
+
+
+def test_compute_user_handle_deterministic():
+    assert compute_user_handle("alice", TEST_SECRET) == compute_user_handle("alice", TEST_SECRET)
+
+
+def test_compute_user_handle_different_users():
+    assert compute_user_handle("alice", TEST_SECRET) != compute_user_handle("bob", TEST_SECRET)
+
+
+# ── b64url helpers ───────────────────────────────────────────────────────
+
+
+def test_b64url_roundtrip():
+    data = b'\x00\x01\x02\xff\xfe\xfd'
+    assert b64url_decode(b64url_encode(data)) == data
+
+
+def test_b64url_no_padding():
+    encoded = b64url_encode(b'\x00' * 3)
+    assert '=' not in encoded
+
+
+# ── verify_registration ─────────────────────────────────────────────────
+
+
+def test_verify_registration_valid():
+    cdj_b64, att_b64 = _build_attestation()
+    result = verify_registration(
+        client_data_json_b64=cdj_b64,
+        attestation_object_b64=att_b64,
+        expected_challenge=CHALLENGE,
+        expected_rp_id=RP_ID,
+        expected_origin=ORIGIN,
+    )
+    assert result.credential_id == CRED_ID
+    assert len(result.public_key_cose) > 0
+    decoded = cbor.decode(result.public_key_cose)
+    assert decoded[1] == 2  # kty: EC2
+
+
+def test_verify_registration_wrong_challenge():
+    cdj_b64, att_b64 = _build_attestation()
+    with pytest.raises(ValueError, match="Challenge mismatch"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=b'\xff' * 32,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+        )
+
+
+def test_verify_registration_wrong_origin():
+    cdj_b64, att_b64 = _build_attestation()
+    with pytest.raises(ValueError, match="Origin mismatch"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin="https://evil.example.com",
+        )
+
+
+def test_verify_registration_wrong_rp_id():
+    cdj_b64, att_b64 = _build_attestation()
+    with pytest.raises(ValueError, match="RP ID hash mismatch"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=CHALLENGE,
+            expected_rp_id="wrong.example.com",
+            expected_origin=ORIGIN,
+        )
+
+
+def test_verify_registration_wrong_type():
+    cdj_b64, att_b64 = _build_attestation(cdj_type='webauthn.get')
+    with pytest.raises(ValueError, match="clientData type"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+        )
+
+
+def test_verify_registration_no_user_presence():
+    cdj_b64, att_b64 = _build_attestation(flags=0x40)  # AT set but UP not set
+    with pytest.raises(ValueError, match="User presence"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+        )
+
+
+def test_verify_registration_no_attested_data():
+    cdj_b64, att_b64 = _build_attestation(
+        flags=0x01, include_cred_data=False
+    )  # UP set but AT not set, no credential data bytes
+    with pytest.raises(ValueError, match="(attested credential data|No attested)"):
+        verify_registration(
+            client_data_json_b64=cdj_b64,
+            attestation_object_b64=att_b64,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+        )

--- a/tests/unit/utility/test_passkey.py
+++ b/tests/unit/utility/test_passkey.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, ed25519, rsa
 from fido2 import cbor
 
 from noggin.utility.passkey import (
+    AssertionResult,
     b64url_decode,
     b64url_encode,
     compute_user_handle,
@@ -16,6 +17,7 @@ from noggin.utility.passkey import (
     detect_key_type,
     format_passkey_attr,
     parse_passkey_attr,
+    verify_assertion,
     verify_registration,
 )
 
@@ -376,4 +378,222 @@ def test_verify_registration_no_attested_data():
             expected_challenge=CHALLENGE,
             expected_rp_id=RP_ID,
             expected_origin=ORIGIN,
+        )
+
+
+# ── verify_assertion ───────────────────────────────────────────────────
+
+
+def _make_assertion(
+    rp_id=RP_ID,
+    challenge=CHALLENGE,
+    origin=ORIGIN,
+    cdj_type='webauthn.get',
+    flags=0x01,
+    counter=1,
+    private_key=None,
+    public_key_der=None,
+):
+    """Build a complete WebAuthn assertion with a real signature."""
+    if private_key is None:
+        private_key = ec.generate_private_key(ec.SECP256R1())
+    if public_key_der is None:
+        public_key_der = private_key.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+
+    rp_id_hash = hashlib.sha256(rp_id.encode()).digest()
+    auth_data = rp_id_hash + bytes([flags]) + struct.pack('>I', counter)
+
+    challenge_b64url = b64url_encode(challenge)
+    cdj = json.dumps(
+        {'type': cdj_type, 'challenge': challenge_b64url, 'origin': origin}
+    )
+    cdj_bytes = cdj.encode()
+    client_data_hash = hashlib.sha256(cdj_bytes).digest()
+
+    signed_data = auth_data + client_data_hash
+
+    from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
+
+    if isinstance(private_key, ec.EllipticCurvePrivateKey):
+        from cryptography.hazmat.primitives import hashes
+
+        der_sig = private_key.sign(signed_data, ec.ECDSA(hashes.SHA256()))
+        r, s = asym_utils.decode_dss_signature(der_sig)
+        byte_len = (private_key.key_size + 7) // 8
+        raw_sig = r.to_bytes(byte_len, 'big') + s.to_bytes(byte_len, 'big')
+    elif isinstance(private_key, ed25519.Ed25519PrivateKey):
+        raw_sig = private_key.sign(signed_data)
+    elif isinstance(private_key, rsa.RSAPrivateKey):
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        raw_sig = private_key.sign(
+            signed_data, padding.PKCS1v15(), hashes.SHA256()
+        )
+    else:
+        raise TypeError(f"Unsupported key type: {type(private_key)}")
+
+    return {
+        'client_data_json_b64': b64url_encode(cdj_bytes),
+        'authenticator_data_b64': b64url_encode(auth_data),
+        'signature_b64': b64url_encode(raw_sig),
+        'public_key_der': public_key_der,
+    }
+
+
+def test_verify_assertion_es256():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    result = verify_assertion(
+        credential_id=CRED_ID,
+        expected_challenge=CHALLENGE,
+        expected_rp_id=RP_ID,
+        expected_origin=ORIGIN,
+        **assertion,
+    )
+    assert isinstance(result, AssertionResult)
+    assert result.credential_id == CRED_ID
+
+
+def test_verify_assertion_eddsa():
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    result = verify_assertion(
+        credential_id=CRED_ID,
+        expected_challenge=CHALLENGE,
+        expected_rp_id=RP_ID,
+        expected_origin=ORIGIN,
+        **assertion,
+    )
+    assert result.credential_id == CRED_ID
+
+
+def test_verify_assertion_rs256():
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    result = verify_assertion(
+        credential_id=CRED_ID,
+        expected_challenge=CHALLENGE,
+        expected_rp_id=RP_ID,
+        expected_origin=ORIGIN,
+        **assertion,
+    )
+    assert result.credential_id == CRED_ID
+
+
+def test_verify_assertion_wrong_challenge():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    with pytest.raises(ValueError, match="Challenge mismatch"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=b'\xff' * 32,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+            **assertion,
+        )
+
+
+def test_verify_assertion_wrong_origin():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    with pytest.raises(ValueError, match="Origin mismatch"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin="https://evil.example.com",
+            **assertion,
+        )
+
+
+def test_verify_assertion_wrong_rp_id():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    with pytest.raises(ValueError, match="RP ID hash mismatch"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=CHALLENGE,
+            expected_rp_id="wrong.example.com",
+            expected_origin=ORIGIN,
+            **assertion,
+        )
+
+
+def test_verify_assertion_wrong_type():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(
+        private_key=private_key, public_key_der=pub_der, cdj_type='webauthn.create'
+    )
+    with pytest.raises(ValueError, match="clientData type"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+            **assertion,
+        )
+
+
+def test_verify_assertion_no_user_presence():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(
+        private_key=private_key, public_key_der=pub_der, flags=0x00
+    )
+    with pytest.raises(ValueError, match="User presence"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+            **assertion,
+        )
+
+
+def test_verify_assertion_invalid_signature():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pub_der = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion = _make_assertion(private_key=private_key, public_key_der=pub_der)
+    # Use a different key's public key to cause signature mismatch
+    other_key = ec.generate_private_key(ec.SECP256R1())
+    other_pub_der = other_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    assertion['public_key_der'] = other_pub_der
+    with pytest.raises(ValueError, match="Signature verification failed"):
+        verify_assertion(
+            credential_id=CRED_ID,
+            expected_challenge=CHALLENGE,
+            expected_rp_id=RP_ID,
+            expected_origin=ORIGIN,
+            **assertion,
         )


### PR DESCRIPTION
This is a first cut of supporting passkeys in Noggin. FreeIPA supports passkeys natively for Kerberos authentication and while working on a new OAuth2 IdP for FreeIPA, I added ability to login with FIDO2 passkeys and manage them in IPA. This PR represents a port of that code to Python and adjusted to Noggin's django app.

I haven't tried it yet myself -- the original FreeIPA integration works but Noggin port needs testing.

Assisted by Claude Code