### PR TITLE
Add OTP recovery codes and admin-assisted OTP reset

### DIFF
--- a/deployment/noggin.cfg.example
+++ b/deployment/noggin.cfg.example
@@ -124,5 +124,23 @@ CHAT_MATRIX_TO_ARGS = "web-instance[element.io]=app.element.io"
 # BASSET_URL = None
 # SPAMCHECK_TOKEN_EXPIRATION = 60  # in minutes
 
+# OTP Recovery Codes
+# Number of recovery codes to generate. Must not exceed the FreeIPA
+# ipatokenHOTPauthWindow (default: 10).
+# OTP_RECOVERY_CODE_COUNT = 10
+# Token description used to identify recovery tokens.
+# WARNING: Changing this value after recovery tokens have been created will
+# cause existing tokens to no longer be recognized as recovery tokens.
+# OTP_RECOVERY_DESCRIPTION = "Recovery codes"
+# Warn the user when this many or fewer recovery codes remain.
+# OTP_RECOVERY_LOW_THRESHOLD = 3
+# Auto-generate recovery codes when the user enrolls their first OTP token.
+# OTP_REQUIRE_RECOVERY_CODES = False
+# IPA role whose members may reset another user's OTP tokens and generate
+# recovery codes on their behalf. Set to None (default) to disable.
+# To set up: ipa role-add "OTP Recovery Admins" --desc="..."
+#            ipa role-add-member "OTP Recovery Admins" --users=helpdesk_user
+# OTP_ADMIN_RECOVERY_ROLE = "OTP Recovery Admins"
+
 # Set to True to enable Fedora Messaging integration
 # FEDORA_MESSAGING_ENABLED = True

--- a/docs/design-otp-recovery-codes.rst
+++ b/docs/design-otp-recovery-codes.rst
@@ -1,0 +1,791 @@
+=====================
+OTP Recovery Codes
+=====================
+
+:Author: Alexander Bokovoy
+:Status: Implemented
+:Created: 2026-07-02
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+
+Problem Statement
+=================
+
+When a Noggin user enrolls an OTP token for two-factor authentication,
+losing the authenticator device (phone loss, factory reset, hardware
+failure) locks them out completely. FreeIPA enforces OTP once any token
+is active for the user — there is no fallback. The only recovery path
+today requires an IPA administrator to delete the lost token and
+provision a new one.
+
+This is unacceptable for a self-service portal. Users must have a
+recovery mechanism they can set up *before* lockout occurs, without
+requiring administrator intervention.
+
+
+Goals
+=====
+
+1. Allow users to generate a set of single-use recovery codes during OTP
+   enrollment.
+2. Any recovery code can be used in place of a TOTP code at any login
+   prompt (Noggin, SSH, FreeIPA WebUI, etc.).
+3. No changes to FreeIPA schema, ``ipa-otpd``, or 389-ds SLAPI plugins.
+4. Fit naturally into Noggin's existing OTP management UI.
+5. Recovery codes can be regenerated (invalidating all previous codes).
+
+
+Non-Goals
+=========
+
+- Out-of-band identity verification (email link, manager approval) for
+  locked-out users who never set up recovery codes.
+- Per-token HOTP authentication window overrides (requires FreeIPA
+  schema changes).
+
+
+Design
+======
+
+Overview
+--------
+
+Recovery codes are implemented as an **always-active HOTP token** owned
+by the user. Each recovery code is a pre-computed HOTP value for a
+sequential counter position. Because the token stays enabled, the
+FreeIPA OTP validation path accepts recovery codes alongside the user's
+primary TOTP token with no server-side changes.
+
+This is the same pattern used by Google, GitHub, and most services that
+offer backup codes for 2FA.
+
+
+How It Works in FreeIPA
+-----------------------
+
+FreeIPA's OTP validation happens inside the ``ipa-pwd-extop`` SLAPI
+plugin (``prepost.c:ipapwd_pre_bind_otp()``). When a user authenticates
+with ``password + OTP``:
+
+1. The plugin calls ``otp_token_find()`` which searches LDAP for all
+   **active** tokens owned by the user. The LDAP filter excludes
+   disabled tokens (``ipatokenDisabled=TRUE``) and tokens outside their
+   validity window.
+
+2. ``otp_token_validate_berval()`` iterates over all matching tokens and
+   tries to validate the OTP code from the end of the password string
+   against each token (TOTP or HOTP).
+
+3. For an HOTP token, validation checks the code against
+   ``counter + offset`` for offsets 0 through ``ipatokenHOTPauthWindow``
+   (default: 10). On success, the counter advances past the matched
+   position. The counter never goes backwards, so each code is
+   single-use.
+
+Because the recovery HOTP token is active and owned by the user, it
+participates in this validation loop transparently. No changes to the
+FreeIPA C code, Python plugins, or LDAP schema are needed.
+
+
+Identifying Recovery Tokens
+----------------------------
+
+FreeIPA has no ``ipatokenPurpose`` attribute. Recovery tokens are
+distinguished by convention:
+
+- **Description**: Set to ``"Recovery codes"`` (the literal string, not
+  localized in LDAP — localization is only in the Noggin UI).
+- **Token type**: ``hotp`` (as opposed to ``totp`` for the primary
+  token).
+
+Noggin identifies a user's recovery token by loading all tokens and
+filtering with the ``is_recovery(description)`` method::
+
+    desc = current_app.config['OTP_RECOVERY_DESCRIPTION']
+    recovery_token = next(
+        (t for t in all_tokens if t.is_recovery(desc)), None
+    )
+
+When generating or regenerating codes, the route also does a targeted
+search::
+
+    ipa.otptoken_find(
+        o_ipatokenowner=username,
+        o_type='hotp',
+        o_description=current_app.config['OTP_RECOVERY_DESCRIPTION'],
+    )
+
+The description is a convention, not an enforcement mechanism. A user
+who renames the token via IPA CLI breaks the lookup, but the codes still
+work for authentication. Noggin hides the rename/disable/delete buttons
+for recovery tokens and blocks renaming a regular token to the recovery
+description.
+
+
+Code Count and HOTP Auth Window
+-------------------------------
+
+The default ``ipatokenHOTPauthWindow`` is **10**, meaning the server
+accepts codes up to 10 counter positions ahead of the current counter.
+This constrains the design:
+
+- **Generate exactly 10 codes** (counter positions 0–9).
+- If the user uses code #7 first, the counter advances to 8. Codes 0–6
+  become permanently invalid. Codes 8 and 9 remain valid.
+- Generating more than 10 codes would fail: code #15 is 15 positions
+  ahead of counter 0, exceeding the auth window.
+
+The global HOTP auth window is configurable via ``ipa otpconfig-mod
+--hotpauthwindow=N``, but this is a deployment decision and not
+something Noggin should change.
+
+
+Implementation Plan
+===================
+
+1. Configuration
+----------------
+
+Add to ``noggin/defaults.py``::
+
+    # Number of recovery codes to generate. Must not exceed the FreeIPA
+    # ipatokenHOTPauthWindow (default: 10).
+    OTP_RECOVERY_CODE_COUNT = 10
+    # Description string used to identify recovery tokens in LDAP.
+    OTP_RECOVERY_DESCRIPTION = "Recovery codes"
+
+The code count is a configuration value rather than a hard-coded constant
+so deployments with a larger ``ipatokenHOTPauthWindow`` can increase it.
+
+
+2. Recovery Code Generation Utility
+------------------------------------
+
+A helper in ``noggin/utility/recovery_codes.py`` computes HOTP codes
+from a Base32-encoded key::
+
+    from pyotp import HOTP
+
+    def generate_recovery_codes(secret_b32: str, count: int) -> list[str]:
+        """Pre-compute HOTP codes for counter positions 0..count-1.
+
+        Returns a list of zero-padded 8-digit code strings.
+        """
+        hotp = HOTP(secret_b32, digits=8)
+        return [hotp.at(i) for i in range(count)]
+
+Using 8 digits (vs 6 for TOTP) makes recovery codes visually distinct
+from regular OTP codes, reducing user confusion. The ``pyotp`` library
+already supports HOTP; no new dependencies are needed.
+
+
+3. OTPToken Representation
+---------------------------
+
+``noggin/representation/otptoken.py`` exposes the HOTP counter and a
+method to identify recovery tokens::
+
+    class OTPToken(Representation):
+        attr_names = {
+            "uniqueid": "ipatokenuniqueid",
+            "description": "description",
+            "disabled": "ipatokendisabled",
+            "counter": "ipatokenhotpcounter",
+        }
+        attr_types = {
+            "disabled": "bool",
+            "counter": "int",
+        }
+        pkey = "uniqueid"
+        ipa_object = "otptoken"
+
+        @property
+        def uri(self):
+            return self.raw.get('uri')
+
+        def is_recovery(self, recovery_description):
+            token_type = self.raw.get('type') or ''
+            if isinstance(token_type, list):
+                token_type = token_type[0] if token_type else ''
+            return (
+                token_type.lower() == 'hotp'
+                and self.description == recovery_description
+            )
+
+``is_recovery`` is a **method** (not a property) that takes the
+recovery description string as a parameter. This decouples the
+``OTPToken`` class from the Flask application context — the caller
+passes ``current_app.config['OTP_RECOVERY_DESCRIPTION']`` rather than
+the representation reading it from ``current_app`` directly.
+
+The ``type`` field is a virtual attribute that FreeIPA computes from the
+LDAP objectClass (``ipatokenTOTP`` → ``"TOTP"``, ``ipatokenHOTP`` →
+``"HOTP"``). It is returned by ``otptoken_find`` and ``otptoken_show``
+but is **not** included in ``attr_names`` because FreeIPA returns it as
+a plain string (not a list) or sometimes as a list, depending on
+context. The method reads from ``self.raw`` directly and handles both
+cases.
+
+The ``counter`` attribute uses an ``int`` converter (added to
+``noggin/representation/base.py``) to parse the HOTP counter value,
+which is used to compute how many recovery codes remain.
+
+
+4. Forms
+--------
+
+Add to ``noggin/form/edit_user.py``::
+
+    class UserSettingsGenerateRecoveryForm(ModestForm):
+        password = PasswordField(
+            _('Enter your current password'),
+            validators=[DataRequired(message=_('You must provide a password'))],
+        )
+        otp = StringField(
+            _('One-Time Password'),
+            validators=[Optional()],
+        )
+        submit = SubmitButtonField(_("Generate Recovery Codes"))
+
+
+    class UserSettingsRegenerateRecoveryForm(ModestForm):
+        password = PasswordField(
+            _('Enter your current password'),
+            validators=[DataRequired(message=_('You must provide a password'))],
+        )
+        otp = StringField(
+            _('One-Time Password'),
+            validators=[Optional()],
+        )
+        submit = SubmitButtonField(_("Regenerate Recovery Codes"))
+
+Two distinct form classes allow ``ModestForm``'s submit-button detection
+to distinguish which action the user intends on a page with both forms.
+
+
+5. Controller Routes
+--------------------
+
+All OTP routes live in ``noggin/controller/user_otp.py`` (extracted from
+``user.py`` for maintainability). The module includes a
+``_reauthenticate(form, auth_username)`` helper that consolidates the
+password+OTP re-authentication pattern used by the generate, regenerate,
+and admin reset routes.
+
+``POST /user/<username>/settings/otp/recovery/generate``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Generates a new set of recovery codes. Steps:
+
+1. Validate ``UserSettingsGenerateRecoveryForm``.
+2. Re-authenticate the user with ``maybe_ipa_login()`` (password +
+   existing OTP).
+3. Check that the user has no existing recovery token (to prevent
+   duplicates).
+4. Generate a 35-byte random key:
+   ``b32encode(os.urandom(OTP_KEY_LENGTH)).decode('ascii')``.
+5. Create the HOTP token in FreeIPA::
+
+       ipa.otptoken_add(
+           o_ipatokenowner=username,
+           o_type='hotp',
+           o_ipatokenotpkey=secret,
+           o_ipatokenotpdigits=8,
+           o_ipatokenotpalgorithm='sha256',
+           o_description='Recovery codes',
+       )
+
+6. Compute HOTP codes 0..9 from the key using ``generate_recovery_codes()``.
+7. Render a page showing the codes with a strong warning to save them.
+
+``POST /user/<username>/settings/otp/recovery/regenerate``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Regenerates recovery codes (invalidates all previous ones). Steps:
+
+1. Validate ``UserSettingsRegenerateRecoveryForm``.
+2. Re-authenticate the user.
+3. Find and delete the existing recovery token::
+
+       tokens = ipa.otptoken_find(
+           o_ipatokenowner=username,
+           o_type='hotp',
+           o_description='Recovery codes',
+       )
+       for t in tokens['result']:
+           ipa.otptoken_del(
+               a_ipatokenuniqueid=t['ipatokenuniqueid'][0],
+           )
+
+4. Create a new HOTP token and compute codes (same as generate flow).
+5. Render the codes page.
+
+
+6. OTP Settings Page Changes
+-----------------------------
+
+``user_settings_otp()`` in ``noggin/controller/user_otp.py``:
+
+- Passes ``generate_recovery_form`` and ``regenerate_recovery_form`` to
+  the template.
+- Separates tokens into regular tokens and recovery tokens using the
+  ``_categorize_tokens()`` helper::
+
+      def _categorize_tokens(all_tokens):
+          desc = current_app.config['OTP_RECOVERY_DESCRIPTION']
+          tokens = [t for t in all_tokens if not t.is_recovery(desc)]
+          tokens.sort(key=lambda t: t.description or "")
+          recovery_token = next(
+              (t for t in all_tokens if t.is_recovery(desc)), None
+          )
+          return tokens, recovery_token
+
+- Passes ``recovery_token`` and the forms to the template.
+
+
+7. Template Changes
+-------------------
+
+Shared recovery code display logic is in
+``noggin/templates/_recovery_codes.html``, which provides two Jinja2
+macros:
+
+- ``codes_grid(recovery_codes)`` — renders the 2-column grid of codes
+  with Copy and Download buttons.
+- ``codes_scripts(download_filename)`` — renders the JavaScript for
+  copy-to-clipboard and download-as-text-file functionality.
+
+Both ``user-settings-otp.html`` and ``user-settings-otp-admin-reset.html``
+import these macros with ``{% import '_recovery_codes.html' as recovery_macros %}``.
+
+Changes to ``user-settings-otp.html``:
+
+Recovery codes section (after the token list)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: html+jinja
+
+   <div class="card-body mt-4">
+     <h5>{{ _("Recovery Codes") }}</h5>
+     <p class="text-muted">
+       {{ _("Recovery codes can be used to sign in if you lose access "
+            "to your authenticator app. Each code can only be used once.") }}
+     </p>
+     {% if recovery_token %}
+       <p>
+         <span class="badge bg-success">{{ _("Active") }}</span>
+         {{ _("You have recovery codes set up.") }}
+       </p>
+       <form action="{{ url_for('.user_settings_otp_recovery_regenerate',
+                        username=current_user.username) }}"
+             method="post" class="d-inline">
+         <input type="hidden" name="csrf_token"
+                value="{{ csrf_token() }}"/>
+         {{ regenerate_recovery_form.password(
+                placeholder=_("Current password")) }}
+         {% if tokens %}
+           {{ regenerate_recovery_form.otp(
+                  placeholder=_("One-Time Password")) }}
+         {% endif %}
+         {{ regenerate_recovery_form.submit(color="warning") }}
+       </form>
+     {% else %}
+       <p>
+         <span class="badge bg-warning text-dark">{{ _("Not set up") }}</span>
+         {{ _("You have no recovery codes. Generate them now to avoid "
+              "being locked out if you lose your authenticator device.") }}
+       </p>
+       <form action="{{ url_for('.user_settings_otp_recovery_generate',
+                        username=current_user.username) }}"
+             method="post" class="d-inline">
+         <input type="hidden" name="csrf_token"
+                value="{{ csrf_token() }}"/>
+         {{ generate_recovery_form.password(
+                placeholder=_("Current password")) }}
+         {% if tokens %}
+           {{ generate_recovery_form.otp(
+                  placeholder=_("One-Time Password")) }}
+         {% endif %}
+         {{ generate_recovery_form.submit(color="primary") }}
+       </form>
+     {% endif %}
+   </div>
+
+Recovery codes display modal
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+After generation/regeneration, display the codes in a modal with:
+
+- A grid of 10 codes in monospace font (2 columns × 5 rows).
+- A "Copy all" button.
+- A "Download as text file" button.
+- A prominent warning: *"Save these codes in a safe place. You will not
+  be able to see them again."*
+- A checkbox: *"I have saved my recovery codes"* that enables the
+  "Done" button.
+
+Recovery token in the token list
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The recovery token must **not** appear in the regular token list. It is
+shown only in the dedicated recovery codes section. The
+``_categorize_tokens()`` helper (applied in the controller, not the
+template) separates recovery tokens from regular ones.
+
+First-token enrollment prompt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a user creates their **first** OTP token, after the TOTP
+confirmation step, redirect to the recovery codes generation flow (or
+show a strong prompt to generate them). This ensures every OTP user has
+recovery codes from day one.
+
+The implementation should add a flash message after successful first
+token creation::
+
+    flash(
+        Markup(_(
+            'The token has been created. <a href="%(url)s">Generate '
+            'recovery codes</a> now to avoid being locked out.',
+            url=url_for('.user_settings_otp', username=username),
+        )),
+        "warning",
+    )
+
+
+8. Last-Token Protection Interaction
+--------------------------------------
+
+FreeIPA's ``ipa-otp-lasttoken`` SLAPI plugin prevents deleting or
+disabling the last active token for a user with OTP-only authentication.
+This interacts with recovery codes in two ways:
+
+**Positive**: If the user deletes all their TOTP tokens, the recovery
+HOTP token remains as the last active token and cannot be deleted. The
+user is not fully locked out — they can still authenticate with
+``password + recovery_code``.
+
+**Regeneration edge case**: The regenerate flow deletes the old recovery
+token before creating a new one. If the recovery token is the user's
+*only* active token, the delete will fail with
+``"Can't delete last active token"``. Noggin must handle this error and
+tell the user to add a regular OTP token first. In practice this is
+unlikely — the user would have to delete all TOTP tokens while keeping
+the recovery token, which is a degenerate state.
+
+The regeneration handler should catch this::
+
+    except python_freeipa.exceptions.BadRequest as e:
+        if "Can't delete last active token" in e.message:
+            flash(
+                _('Cannot regenerate recovery codes while they are '
+                  'your only active token. Add a regular OTP token '
+                  'first.'),
+                'warning',
+            )
+            return redirect(
+                url_for('.user_settings_otp', username=username)
+            )
+
+
+Security Considerations
+=======================
+
+Recovery codes are always valid
+-------------------------------
+
+Unlike a disabled-token approach, recovery codes can be used at any
+time, not only when the primary token is lost. This is by design — it
+matches industry practice — but it means:
+
+- Recovery codes are an equivalent credential to the TOTP token.
+- Compromise of recovery codes = compromise of the second factor.
+- The codes page must emphasize secure storage (password manager, printed
+  and locked away).
+
+Recovery codes are shown only once
+-----------------------------------
+
+The HOTP key is stored in LDAP with ``no_display`` — it cannot be read
+back after creation. Noggin computes the codes client-side (in the
+controller) immediately after ``otptoken_add`` and renders them in the
+response. The codes are never stored by Noggin (no database, no session,
+no file).
+
+If the user loses the codes without using them, they must regenerate
+(which requires authentication with password + existing OTP).
+
+Brute-force resistance
+-----------------------
+
+8-digit codes provide 10^8 (100 million) possible values. FreeIPA's
+authentication lockout policy (``krbMaxFailCount``) applies to OTP
+failures, so brute-force is rate-limited at the IPA level. No additional
+rate limiting is needed in Noggin.
+
+Counter exhaustion
+------------------
+
+After all 10 recovery codes are used, the HOTP counter is at 10. Any
+further codes would need to be within the auth window of the current
+counter — since there are no pre-computed codes for counter ≥ 10, the
+token becomes effectively inert. The user must regenerate codes.
+
+The ``_get_recovery_codes_remaining()`` helper in
+``noggin/controller/user_otp.py`` queries ``ipatokenHOTPcounter`` via
+``otptoken_show`` and computes the remaining count. The OTP settings
+page displays "N codes remaining" with status badges. When the remaining
+count drops to ``OTP_RECOVERY_LOW_THRESHOLD`` (default: 3) or below, a
+warning badge is shown. When all codes are exhausted, a danger badge
+prompts immediate regeneration.
+
+
+Testing Plan
+============
+
+Unit tests
+----------
+
+Tests in ``tests/unit/controller/test_user_otp.py`` (64 tests). The
+recovery code tests use mock-based testing (``mock_ipa_client`` fixture)
+instead of VCR cassettes, since VCR cassettes are fragile and these
+routes were added after the original cassettes were recorded. Admin
+reset tests use a ``mock_admin_client`` fixture that provides a
+logged-in admin session with mocked IPA admin.
+
+**Core recovery code tests:**
+
+- **test_recovery_generate**: Create a recovery token, verify 10
+  eight-digit codes are returned in the response.
+- **test_recovery_generate_requires_auth**: Wrong password returns
+  error.
+- **test_recovery_generate_duplicate**: Generating codes when a
+  recovery token already exists returns an error.
+- **test_recovery_regenerate**: Old token is deleted and a new one
+  is created with fresh codes.
+- **test_recovery_regenerate_last_token**: Graceful handling when the
+  recovery token is the user's last active token.
+- **test_recovery_generate_ipa_error**: IPA error during token
+  creation shows error message.
+- **test_recovery_token_hidden_from_list**: Recovery token does not
+  appear in the regular token list.
+- **test_recovery_token_no_rename**: Recovery token has no rename
+  button in the UI.
+- **test_rename_to_recovery_description_blocked**: Renaming a regular
+  token to the recovery description is rejected.
+- **test_recovery_generate_no_permission**: Cannot generate codes for
+  another user.
+- **test_recovery_regenerate_no_permission**: Cannot regenerate codes
+  for another user.
+- **test_recovery_generate_invalid_form**: Missing password returns
+  validation error.
+- **test_recovery_regenerate_delete_error**: IPA error during old
+  recovery token deletion shows error message.
+- **test_recovery_generate_cache_control**: Recovery code response
+  includes ``Cache-Control: no-store``.
+
+**Remaining code count tests:**
+
+- **test_recovery_codes_remaining_display**: Remaining count and green
+  "Active" badge appear when codes are available.
+- **test_recovery_codes_remaining_low_warning**: Warning badge appears
+  when codes are at or below the low threshold.
+- **test_recovery_codes_remaining_zero**: Danger badge and
+  "Exhausted" message when all codes are used.
+
+**Mandatory recovery code tests:**
+
+- **test_mandatory_recovery_codes_on_first_token**: With
+  ``OTP_REQUIRE_RECOVERY_CODES`` enabled, confirming the first OTP
+  token auto-generates recovery codes and shows the modal.
+- **test_mandatory_recovery_codes_disabled**: With the config
+  disabled (default), first token redirect with warning flash.
+- **test_mandatory_recovery_codes_already_has_recovery**: No
+  auto-generation when the user already has a recovery token.
+- **test_mandatory_recovery_codes_auto_generate_failure**: IPA error
+  during auto-generation falls back to a warning flash.
+
+**Admin-assisted recovery tests:**
+
+- **test_admin_otp_reset_get**: Admin sees the confirmation page with
+  the target user's current tokens listed.
+- **test_admin_otp_reset_post**: Admin resets OTP, all tokens deleted,
+  recovery codes generated and shown.
+- **test_admin_otp_reset_no_permission**: Non-admin user is rejected.
+- **test_admin_otp_reset_self**: Admin trying to reset their own OTP
+  redirects to normal OTP settings.
+- **test_admin_otp_reset_disabled**: Route returns 404 when
+  ``OTP_ADMIN_RECOVERY_ROLE`` is None.
+- **test_admin_otp_reset_requires_auth**: Wrong password is rejected.
+- **test_admin_otp_reset_delete_error**: IPA error during token
+  deletion shows error message.
+- **test_admin_otp_reset_create_error**: IPA error during recovery
+  token creation shows error message.
+- **test_admin_otp_reset_cache_control**: Admin reset response includes
+  ``Cache-Control: no-store``.
+- **test_admin_otp_reset_group_membership**: Admin with role membership
+  via group (not direct user membership) can access OTP reset.
+
+**Recovery code utility tests** (``tests/unit/utility/test_recovery_codes.py``,
+8 tests):
+
+- **test_generate_recovery_codes_count**: Verify correct number of
+  codes are generated.
+- **test_generate_recovery_codes_eight_digits**: Verify each code is
+  exactly 8 digits.
+- **test_generate_recovery_codes_match_hotp**: Verify codes match
+  ``pyotp.HOTP`` output.
+- **test_generate_recovery_codes_uses_sha256**: Verify SHA-256
+  algorithm is used.
+- **test_generate_recovery_codes_zero_count**: Zero count returns
+  empty list.
+- **test_generate_recovery_codes_negative_count**: Negative count
+  returns empty list.
+- **test_generate_recovery_codes_unique**: Verify all codes in a set
+  are unique.
+- **test_generate_recovery_codes_custom_count**: Custom count
+  generates correct number of codes.
+
+Integration tests
+-----------------
+
+Against a live FreeIPA instance:
+
+- Enroll a TOTP token and generate recovery codes.
+- Authenticate with ``password + recovery_code`` (using one of the 10
+  codes).
+- Verify the used code no longer works (counter advanced).
+- Verify remaining codes still work.
+- Regenerate codes and verify old codes no longer work.
+
+
+Migration
+=========
+
+Existing users who already have OTP tokens will not have recovery codes.
+On the OTP settings page, they will see *"Not set up"* with a button to
+generate codes. No data migration is needed — the feature is purely
+additive.
+
+
+Additional Features
+====================
+
+The following features extend the core recovery code functionality.
+
+Remaining code count
+---------------------
+
+Noggin queries ``ipatokenHOTPcounter`` via ``otptoken_show`` for the
+user's recovery token and computes the remaining code count as
+``OTP_RECOVERY_CODE_COUNT - counter``. The OTP settings page displays
+this count alongside a colored status badge:
+
+- **Active** (green): Codes available, count above the low threshold.
+- **Low** (orange): Remaining count at or below
+  ``OTP_RECOVERY_LOW_THRESHOLD`` (default: 3). The user is prompted
+  to consider regenerating.
+- **Exhausted** (red): All codes have been used. The user is urged to
+  regenerate immediately.
+
+When the counter cannot be retrieved (e.g. IPA error), the page falls
+back to a generic "You have recovery codes set up" message.
+
+Configuration::
+
+    # Warn the user when this many or fewer recovery codes remain.
+    OTP_RECOVERY_LOW_THRESHOLD = 3
+
+Mandatory recovery codes on first OTP enrollment
+--------------------------------------------------
+
+When ``OTP_REQUIRE_RECOVERY_CODES`` is ``True``, confirming the first
+OTP token automatically generates recovery codes and displays them in
+the codes modal. The user must acknowledge saving the codes before
+proceeding. This ensures every OTP user has recovery codes from the
+moment they enable two-factor authentication.
+
+When the flag is ``False`` (the default), a flash message with a link
+to generate recovery codes is shown instead.
+
+Configuration::
+
+    # Auto-generate recovery codes when the user enrolls their first
+    # OTP token.
+    OTP_REQUIRE_RECOVERY_CODES = False
+
+Admin-assisted OTP recovery
+-----------------------------
+
+Allows users with a designated IPA role to reset a locked-out user's
+OTP tokens and generate recovery codes to share with them through a
+verified out-of-band channel.
+
+**How it works:**
+
+1. The admin navigates to the locked-out user's profile page and
+   clicks "Reset OTP".
+2. A confirmation page shows the user's current OTP tokens and explains
+   what the reset will do.
+3. The admin enters their own password to confirm.
+4. All of the target user's OTP tokens (TOTP and existing recovery) are
+   deleted via ``ipa_admin``.
+5. A new HOTP recovery token is created and recovery codes are
+   generated.
+6. The admin shares the codes with the user through a secure channel.
+7. The user logs in with ``password + recovery_code`` and can then
+   enroll a new TOTP token.
+
+**Access control:**
+
+The ``require_otp_admin`` decorator checks whether the current user is
+a member of the IPA role named in ``OTP_ADMIN_RECOVERY_ROLE``. The
+role membership is checked via ``ipa_admin.role_show()``. An admin
+cannot use this route on their own account (they are redirected to the
+normal OTP settings page).
+
+**Routes:**
+
+- ``GET /user/<username>/settings/otp/admin-reset`` — Confirmation
+  page showing current tokens and the reset form.
+- ``POST /user/<username>/settings/otp/admin-reset`` — Executes the
+  reset and renders the recovery codes.
+
+**Configuration:**
+
+::
+
+    # IPA role whose members may reset another user's OTP tokens.
+    # Set to None (default) to disable the feature entirely.
+    OTP_ADMIN_RECOVERY_ROLE = None
+
+**Setting up the IPA role:**
+
+.. code-block:: shell
+
+    # Create the role (once)
+    ipa role-add "OTP Recovery Admins" \
+        --desc="Members can reset OTP tokens for locked-out users"
+
+    # Grant the role to specific users
+    ipa role-add-member "OTP Recovery Admins" --users=helpdesk_user
+
+    # Configure Noggin
+    # In noggin.cfg:
+    OTP_ADMIN_RECOVERY_ROLE = "OTP Recovery Admins"
+
+**Security considerations:**
+
+- The admin must re-authenticate with their own password before
+  performing a reset. This prevents CSRF and ensures the action is
+  intentional.
+- All token operations use the ``ipa_admin`` privileged client, not
+  the admin's own IPA session, since the admin may not have direct
+  LDAP permissions on the target user's tokens.
+- The reset action is logged at INFO level:
+  ``Admin <admin> reset OTP for user <username>``.
+- Recovery codes are shown once and never stored by Noggin. The admin
+  must share them immediately through a secure channel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,14 @@ for information on migrating applications to the new API.
 
    contributing
 
+.. Design Documents
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Design Documents
+
+   design-otp-recovery-codes
+
 
 .. Release Notes
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -122,6 +122,66 @@ Next time you log in to Noggin, you will need to enter in your password followed
 chosen authenticator app.
 
 
+What are recovery codes?
+************************
+Recovery codes are single-use backup codes that let you sign in if you lose access to your
+authenticator device (phone loss, factory reset, hardware failure). Each code can only be used
+once. After using a code, it is permanently consumed and cannot be reused.
+
+Recovery codes work anywhere your OTP code works: Noggin login, SSH, FreeIPA WebUI, and any
+other service that authenticates through FreeIPA.
+
+
+How do I generate recovery codes?
+**********************************
+After adding your first OTP token, go to the **OTP** tab in your user settings. Scroll down
+to the **Recovery Codes** section and enter your current password (and OTP code if you already
+have a token). Click **Generate Recovery Codes**.
+
+A set of 10 eight-digit recovery codes will be displayed. **Save these codes in a safe place** —
+you will not be able to see them again. Store them in a password manager or print them and keep
+them in a secure location.
+
+You must check the "I have saved my recovery codes" checkbox before dismissing the codes dialog.
+
+.. note::
+    If your Noggin deployment has ``OTP_REQUIRE_RECOVERY_CODES`` enabled, recovery codes will
+    be generated automatically when you enroll your first OTP token. You will be shown the codes
+    immediately and must acknowledge saving them before continuing.
+
+
+How do I use a recovery code?
+*****************************
+When prompted for your OTP code during login, enter one of your recovery codes instead of the
+code from your authenticator app. Each recovery code is 8 digits (compared to the usual 6-digit
+OTP code).
+
+After a recovery code is used, it is consumed and cannot be used again. You can check how many
+codes remain on the **OTP** tab of your user settings — the remaining count is shown with a
+colored status badge:
+
+- **Active** (green): You have a comfortable number of codes remaining.
+- **Low** (orange): You are running low on codes. Consider regenerating.
+- **Exhausted** (red): All codes have been used. Regenerate immediately.
+
+
+How do I regenerate recovery codes?
+************************************
+If you have used some or all of your recovery codes, or if you believe they may have been
+compromised, you can regenerate them. Go to the **OTP** tab in your user settings, scroll to
+the **Recovery Codes** section, enter your password and OTP code, and click
+**Regenerate Recovery Codes**.
+
+This permanently invalidates all previous recovery codes and generates a fresh set of 10 codes.
+Save the new codes in a safe place.
+
+
+What happens if I lose my authenticator and have no recovery codes?
+*******************************************************************
+If you have lost your authenticator device and never generated recovery codes (or have used all
+of them), you will need to contact your system administrator. If your Noggin deployment has
+admin-assisted OTP recovery enabled, an authorized administrator can reset your OTP tokens and
+provide you with temporary recovery codes to regain access to your account.
 
 
 

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -1,6 +1,3 @@
-import os
-from base64 import b32encode
-
 import jwt
 import python_freeipa
 from flask import (
@@ -10,32 +7,23 @@ from flask import (
     redirect,
     render_template,
     request,
-    session,
     url_for,
 )
 from flask_babel import _
 from flask_mail import Message
 from markupsafe import Markup
-from pyotp import TOTP
-from werkzeug.datastructures import MultiDict
 
 from noggin.app import mailer
 from noggin.form.base import BaseForm
 from noggin.form.edit_user import (
-    UserSettingsAddOTPForm,
     UserSettingsAgreementSign,
-    UserSettingsConfirmOTPForm,
     UserSettingsEmailForm,
     UserSettingsKeysForm,
-    UserSettingsOTPNameChange,
-    UserSettingsOTPStatusChange,
     UserSettingsProfileForm,
 )
 from noggin.representation.agreement import Agreement
 from noggin.representation.group import Group
-from noggin.representation.otptoken import OTPToken
 from noggin.representation.user import User
-from noggin.security.ipa import maybe_ipa_login
 from noggin.utility import messaging
 from noggin.utility.controllers import require_self, user_or_404, with_ipa
 from noggin.utility.forms import FormError, handle_form_errors
@@ -43,10 +31,6 @@ from noggin.utility.token import Audience, make_token, read_token
 from noggin_messages import UserUpdateV1
 
 from . import blueprint as bp
-
-# Must be the same as KEY_LENGTH in ipaserver/plugins/otptoken.py
-# For maximum compatibility, must be a multiple of 5.
-OTP_KEY_LENGTH = 35
 
 
 @bp.route('/user/<username>/')
@@ -106,9 +90,11 @@ def _user_mod(ipa, form, user, details, redirect_to):
                 )
                 raise FormError("non_field_errors", e.message)
         flash(
-            Markup(  # nosec B704
-                f'Profile Updated: <a href=\"{url_for(".user", username=user.username)}\">'
-                'view your profile</a>'
+            Markup(
+                _(
+                    'Profile Updated: <a href="%(url)s">view your profile</a>',
+                    url=url_for(".user", username=user.username),
+                )
             ),
             'success',
         )
@@ -330,202 +316,6 @@ def user_settings_keys(ipa, username):
     return render_template(
         'user-settings-keys.html', user=user, form=form, activetab="keys"
     )
-
-
-@bp.route('/user/<username>/settings/otp/', methods=['GET', 'POST'])
-@with_ipa()
-@require_self
-def user_settings_otp(ipa, username):
-    addotpform = UserSettingsAddOTPForm(prefix="add-")
-    confirmotpform = UserSettingsConfirmOTPForm(prefix="confirm-")
-    user = User(user_or_404(ipa, username))
-    secret = None
-
-    if addotpform.validate_on_submit():
-        description = addotpform.description.data
-        password = addotpform.password.data
-        if addotpform.otp.data:
-            password += addotpform.otp.data
-
-        try:
-            maybe_ipa_login(current_app, session, username, password)
-        except python_freeipa.exceptions.InvalidSessionPassword:
-            addotpform.password.errors.append(_("Incorrect password"))
-        else:
-            secret = b32encode(os.urandom(OTP_KEY_LENGTH)).decode('ascii')
-            # Prefill the form for the next step
-            confirmotpform.process(
-                MultiDict(
-                    {"confirm-secret": secret, "confirm-description": description}
-                )
-            )
-    if confirmotpform.validate_on_submit():
-        try:
-            ipa.otptoken_add(
-                o_ipatokenowner=username,
-                o_description=confirmotpform.description.data,
-                o_ipatokenotpkey=confirmotpform.secret.data,
-            )
-        except python_freeipa.exceptions.FreeIPAError as e:
-            current_app.logger.error(
-                f'An error happened while creating an OTP token for user {username}: {e.message}'
-            )
-            confirmotpform.non_field_errors.errors.append(_('Cannot create the token.'))
-        else:
-            flash(_('The token has been created.'), "success")
-            return redirect(url_for('.user_settings_otp', username=username))
-
-    if confirmotpform.is_submitted():
-        # This form is inside the modal. Keep a value in otp_uri or the modal will not open
-        # to show the errors.
-        secret = confirmotpform.secret.data
-
-    # Compute the token URI
-    if secret:
-        description = addotpform.description.data or confirmotpform.description.data
-        token = TOTP(secret)
-        otp_uri = token.provisioning_uri(name=description, issuer_name=user.krbname)
-    else:
-        otp_uri = None
-
-    # List existing tokens
-    tokens = [
-        OTPToken(t) for t in ipa.otptoken_find(o_ipatokenowner=username)["result"]
-    ]
-    tokens.sort(key=lambda t: t.description or "")
-
-    return render_template(
-        'user-settings-otp.html',
-        addotpform=addotpform,
-        confirmotpform=confirmotpform,
-        user=user,
-        activetab="otp",
-        tokens=tokens,
-        otp_uri=otp_uri,
-    )
-
-
-@bp.route('/user/<username>/settings/otp/rename/', methods=['POST'])
-@with_ipa()
-@require_self
-def user_settings_otp_rename(ipa, username):
-    form = UserSettingsOTPNameChange()
-
-    if form.validate_on_submit():
-        try:
-            ipa.otptoken_mod(
-                a_ipatokenuniqueid=form.token.data,
-                o_description=form.description.data,
-            )
-        except (
-            python_freeipa.exceptions.BadRequest,
-            python_freeipa.exceptions.FreeIPAError,
-        ) as e:
-            if e.message != "no modifications to be performed":
-                flash(_('Cannot rename the token.'), 'danger')
-                current_app.logger.error(
-                    f'Something went wrong renaming an OTP token for user {username}: {e}'
-                )
-
-    for field_errors in form.errors.values():
-        for error in field_errors:
-            flash(error, 'danger')
-
-    return redirect(url_for('.user_settings_otp', username=username))
-
-
-@bp.route('/user/<username>/settings/otp/disable/', methods=['POST'])
-@with_ipa()
-@require_self
-def user_settings_otp_disable(ipa, username):
-    form = UserSettingsOTPStatusChange()
-
-    if form.validate_on_submit():
-        token = form.token.data
-        try:
-            ipa.otptoken_mod(a_ipatokenuniqueid=token, o_ipatokendisabled=True)
-        except python_freeipa.exceptions.BadRequest as e:
-            if (
-                e.message
-                == "Server is unwilling to perform: Can't disable last active token"
-            ):
-                flash(_('Sorry, You cannot disable your last active token.'), 'warning')
-            else:
-                flash(_('Cannot disable the token.'), 'danger')
-                current_app.logger.error(
-                    f'Something went wrong disabling an OTP token for user {username}: {e}'
-                )
-        except python_freeipa.exceptions.FreeIPAError as e:
-            flash(_('Cannot disable the token.'), 'danger')
-            current_app.logger.error(
-                f'Something went wrong disabling an OTP token for user {username}: {e}'
-            )
-
-    for field_errors in form.errors.values():
-        for error in field_errors:
-            flash(error, 'danger')
-    return redirect(url_for('.user_settings_otp', username=username))
-
-
-@bp.route('/user/<username>/settings/otp/enable/', methods=['POST'])
-@with_ipa()
-@require_self
-def user_settings_otp_enable(ipa, username):
-    form = UserSettingsOTPStatusChange()
-
-    if form.validate_on_submit():
-        token = form.token.data
-        try:
-            ipa.otptoken_mod(a_ipatokenuniqueid=token, o_ipatokendisabled=False)
-        except (
-            python_freeipa.exceptions.BadRequest,
-            python_freeipa.exceptions.FreeIPAError,
-        ) as e:
-            flash(
-                _('Cannot enable the token. %(errormessage)s', errormessage=e), 'danger'
-            )
-            current_app.logger.error(
-                f'Something went wrong enabling an OTP token for user {username}: {e}'
-            )
-
-    for field_errors in form.errors.values():
-        for error in field_errors:
-            flash(error, 'danger')
-    return redirect(url_for('.user_settings_otp', username=username))
-
-
-@bp.route('/user/<username>/settings/otp/delete/', methods=['POST'])
-@with_ipa()
-@require_self
-def user_settings_otp_delete(ipa, username):
-    form = UserSettingsOTPStatusChange()
-
-    if form.validate_on_submit():
-        username = session.get('noggin_username')
-        token = form.token.data
-        try:
-            ipa.otptoken_del(a_ipatokenuniqueid=token)
-        except python_freeipa.exceptions.BadRequest as e:
-            if (
-                e.message
-                == "Server is unwilling to perform: Can't delete last active token"
-            ):
-                flash(_('Sorry, You cannot delete your last active token.'), 'warning')
-            else:
-                flash(_('Cannot delete the token.'), 'danger')
-                current_app.logger.error(
-                    f'Something went wrong deleting OTP token for user {username}: {e}'
-                )
-        except python_freeipa.exceptions.FreeIPAError as e:
-            flash(_('Cannot delete the token.'), 'danger')
-            current_app.logger.error(
-                f'Something went wrong deleting OTP token for user {username}: {e}'
-            )
-
-    for field_errors in form.errors.values():
-        for error in field_errors:
-            flash(error, 'danger')
-    return redirect(url_for('.user_settings_otp', username=username))
 
 
 def handle_agreement_form(ipa, user, form):

--- a/noggin/controller/user.py
+++ b/noggin/controller/user.py
@@ -13,7 +13,7 @@ from flask_babel import _
 from flask_mail import Message
 from markupsafe import Markup
 
-from noggin.app import mailer
+from noggin.app import ipa_admin, mailer
 from noggin.form.base import BaseForm
 from noggin.form.edit_user import (
     UserSettingsAgreementSign,
@@ -25,7 +25,12 @@ from noggin.representation.agreement import Agreement
 from noggin.representation.group import Group
 from noggin.representation.user import User
 from noggin.utility import messaging
-from noggin.utility.controllers import require_self, user_or_404, with_ipa
+from noggin.utility.controllers import (
+    is_role_member,
+    require_self,
+    user_or_404,
+    with_ipa,
+)
 from noggin.utility.forms import FormError, handle_form_errors
 from noggin.utility.token import Audience, make_token, read_token
 from noggin_messages import UserUpdateV1
@@ -66,12 +71,28 @@ def user(ipa, username):
     if user != g.current_user and user.is_private:
         user.anonymize()
 
+    # Check if the current user is an OTP recovery admin
+    is_otp_admin = False
+    role = current_app.config.get('OTP_ADMIN_RECOVERY_ROLE')
+    if role and g.current_user.username != user.username:
+        try:
+            role_info = ipa_admin.role_show(a_cn=role)
+            is_otp_admin = is_role_member(
+                role_info, g.current_user.username, g.current_user.groups
+            )
+        except python_freeipa.exceptions.FreeIPAError:
+            current_app.logger.warning(
+                'Failed to check OTP admin role for user %s',
+                g.current_user.username,
+            )
+
     return render_template(
         'user.html',
         user=user,
         groups=groups,
         managed_groups=managed_groups,
         member_groups=member_groups,
+        is_otp_admin=is_otp_admin,
     )
 
 

--- a/noggin/controller/user_otp.py
+++ b/noggin/controller/user_otp.py
@@ -5,25 +5,30 @@ import python_freeipa
 from flask import (
     current_app,
     flash,
+    make_response,
     redirect,
     render_template,
     session,
     url_for,
 )
 from flask_babel import _
+from markupsafe import Markup
 from pyotp import TOTP
 from werkzeug.datastructures import MultiDict
 
 from noggin.form.edit_user import (
     UserSettingsAddOTPForm,
     UserSettingsConfirmOTPForm,
+    UserSettingsGenerateRecoveryForm,
     UserSettingsOTPNameChange,
     UserSettingsOTPStatusChange,
+    UserSettingsRegenerateRecoveryForm,
 )
 from noggin.representation.otptoken import OTPToken
 from noggin.representation.user import User
 from noggin.security.ipa import maybe_ipa_login
 from noggin.utility.controllers import require_self, user_or_404, with_ipa
+from noggin.utility.recovery_codes import generate_recovery_codes
 
 from . import blueprint as bp
 
@@ -38,6 +43,8 @@ OTP_KEY_LENGTH = 35
 def user_settings_otp(ipa, username):
     addotpform = UserSettingsAddOTPForm(prefix="add-")
     confirmotpform = UserSettingsConfirmOTPForm(prefix="confirm-")
+    generate_recovery_form = UserSettingsGenerateRecoveryForm(prefix="gen-")
+    regenerate_recovery_form = UserSettingsRegenerateRecoveryForm(prefix="regen-")
     user = User(user_or_404(ipa, username))
     secret = None
 
@@ -73,6 +80,49 @@ def user_settings_otp(ipa, username):
             confirmotpform.non_field_errors.errors.append(_('Cannot create the token.'))
         else:
             flash(_('The token has been created.'), "success")
+            # Check if the user should generate recovery codes
+            try:
+                all_user_tokens = ipa.otptoken_find(
+                    o_ipatokenowner=username
+                )["result"]
+            except python_freeipa.exceptions.FreeIPAError:
+                current_app.logger.warning(
+                    'Failed to check recovery tokens for user %s '
+                    'after OTP creation',
+                    username,
+                )
+                return redirect(
+                    url_for('.user_settings_otp', username=username)
+                )
+            desc = current_app.config['OTP_RECOVERY_DESCRIPTION']
+            has_recovery = any(
+                OTPToken(t).is_recovery(desc) for t in all_user_tokens
+            )
+            if not has_recovery:
+                if current_app.config.get('OTP_REQUIRE_RECOVERY_CODES'):
+                    try:
+                        codes, _token_id = _create_recovery_token(ipa, username)
+                        return _render_otp_page(
+                            ipa, username, recovery_codes=codes
+                        )
+                    except python_freeipa.exceptions.FreeIPAError as e:
+                        current_app.logger.error(
+                            f'Error auto-creating recovery codes for '
+                            f'user {username}: {e.message}'
+                        )
+                flash(
+                    Markup(
+                        _(
+                            '<a href="%(url)s">Generate recovery codes</a> '
+                            'now to avoid being locked out.',
+                            url=url_for(
+                                '.user_settings_otp', username=username
+                            )
+                            + '#recovery-codes',
+                        )
+                    ),
+                    "warning",
+                )
             return redirect(url_for('.user_settings_otp', username=username))
 
     if confirmotpform.is_submitted():
@@ -88,21 +138,148 @@ def user_settings_otp(ipa, username):
     else:
         otp_uri = None
 
-    # List existing tokens
-    tokens = [
-        OTPToken(t) for t in ipa.otptoken_find(o_ipatokenowner=username)["result"]
-    ]
-    tokens.sort(key=lambda t: t.description or "")
+    # List existing tokens, separating recovery tokens from regular ones
+    try:
+        all_tokens = [
+            OTPToken(t)
+            for t in ipa.otptoken_find(o_ipatokenowner=username)["result"]
+        ]
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.error(
+            'Failed to list OTP tokens for user %s', username
+        )
+        flash(_('Could not load OTP tokens.'), 'danger')
+        return redirect(url_for('.user', username=username))
+    tokens, recovery_token = _categorize_tokens(all_tokens)
+    recovery_codes_remaining = _get_recovery_codes_remaining(ipa, recovery_token)
 
     return render_template(
         'user-settings-otp.html',
         addotpform=addotpform,
         confirmotpform=confirmotpform,
+        generate_recovery_form=generate_recovery_form,
+        regenerate_recovery_form=regenerate_recovery_form,
         user=user,
         activetab="otp",
         tokens=tokens,
+        recovery_token=recovery_token,
+        recovery_codes_remaining=recovery_codes_remaining,
         otp_uri=otp_uri,
     )
+
+
+def _create_recovery_token(ipa_client, username):
+    secret = b32encode(os.urandom(OTP_KEY_LENGTH)).decode('ascii')
+    result = ipa_client.otptoken_add(
+        o_ipatokenowner=username,
+        o_type='hotp',
+        o_ipatokenotpkey=secret,
+        o_ipatokenotpdigits=8,
+        o_ipatokenotpalgorithm='sha256',
+        o_description=current_app.config['OTP_RECOVERY_DESCRIPTION'],
+    )
+    try:
+        token_id = result['result']['ipatokenuniqueid'][0]
+    except (KeyError, IndexError) as e:
+        raise python_freeipa.exceptions.FreeIPAError(
+            message=f'Unexpected response when creating recovery token: {e}',
+            code=500,
+        ) from e
+    codes = generate_recovery_codes(
+        secret, current_app.config['OTP_RECOVERY_CODE_COUNT']
+    )
+    return codes, token_id
+
+
+def _get_recovery_codes_remaining(ipa, recovery_token):
+    if not recovery_token:
+        return None
+    try:
+        detail = OTPToken(
+            ipa.otptoken_show(
+                a_ipatokenuniqueid=recovery_token.uniqueid, o_all=True
+            )["result"]
+        )
+        return max(
+            0,
+            current_app.config['OTP_RECOVERY_CODE_COUNT'] - detail.counter,
+        )
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.warning(
+            'Failed to fetch recovery token details for %s',
+            recovery_token.uniqueid,
+        )
+        return None
+
+
+def _categorize_tokens(all_tokens):
+    desc = current_app.config['OTP_RECOVERY_DESCRIPTION']
+    tokens = [t for t in all_tokens if not t.is_recovery(desc)]
+    tokens.sort(key=lambda t: t.description or "")
+    recovery_token = next(
+        (t for t in all_tokens if t.is_recovery(desc)), None
+    )
+    return tokens, recovery_token
+
+
+def _reauthenticate(form, auth_username):
+    password = form.password.data
+    if form.otp.data:
+        password += form.otp.data
+    try:
+        maybe_ipa_login(current_app, session, auth_username, password)
+        return True
+    except python_freeipa.exceptions.InvalidSessionPassword:
+        flash(_('Incorrect password'), 'danger')
+        return False
+
+
+def _render_otp_page(ipa, username, recovery_codes=None, user=None):
+    if user is None:
+        user = User(user_or_404(ipa, username))
+    try:
+        all_tokens = [
+            OTPToken(t)
+            for t in ipa.otptoken_find(o_ipatokenowner=username)["result"]
+        ]
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.error(
+            'Failed to list OTP tokens for user %s', username
+        )
+        if recovery_codes:
+            all_tokens = []
+            flash(
+                _('Could not load your token list, but your new recovery '
+                  'codes are shown below. Please save them now.'),
+                'warning',
+            )
+        else:
+            flash(_('Could not load OTP tokens.'), 'danger')
+            return redirect(url_for('.user', username=username))
+    tokens, recovery_token = _categorize_tokens(all_tokens)
+    recovery_codes_remaining = _get_recovery_codes_remaining(ipa, recovery_token)
+
+    response = make_response(
+        render_template(
+            'user-settings-otp.html',
+            addotpform=UserSettingsAddOTPForm(prefix="add-"),
+            confirmotpform=UserSettingsConfirmOTPForm(prefix="confirm-"),
+            generate_recovery_form=UserSettingsGenerateRecoveryForm(prefix="gen-"),
+            regenerate_recovery_form=UserSettingsRegenerateRecoveryForm(
+                prefix="regen-"
+            ),
+            user=user,
+            activetab="otp",
+            tokens=tokens,
+            recovery_token=recovery_token,
+            recovery_codes_remaining=recovery_codes_remaining,
+            otp_uri=None,
+            recovery_codes=recovery_codes,
+        )
+    )
+    if recovery_codes:
+        response.headers['Cache-Control'] = 'no-store'
+    return response
 
 
 @bp.route('/user/<username>/settings/otp/rename/', methods=['POST'])
@@ -112,9 +289,18 @@ def user_settings_otp_rename(ipa, username):
     form = UserSettingsOTPNameChange()
 
     if form.validate_on_submit():
+        token_id = form.token.data
+        recovery_desc = current_app.config.get('OTP_RECOVERY_DESCRIPTION')
+        if recovery_desc and form.description.data == recovery_desc:
+            flash(
+                _('This description is reserved for recovery codes.'),
+                'warning',
+            )
+            return redirect(url_for('.user_settings_otp', username=username))
+
         try:
             ipa.otptoken_mod(
-                a_ipatokenuniqueid=form.token.data,
+                a_ipatokenuniqueid=token_id,
                 o_description=form.description.data,
             )
         except (
@@ -220,6 +406,126 @@ def user_settings_otp_delete(ipa, username):
             current_app.logger.error(
                 f'Something went wrong deleting OTP token for user {username}: {e}'
             )
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+    return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/recovery/generate', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_recovery_generate(ipa, username):
+    form = UserSettingsGenerateRecoveryForm(prefix="gen-")
+
+    if form.validate_on_submit():
+        if not _reauthenticate(form, username):
+            return redirect(url_for('.user_settings_otp', username=username))
+
+        # Check for existing recovery token
+        try:
+            existing = ipa.otptoken_find(
+                o_ipatokenowner=username,
+                o_type='hotp',
+                o_description=current_app.config['OTP_RECOVERY_DESCRIPTION'],
+            )
+        except python_freeipa.exceptions.FreeIPAError:
+            current_app.logger.error(
+                'Failed to check existing recovery tokens for user %s',
+                username,
+            )
+            flash(_('Cannot create recovery codes.'), 'danger')
+            return redirect(url_for('.user_settings_otp', username=username))
+        if existing['count'] > 0:
+            flash(
+                _('You already have recovery codes. Regenerate them instead.'),
+                'warning',
+            )
+            return redirect(url_for('.user_settings_otp', username=username))
+
+        try:
+            codes, _token_id = _create_recovery_token(ipa, username)
+        except python_freeipa.exceptions.FreeIPAError as e:
+            current_app.logger.error(
+                f'Error creating recovery token for user {username}: {e.message}'
+            )
+            flash(_('Cannot create recovery codes.'), 'danger')
+            return redirect(url_for('.user_settings_otp', username=username))
+
+        return _render_otp_page(ipa, username, recovery_codes=codes)
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+    return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/recovery/regenerate', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_recovery_regenerate(ipa, username):
+    form = UserSettingsRegenerateRecoveryForm(prefix="regen-")
+
+    if form.validate_on_submit():
+        if not _reauthenticate(form, username):
+            return redirect(url_for('.user_settings_otp', username=username))
+
+        # Find and delete existing recovery tokens
+        try:
+            existing = ipa.otptoken_find(
+                o_ipatokenowner=username,
+                o_type='hotp',
+                o_description=current_app.config['OTP_RECOVERY_DESCRIPTION'],
+            )
+        except python_freeipa.exceptions.FreeIPAError:
+            current_app.logger.error(
+                'Failed to find recovery tokens for user %s', username
+            )
+            flash(_('Cannot regenerate recovery codes.'), 'danger')
+            return redirect(url_for('.user_settings_otp', username=username))
+        for t in existing['result']:
+            try:
+                ipa.otptoken_del(
+                    a_ipatokenuniqueid=t['ipatokenuniqueid'][0],
+                )
+            except python_freeipa.exceptions.BadRequest as e:
+                if "Can't delete last active token" in str(e):
+                    flash(
+                        _(
+                            'Cannot regenerate recovery codes while they are '
+                            'your only active token. Add a regular OTP token '
+                            'first.'
+                        ),
+                        'warning',
+                    )
+                else:
+                    current_app.logger.error(
+                        'Error deleting recovery token for user %s: %s',
+                        username,
+                        e,
+                    )
+                    flash(_('Cannot regenerate recovery codes.'), 'danger')
+                return redirect(
+                    url_for('.user_settings_otp', username=username)
+                )
+            except python_freeipa.exceptions.FreeIPAError as e:
+                current_app.logger.error(
+                    f'Error deleting old recovery token for user {username}: {e.message}'
+                )
+                flash(_('Cannot regenerate recovery codes.'), 'danger')
+                return redirect(url_for('.user_settings_otp', username=username))
+
+        try:
+            codes, _token_id = _create_recovery_token(ipa, username)
+        except python_freeipa.exceptions.FreeIPAError as e:
+            current_app.logger.error(
+                f'Error creating recovery token for user {username}: {e.message}'
+            )
+            flash(_('Cannot create recovery codes.'), 'danger')
+            return redirect(url_for('.user_settings_otp', username=username))
+
+        return _render_otp_page(ipa, username, recovery_codes=codes)
 
     for field_errors in form.errors.values():
         for error in field_errors:

--- a/noggin/controller/user_otp.py
+++ b/noggin/controller/user_otp.py
@@ -16,7 +16,9 @@ from markupsafe import Markup
 from pyotp import TOTP
 from werkzeug.datastructures import MultiDict
 
+from noggin.app import ipa_admin
 from noggin.form.edit_user import (
+    AdminOTPResetForm,
     UserSettingsAddOTPForm,
     UserSettingsConfirmOTPForm,
     UserSettingsGenerateRecoveryForm,
@@ -27,8 +29,10 @@ from noggin.form.edit_user import (
 from noggin.representation.otptoken import OTPToken
 from noggin.representation.user import User
 from noggin.security.ipa import maybe_ipa_login
-from noggin.utility.controllers import require_self, user_or_404, with_ipa
+from noggin.utility import messaging
+from noggin.utility.controllers import require_otp_admin, require_self, user_or_404, with_ipa
 from noggin.utility.recovery_codes import generate_recovery_codes
+from noggin_messages import UserUpdateV1
 
 from . import blueprint as bp
 
@@ -531,3 +535,120 @@ def user_settings_otp_recovery_regenerate(ipa, username):
         for error in field_errors:
             flash(error, 'danger')
     return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/admin-reset', methods=['GET', 'POST'])
+@with_ipa()
+@require_otp_admin
+def user_settings_otp_admin_reset(ipa, username):
+    user = User(user_or_404(ipa, username))
+    form = AdminOTPResetForm(prefix="admin-reset-")
+
+    if form.validate_on_submit():
+        admin_username = session.get('noggin_username')
+        if not _reauthenticate(form, admin_username):
+            return redirect(
+                url_for('.user_settings_otp_admin_reset', username=username)
+            )
+
+        try:
+            codes, new_token_id = _create_recovery_token(ipa_admin, username)
+        except python_freeipa.exceptions.FreeIPAError as e:
+            current_app.logger.error(
+                f'Admin {admin_username} failed to create recovery token '
+                f'for user {username}: {e}'
+            )
+            flash(_('Error creating recovery codes.'), 'danger')
+            return redirect(
+                url_for('.user_settings_otp_admin_reset', username=username)
+            )
+
+        try:
+            all_tokens = ipa_admin.otptoken_find(o_ipatokenowner=username)
+        except python_freeipa.exceptions.FreeIPAError as e:
+            current_app.logger.error(
+                'Failed to list tokens for user %s after recovery '
+                'token creation: %s',
+                username,
+                e,
+            )
+            flash(
+                _(
+                    'Recovery codes were created but old tokens could '
+                    'not be removed. Please try again.'
+                ),
+                'warning',
+            )
+            return redirect(
+                url_for('.user_settings_otp_admin_reset', username=username)
+            )
+
+        for t in all_tokens['result']:
+            token_id = t['ipatokenuniqueid'][0]
+            if token_id == new_token_id:
+                continue
+            try:
+                ipa_admin.otptoken_del(
+                    a_ipatokenuniqueid=token_id,
+                )
+            except python_freeipa.exceptions.FreeIPAError as e:
+                current_app.logger.error(
+                    f'Admin {admin_username} failed to delete token '
+                    f'{token_id} for user {username}: {e}'
+                )
+                flash(_('Error deleting OTP tokens.'), 'danger')
+                return redirect(
+                    url_for('.user_settings_otp_admin_reset', username=username)
+                )
+
+        current_app.logger.info(
+            f'Admin {admin_username} reset OTP for user {username}'
+        )
+        messaging.publish(
+            UserUpdateV1(
+                {
+                    "msg": {
+                        "agent": admin_username,
+                        "user": username,
+                        "fields": ["otp_reset"],
+                    }
+                }
+            )
+        )
+        flash(
+            _('OTP tokens have been reset for %(username)s.', username=username),
+            'success',
+        )
+        response = make_response(
+            render_template(
+                'user-settings-otp-admin-reset.html',
+                target_user=user,
+                recovery_codes=codes,
+                form=form,
+            )
+        )
+        response.headers['Cache-Control'] = 'no-store'
+        return response
+
+    try:
+        all_tokens = [
+            OTPToken(t)
+            for t in ipa_admin.otptoken_find(
+                o_ipatokenowner=username
+            )["result"]
+        ]
+    except python_freeipa.exceptions.FreeIPAError:
+        current_app.logger.error(
+            'Failed to list OTP tokens for user %s', username
+        )
+        flash(_('Could not load OTP tokens.'), 'danger')
+        return redirect(url_for('.user', username=username))
+    tokens, recovery_token = _categorize_tokens(all_tokens)
+
+    return render_template(
+        'user-settings-otp-admin-reset.html',
+        target_user=user,
+        tokens=tokens,
+        recovery_token=recovery_token,
+        form=form,
+    )

--- a/noggin/controller/user_otp.py
+++ b/noggin/controller/user_otp.py
@@ -1,0 +1,227 @@
+import os
+from base64 import b32encode
+
+import python_freeipa
+from flask import (
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    session,
+    url_for,
+)
+from flask_babel import _
+from pyotp import TOTP
+from werkzeug.datastructures import MultiDict
+
+from noggin.form.edit_user import (
+    UserSettingsAddOTPForm,
+    UserSettingsConfirmOTPForm,
+    UserSettingsOTPNameChange,
+    UserSettingsOTPStatusChange,
+)
+from noggin.representation.otptoken import OTPToken
+from noggin.representation.user import User
+from noggin.security.ipa import maybe_ipa_login
+from noggin.utility.controllers import require_self, user_or_404, with_ipa
+
+from . import blueprint as bp
+
+# Must be the same as KEY_LENGTH in ipaserver/plugins/otptoken.py
+# For maximum compatibility, must be a multiple of 5.
+OTP_KEY_LENGTH = 35
+
+
+@bp.route('/user/<username>/settings/otp/', methods=['GET', 'POST'])
+@with_ipa()
+@require_self
+def user_settings_otp(ipa, username):
+    addotpform = UserSettingsAddOTPForm(prefix="add-")
+    confirmotpform = UserSettingsConfirmOTPForm(prefix="confirm-")
+    user = User(user_or_404(ipa, username))
+    secret = None
+
+    if addotpform.validate_on_submit():
+        description = addotpform.description.data
+        password = addotpform.password.data
+        if addotpform.otp.data:
+            password += addotpform.otp.data
+
+        try:
+            maybe_ipa_login(current_app, session, username, password)
+        except python_freeipa.exceptions.InvalidSessionPassword:
+            addotpform.password.errors.append(_("Incorrect password"))
+        else:
+            secret = b32encode(os.urandom(OTP_KEY_LENGTH)).decode('ascii')
+            # Prefill the form for the next step
+            confirmotpform.process(
+                MultiDict(
+                    {"confirm-secret": secret, "confirm-description": description}
+                )
+            )
+    if confirmotpform.validate_on_submit():
+        try:
+            ipa.otptoken_add(
+                o_ipatokenowner=username,
+                o_description=confirmotpform.description.data,
+                o_ipatokenotpkey=confirmotpform.secret.data,
+            )
+        except python_freeipa.exceptions.FreeIPAError as e:
+            current_app.logger.error(
+                f'An error happened while creating an OTP token for user {username}: {e.message}'
+            )
+            confirmotpform.non_field_errors.errors.append(_('Cannot create the token.'))
+        else:
+            flash(_('The token has been created.'), "success")
+            return redirect(url_for('.user_settings_otp', username=username))
+
+    if confirmotpform.is_submitted():
+        # This form is inside the modal. Keep a value in otp_uri or the modal will not open
+        # to show the errors.
+        secret = confirmotpform.secret.data
+
+    # Compute the token URI
+    if secret:
+        description = addotpform.description.data or confirmotpform.description.data
+        token = TOTP(secret)
+        otp_uri = token.provisioning_uri(name=description, issuer_name=user.krbname)
+    else:
+        otp_uri = None
+
+    # List existing tokens
+    tokens = [
+        OTPToken(t) for t in ipa.otptoken_find(o_ipatokenowner=username)["result"]
+    ]
+    tokens.sort(key=lambda t: t.description or "")
+
+    return render_template(
+        'user-settings-otp.html',
+        addotpform=addotpform,
+        confirmotpform=confirmotpform,
+        user=user,
+        activetab="otp",
+        tokens=tokens,
+        otp_uri=otp_uri,
+    )
+
+
+@bp.route('/user/<username>/settings/otp/rename/', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_rename(ipa, username):
+    form = UserSettingsOTPNameChange()
+
+    if form.validate_on_submit():
+        try:
+            ipa.otptoken_mod(
+                a_ipatokenuniqueid=form.token.data,
+                o_description=form.description.data,
+            )
+        except (
+            python_freeipa.exceptions.BadRequest,
+            python_freeipa.exceptions.FreeIPAError,
+        ) as e:
+            if e.message != "no modifications to be performed":
+                flash(_('Cannot rename the token.'), 'danger')
+                current_app.logger.error(
+                    f'Something went wrong renaming an OTP token for user {username}: {e}'
+                )
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+
+    return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/disable/', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_disable(ipa, username):
+    form = UserSettingsOTPStatusChange()
+
+    if form.validate_on_submit():
+        token = form.token.data
+        try:
+            ipa.otptoken_mod(a_ipatokenuniqueid=token, o_ipatokendisabled=True)
+        except python_freeipa.exceptions.BadRequest as e:
+            if (
+                e.message
+                == "Server is unwilling to perform: Can't disable last active token"
+            ):
+                flash(_('Sorry, You cannot disable your last active token.'), 'warning')
+            else:
+                flash(_('Cannot disable the token.'), 'danger')
+                current_app.logger.error(
+                    f'Something went wrong disabling an OTP token for user {username}: {e}'
+                )
+        except python_freeipa.exceptions.FreeIPAError as e:
+            flash(_('Cannot disable the token.'), 'danger')
+            current_app.logger.error(
+                f'Something went wrong disabling an OTP token for user {username}: {e}'
+            )
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+    return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/enable/', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_enable(ipa, username):
+    form = UserSettingsOTPStatusChange()
+
+    if form.validate_on_submit():
+        token = form.token.data
+        try:
+            ipa.otptoken_mod(a_ipatokenuniqueid=token, o_ipatokendisabled=False)
+        except (
+            python_freeipa.exceptions.BadRequest,
+            python_freeipa.exceptions.FreeIPAError,
+        ) as e:
+            flash(
+                _('Cannot enable the token. %(errormessage)s', errormessage=e), 'danger'
+            )
+            current_app.logger.error(
+                f'Something went wrong enabling an OTP token for user {username}: {e}'
+            )
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+    return redirect(url_for('.user_settings_otp', username=username))
+
+
+@bp.route('/user/<username>/settings/otp/delete/', methods=['POST'])
+@with_ipa()
+@require_self
+def user_settings_otp_delete(ipa, username):
+    form = UserSettingsOTPStatusChange()
+
+    if form.validate_on_submit():
+        token = form.token.data
+        try:
+            ipa.otptoken_del(a_ipatokenuniqueid=token)
+        except python_freeipa.exceptions.BadRequest as e:
+            if (
+                e.message
+                == "Server is unwilling to perform: Can't delete last active token"
+            ):
+                flash(_('Sorry, You cannot delete your last active token.'), 'warning')
+            else:
+                flash(_('Cannot delete the token.'), 'danger')
+                current_app.logger.error(
+                    f'Something went wrong deleting OTP token for user {username}: {e}'
+                )
+        except python_freeipa.exceptions.FreeIPAError as e:
+            flash(_('Cannot delete the token.'), 'danger')
+            current_app.logger.error(
+                f'Something went wrong deleting OTP token for user {username}: {e}'
+            )
+
+    for field_errors in form.errors.values():
+        for error in field_errors:
+            flash(error, 'danger')
+    return redirect(url_for('.user_settings_otp', username=username))

--- a/noggin/defaults.py
+++ b/noggin/defaults.py
@@ -72,3 +72,18 @@ AGREEMENT_WARNINGS = {
         "platforms."
     ),
 }
+
+# Number of recovery codes to generate. Must not exceed the FreeIPA
+# ipatokenHOTPauthWindow (default: 10).
+OTP_RECOVERY_CODE_COUNT = 10
+# Token description used to identify recovery tokens.
+# WARNING: Changing this value after recovery tokens have been created will
+# cause existing tokens to no longer be recognized as recovery tokens.
+OTP_RECOVERY_DESCRIPTION = "Recovery codes"
+# Warn the user when this many or fewer recovery codes remain.
+OTP_RECOVERY_LOW_THRESHOLD = 3
+# Auto-generate recovery codes when the user enrolls their first OTP token.
+OTP_REQUIRE_RECOVERY_CODES = False
+# IPA role whose members may reset another user's OTP tokens and generate
+# recovery codes on their behalf.  None disables the feature.
+OTP_ADMIN_RECOVERY_ROLE = None

--- a/noggin/form/edit_user.py
+++ b/noggin/form/edit_user.py
@@ -83,7 +83,7 @@ class ProtocolAndNickField(TypeAndStringField):
 
 def https_required(form, field):
     if not field.data.startswith('https://'):
-        raise ValidationError('URL should start with "https://".')
+        raise ValidationError(_('URL should start with "https://".'))
 
 
 class UserSettingsProfileForm(BaseForm):
@@ -243,6 +243,34 @@ class UserSettingsOTPNameChange(BaseForm):
     description = StringField(
         validators=[Optional()],
     )
+
+
+class UserSettingsGenerateRecoveryForm(ModestForm):
+    password = PasswordField(
+        _('Enter your current password'),
+        validators=[DataRequired(message=_('You must provide a password'))],
+    )
+    otp = StringField(
+        _('One-Time Password'),
+        validators=[Optional()],
+    )
+    submit = SubmitButtonField(_("Generate Recovery Codes"))
+
+
+class UserSettingsRegenerateRecoveryForm(UserSettingsGenerateRecoveryForm):
+    submit = SubmitButtonField(_("Regenerate Recovery Codes"))
+
+
+class AdminOTPResetForm(ModestForm):
+    password = PasswordField(
+        _('Enter your password to confirm'),
+        validators=[DataRequired(message=_('You must provide a password'))],
+    )
+    otp = StringField(
+        _('One-Time Password'),
+        validators=[Optional()],
+    )
+    submit = SubmitButtonField(_("Reset OTP and Generate Recovery Codes"))
 
 
 class UserSettingsAgreementSign(BaseForm):

--- a/noggin/representation/base.py
+++ b/noggin/representation/base.py
@@ -17,6 +17,12 @@ def attr_to_bool(value):
     return value[0] in (True, "TRUE")
 
 
+def attr_to_int(value):
+    if not value:
+        return 0
+    return int(value[0])
+
+
 def attr_to_date(value):
     if value is None:
         return None
@@ -26,6 +32,7 @@ def attr_to_date(value):
 
 CONVERTERS = {
     "str": attr_to_str,
+    "int": attr_to_int,
     "list": attr_to_list,
     "bool": attr_to_bool,
     "date": attr_to_date,

--- a/noggin/representation/otptoken.py
+++ b/noggin/representation/otptoken.py
@@ -6,9 +6,11 @@ class OTPToken(Representation):
         "uniqueid": "ipatokenuniqueid",
         "description": "description",
         "disabled": "ipatokendisabled",
+        "counter": "ipatokenhotpcounter",
     }
     attr_types = {
         "disabled": "bool",
+        "counter": "int",
     }
     pkey = "uniqueid"
     ipa_object = "otptoken"
@@ -16,3 +18,12 @@ class OTPToken(Representation):
     @property
     def uri(self):
         return self.raw.get('uri')
+
+    def is_recovery(self, recovery_description):
+        token_type = self.raw.get('type') or ''
+        if isinstance(token_type, list):
+            token_type = token_type[0] if token_type else ''
+        return (
+            token_type.lower() == 'hotp'
+            and self.description == recovery_description
+        )

--- a/noggin/security/ipa_admin.py
+++ b/noggin/security/ipa_admin.py
@@ -15,6 +15,12 @@ class IPAAdmin:
         "stageuser_activate",
         "stageuser_mod",
         "ping",
+        "otptoken_add",
+        "otptoken_del",
+        "otptoken_find",
+        "otptoken_mod",
+        "otptoken_show",
+        "role_show",
     )
     __WRAPPED_METHODS_TESTING = (
         "user_add",
@@ -28,9 +34,6 @@ class IPAAdmin:
         "pwpolicy_add",
         "pwpolicy_mod",
         "pwpolicy_show",
-        "otptoken_add",
-        "otptoken_del",
-        "otptoken_find",
         "stageuser_del",
         "stageuser_mod",
         "batch",

--- a/noggin/templates/_recovery_codes.html
+++ b/noggin/templates/_recovery_codes.html
@@ -1,0 +1,54 @@
+{% macro codes_grid(recovery_codes) %}
+<div class="row justify-content-center my-3">
+  <div class="col-md-10">
+    <div class="row">
+      {% for code in recovery_codes %}
+        <div class="col-6 mb-2">
+          <code class="fs-5" data-role="recovery-code">{{ loop.index }}. {{ code }}</code>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+<div class="d-flex gap-2 mb-3">
+  <button id="copy-codes" class="btn btn-outline-secondary btn-sm" type="button">
+    <i class="fa fa-copy"></i> {{ _("Copy all") }}
+  </button>
+  <button id="download-codes" class="btn btn-outline-secondary btn-sm" type="button">
+    <i class="fa fa-download"></i> {{ _("Download as text file") }}
+  </button>
+</div>
+{% endmacro %}
+
+{% macro codes_scripts(download_filename='recovery-codes.txt') %}
+<script nonce="{{ csp_nonce() }}">
+  $(document).ready(function() {
+      var codes = [];
+      $('[data-role="recovery-code"]').each(function() {
+          codes.push($(this).text().trim());
+      });
+      var codesText = codes.join('\n');
+
+      $('#copy-codes').click(function() {
+          navigator.clipboard.writeText(codesText).then(function() {
+              $('#copy-codes').text({{ _("Copied!") | tojson }});
+              setTimeout(function() {
+                  $('#copy-codes').html('<i class="fa fa-copy"></i> ' + {{ _("Copy all") | tojson }});
+              }, 2000);
+          });
+      });
+
+      $('#download-codes').click(function() {
+          var blob = new Blob([codesText], {type: 'text/plain'});
+          var url = URL.createObjectURL(blob);
+          var a = document.createElement('a');
+          a.href = url;
+          a.download = {{ download_filename | tojson }};
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+      });
+  });
+</script>
+{% endmacro %}

--- a/noggin/templates/user-settings-otp-admin-reset.html
+++ b/noggin/templates/user-settings-otp-admin-reset.html
@@ -1,0 +1,98 @@
+{% extends "main.html" %}
+
+{% import '_form_macros.html' as macros %}
+{% import '_recovery_codes.html' as recovery_macros %}
+
+{% block title %}{{ _("Reset OTP for %(username)s", username=target_user.username) }}{% endblock %}
+
+{% block content %}
+  {{ super() }}
+
+  <div class="container py-4">
+    <div class="row">
+      <div class="col-8 mx-auto">
+        <div class="card">
+          <div class="card-body">
+            <h5 id="pageheading">
+              {{ _("Reset OTP for %(username)s", username=target_user.username) }}
+            </h5>
+
+            {% if recovery_codes %}
+              <div class="alert alert-success" role="alert">
+                {{ _("OTP tokens have been reset. Share the recovery codes below "
+                     "with the user through a verified secure channel.") }}
+              </div>
+              <div class="alert alert-warning" role="alert">
+                <strong>{{ _("These codes will not be shown again.") }}</strong>
+                {{ _("Make sure the user saves them before you leave this page.") }}
+              </div>
+              {{ recovery_macros.codes_grid(recovery_codes) }}
+              <a href="{{ url_for('.user', username=target_user.username) }}"
+                 class="btn btn-primary">{{ _("Done") }}</a>
+
+            {% else %}
+              <p>{{ _("This will delete all OTP tokens for %(username)s and "
+                      "generate a set of recovery codes that you can share with "
+                      "the user.", username=target_user.username) }}</p>
+
+              {% if tokens %}
+                <h6>{{ _("Current OTP tokens:") }}</h6>
+                <ul class="list-group mb-3">
+                  {% for token in tokens %}
+                    <li class="list-group-item">
+                      {{ token.description if token.description else _("(no name)") }}
+                      <span class="text-muted">— {{ token.uniqueid }}</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p class="text-muted">{{ _("This user has no OTP tokens.") }}</p>
+              {% endif %}
+
+              {% if recovery_token %}
+                <p class="text-muted">
+                  <i class="fa fa-info-circle"></i>
+                  {{ _("This user also has recovery codes which will be replaced.") }}
+                </p>
+              {% endif %}
+
+              <div class="alert alert-danger" role="alert">
+                <strong>{{ _("Warning:") }}</strong>
+                {{ _("This action cannot be undone. All existing OTP tokens will "
+                     "be permanently deleted.") }}
+              </div>
+
+              <form action="{{ url_for('.user_settings_otp_admin_reset',
+                               username=target_user.username) }}"
+                    method="post" novalidate>
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <div class="mb-3">
+                  {{ macros.with_errors(form.password, label=False,
+                         placeholder=_("Your password")) }}
+                </div>
+                <div class="mb-3">
+                  {{ macros.with_errors(form.otp, label=False,
+                         placeholder=_("One-Time Password")) }}
+                </div>
+                <div>{{ macros.non_field_errors(form) }}</div>
+                <div class="d-flex justify-content-between">
+                  {{ form.submit(color="danger") }}
+                  <a href="{{ url_for('.user', username=target_user.username) }}"
+                     class="btn btn-secondary">{{ _("Cancel") }}</a>
+                </div>
+              </form>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if recovery_codes %}
+  {{ recovery_macros.codes_scripts(
+       download_filename='recovery-codes-' ~ target_user.username ~ '.txt') }}
+  {% endif %}
+{% endblock %}

--- a/noggin/templates/user-settings-otp.html
+++ b/noggin/templates/user-settings-otp.html
@@ -1,6 +1,7 @@
 {% extends "user-settings.html" %}
 
 {% import '_form_macros.html' as macros %}
+{% import '_recovery_codes.html' as recovery_macros %}
 {% block settings_content %}
 
 {% if otp_uri %}
@@ -9,7 +10,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">{{ _("Scan your new token") }}</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
       </div>
       <div class="modal-body">
         {# Only show the QR code when the user is ready, this gives them time to pick up their phone and check noone is looking over their shoulders #}
@@ -17,7 +18,7 @@
         <div class="text-center"><button id="otp-toggle" class="btn btn-primary" data-bs-toggle="button" aria-pressed="false">{{ _("Reveal") }}</button></div>
         <div id="otp-qrcode" class="text-center mt-3"></div>
         <p class="mb-1 mt-4">{{ _("or copy and paste the following token URL if you can't scan the QR code:") }}</p>
-        <input id="otp-uri" class="form-control" readonly value="{{otp_uri|safe}}" />
+        <input id="otp-uri" class="form-control" readonly value="{{otp_uri}}" />
         <form action="{{ url_for('.user_settings_otp', username=current_user.username) }}" method="post" class="py-3" novalidate>
           <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
           {{ confirmotpform.secret() }}
@@ -29,7 +30,7 @@
           <div>{{ macros.non_field_errors(confirmotpform) }}</div>
           <div class="d-flex justify-content-between">
           {{ confirmotpform.submit(color="primary") }}
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="{{ _('Cancel') }}">
             {{ _("Cancel") }}
           </button>
           </div>
@@ -40,12 +41,45 @@
 </div>
 {% endif%}
 
+{% if recovery_codes %}
+<div class="modal fade" id="recovery-codes-modal" tabindex="-1" role="dialog"
+     aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ _("Recovery Codes") }}</h5>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-warning" role="alert">
+          <strong>{{ _("Save these codes in a safe place.") }}</strong>
+          {{ _("You will not be able to see them again. If you lose your "
+               "authenticator device, you can use one of these codes to sign in.") }}
+        </div>
+        {{ recovery_macros.codes_grid(recovery_codes) }}
+        <div class="form-check mb-3">
+          <input class="form-check-input" type="checkbox" id="codes-saved-check">
+          <label class="form-check-label" for="codes-saved-check">
+            {{ _("I have saved my recovery codes") }}
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button id="done-btn" type="button" class="btn btn-primary disabled"
+                data-bs-dismiss="modal" disabled>
+          {{ _("Done") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="modal fade" id="add-token-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">{{ _("Add OTP Token") }}</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Close') }}"></button>
       </div>
       <div class="modal-body">
         {% if not tokens %}
@@ -123,6 +157,76 @@
 
 {{ otp_notice() if otp_notice is defined and tokens }}
 
+<div class="card-body mt-4" id="recovery-codes">
+  <h5>{{ _("Recovery Codes") }}</h5>
+  <p class="text-muted">
+    {{ _("Recovery codes can be used to sign in if you lose access "
+         "to your authenticator app. Each code can only be used once.") }}
+  </p>
+  {% if recovery_token %}
+    <p>
+      {% if recovery_codes_remaining is not none and recovery_codes_remaining == 0 %}
+        <span class="badge bg-danger">{{ _("Exhausted") }}</span>
+        {{ _("All recovery codes have been used. Regenerate now to stay protected.") }}
+      {% elif recovery_codes_remaining is not none and recovery_codes_remaining <= config.OTP_RECOVERY_LOW_THRESHOLD %}
+        <span class="badge bg-warning text-dark">{{ _("Low") }}</span>
+        {{ ngettext("%(num)d recovery code remaining.",
+                    "%(num)d recovery codes remaining.",
+                    recovery_codes_remaining) }}
+        {{ _("Consider regenerating your recovery codes.") }}
+      {% elif recovery_codes_remaining is not none %}
+        <span class="badge bg-success">{{ _("Active") }}</span>
+        {{ ngettext("%(num)d recovery code remaining.",
+                    "%(num)d recovery codes remaining.",
+                    recovery_codes_remaining) }}
+      {% else %}
+        <span class="badge bg-success">{{ _("Active") }}</span>
+        {{ _("You have recovery codes set up.") }}
+      {% endif %}
+    </p>
+    <form action="{{ url_for('.user_settings_otp_recovery_regenerate',
+                     username=current_user.username) }}"
+          method="post" class="d-inline" novalidate>
+      <input type="hidden" name="csrf_token"
+             value="{{ csrf_token() }}"/>
+      <div class="mb-3">
+        {{ macros.with_errors(regenerate_recovery_form.password,
+               label=False, placeholder=_("Current password")) }}
+      </div>
+      {% if tokens %}
+        <div class="mb-3">
+          {{ macros.with_errors(regenerate_recovery_form.otp,
+                 label=False, placeholder=_("One-Time Password")) }}
+        </div>
+      {% endif %}
+      {{ regenerate_recovery_form.submit(color="warning") }}
+    </form>
+  {% else %}
+    <p>
+      <span class="badge bg-warning text-dark">{{ _("Not set up") }}</span>
+      {{ _("You have no recovery codes. Generate them now to avoid "
+           "being locked out if you lose your authenticator device.") }}
+    </p>
+    <form action="{{ url_for('.user_settings_otp_recovery_generate',
+                     username=current_user.username) }}"
+          method="post" class="d-inline" novalidate>
+      <input type="hidden" name="csrf_token"
+             value="{{ csrf_token() }}"/>
+      <div class="mb-3">
+        {{ macros.with_errors(generate_recovery_form.password,
+               label=False, placeholder=_("Current password")) }}
+      </div>
+      {% if tokens %}
+        <div class="mb-3">
+          {{ macros.with_errors(generate_recovery_form.otp,
+                 label=False, placeholder=_("One-Time Password")) }}
+        </div>
+      {% endif %}
+      {{ generate_recovery_form.submit(color="primary") }}
+    </form>
+  {% endif %}
+</div>
+
 {% endblock %}
 
 {% block scripts %}
@@ -132,9 +236,25 @@
   <script nonce="{{ csp_nonce() }}">
     $(document).ready(function() {
         $('#otp-modal').modal('show');
-        $('#otp-qrcode').hide().qrcode("{{ otp_uri|safe }}");
+        $('#otp-qrcode').hide().qrcode({{ otp_uri|tojson }});
         $('#otp-toggle').click(function() {
           $('#otp-qrcode').slideToggle("fast");
+        });
+    });
+  </script>
+  {% endif %}
+
+  {% if recovery_codes %}
+  {{ recovery_macros.codes_scripts() }}
+  <script nonce="{{ csp_nonce() }}">
+    $(document).ready(function() {
+        $('#recovery-codes-modal').modal('show');
+        $('#codes-saved-check').change(function() {
+            if ($(this).is(':checked')) {
+                $('#done-btn').removeClass('disabled').prop('disabled', false);
+            } else {
+                $('#done-btn').addClass('disabled').prop('disabled', true);
+            }
         });
     });
   </script>

--- a/noggin/templates/user.html
+++ b/noggin/templates/user.html
@@ -16,6 +16,10 @@
             {% if user.username == current_user.username %}
             <a href="{{ url_for('.user_settings_profile', username=user.username) }}" class="btn btn-outline-primary btn-block my-3">{{_("Edit Profile")}}</a>
             {% endif %}
+            {% if is_otp_admin %}
+            <a href="{{ url_for('.user_settings_otp_admin_reset', username=user.username) }}"
+               class="btn btn-warning btn-sm my-1">{{ _("Reset OTP") }}</a>
+            {% endif %}
           </div>
           <ul class="list-group list-group-flush" id="user_attributes">
               {% if user.creation_time %}
@@ -177,7 +181,7 @@
               </li>
           {% else %}
           <li class="list-group-item h4 text-muted h-100 text-center d-flex align-items-center justify-content-center bg-light">
-            {{user.username}} has no group memberships
+            {{ _("%(username)s has no group memberships", username=user.username) }}
           </li>
           {% endfor %}
         </ul>

--- a/noggin/translations/ar/LC_MESSAGES/messages.po
+++ b/noggin/translations/ar/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Arabic translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,39 +7,92 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: ar\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : "
+"n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
-"&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -140,62 +193,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -203,49 +256,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -253,246 +311,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -501,22 +678,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -524,11 +701,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -552,7 +729,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -560,36 +737,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -630,15 +807,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -652,6 +829,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -874,7 +1059,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,12 +1073,16 @@ msgid_plural ""
 "you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -994,6 +1183,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1004,7 +1195,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1016,8 +1207,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1040,60 +1316,150 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1123,7 +1489,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1136,45 +1502,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1436,12 +1811,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1454,3 +1841,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/be/LC_MESSAGES/messages.po
+++ b/noggin/translations/be/LC_MESSAGES/messages.po
@@ -7,1060 +7,1832 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: be\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: none\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr ""
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr ""
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr ""
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr ""
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr ""
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
+msgstr ""
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/bs/LC_MESSAGES/messages.po
+++ b/noggin/translations/bs/LC_MESSAGES/messages.po
@@ -8,49 +8,115 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-03-06 17:55+0000\n"
 "Last-Translator: Aurélien Bompard <aurelien@bompard.org>\n"
-"Language-Team: Bosnian <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/bs/>\n"
 "Language: bs\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Bosnian <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/bs/>\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Lozinka je istekla. Molimo resetujte je."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Nije se moguće prijaviti na IPA server."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Dobrodošli, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token je uspješno sinhronizovan"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Nije se moguće prijaviti na IPA server."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Nije moguće promijeniti lozinku. Pokušajte ponovo."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Korisnik %(username)s nije pronađen na sistemu."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Nije moguće dodati korisnika %(username)s. Greška: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 "Odlično! Korisnički nalog %(username)s je uspješno dodat u grupu: "
 "%(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
@@ -58,52 +124,65 @@ msgstr ""
 "%(groupname)s."
 
 # | msgid "You got it! %(username)s has been removed from %(groupname)s."
+#: noggin/controller/group.py:194
 #, fuzzy, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 "Odlično! Korisnički nalog %(username)s je uspješno uklonjen iz grupe "
 "%(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Stara lozinka ili korisničko ime nisu ispravni"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Nije bilo moguće promijeniti lozinku."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Vaša lozinka je promijenjena"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Već ste zahtjevali reset lozinke. Morate sačeti %(wait_min)s minuta i "
 "%(wait_sec)s sekundi prije novog zahtjeva."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Korisnički nalog %(username)s ne postoji"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Nismo u mogućnosti poslati Vam email. Pokušajte ponovo kasnije"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"E-Mail je postat na vašu adresu sa instrukcijama kako da resetujete svoju "
-"lozinku"
+"E-Mail je postat na vašu adresu sa instrukcijama kako da resetujete svoju"
+" lozinku"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Token je neispravan. Molimo zatražite novi."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Token je istekao. Molimo zatražite novi."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
@@ -111,98 +190,116 @@ msgstr ""
 "Vaša lozinka je promijenjena otkako ste zatražili ovaj token. Molimo "
 "zatražite novi."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Vaša lozinka je promijenjena, ali nije u skladu s pravilima "
-"(%(policy_error)s), te je postavljena kao istekla. Od vas će se tražiti da "
-"je promijenite nakon prijave."
+"(%(policy_error)s), te je postavljena kao istekla. Od vas će se tražiti "
+"da je promijenite nakon prijave."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Pogrešna vrijednost."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Nije moguće promijeniti lozinku. Pokušajte ponovo."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Vaša lozinka je promijenjena."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 #, fuzzy
 msgid "We could not send you the address validation email, please retry later"
 msgstr "Nismo u mogućnosti poslati Vam email. Pokušajte ponovo kasnije"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Greška prilikom kreiranja korisničkog naloga. Pokušajte ponovo."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 #, fuzzy
 msgid "The token is invalid, please register again."
 msgstr "Token je neispravan. Molimo zatražite novi."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 #, fuzzy
 msgid "This token is no longer valid, please register again."
 msgstr "Token je neispravan. Molimo zatražite novi."
 
 # | msgid "Could not change password, please try again."
+#: noggin/controller/registration.py:228
 #, fuzzy
 msgid "This user cannot be found, please register again."
 msgstr "Nije moguće promijeniti lozinku. Pokušajte ponovo."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
 # | msgid "An error occurred while creating the account, please try again."
+#: noggin/controller/registration.py:262
 #, fuzzy
-msgid ""
-"Something went wrong while creating your account, please try again later."
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Greška prilikom kreiranja korisničkog naloga. Pokušajte ponovo."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Vaš korisnički nalog je kreiran, ali lozinka koju ste odabrali nije u skladu "
-"s pravilima (%(policy_error)s), te je postavljena kao istekla. Od vas će se "
-"tražiti da je promijenite nakon prijave."
+"Vaš korisnički nalog je kreiran, ali lozinka koju ste odabrali nije u "
+"skladu s pravilima (%(policy_error)s), te je postavljena kao istekla. Od "
+"vas će se tražiti da je promijenite nakon prijave."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 "Vaš korisnički nalog je kreiran, ali je došlo do greške prilikom "
-"postavljanja vaše lozinke (%(message)s). Možda ćete je morati promijeniti "
-"nakon prijave."
+"postavljanja vaše lozinke (%(message)s). Možda ćete je morati promijeniti"
+" nakon prijave."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
@@ -210,6 +307,7 @@ msgstr ""
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/controller/registration.py:330
 #, fuzzy
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
@@ -218,817 +316,1431 @@ msgstr ""
 "Čestitamo, sada imate korisnički nalog! Samo naprijed i prijavite se za "
 "nastavak."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 #, fuzzy
 msgid "The token is invalid, please set the email again."
 msgstr "Token je neispravan. Molimo zatražite novi."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 #, fuzzy
 msgid "This token is no longer valid, please set the email again."
 msgstr "Token je neispravan. Molimo zatražite novi."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Pogrešna lozinka"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Nije moguće kreirati token."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Nije se moguće prijaviti na IPA server."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
 # | msgid "Cannot create the token."
+#: noggin/controller/user.py:606
 #, fuzzy
 msgid "Cannot rename the token."
 msgstr "Nije moguće kreirati token."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Nažalost, ne možete onemogućiti svoj zadnji aktivni token."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Nije moguće onemogućiti token."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Nije moguće omogućiti token. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Nažalost, ne možete izbrisati zadnji aktivni token."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Ne možete izbrisati token."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Nije moguće kreirati token."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+# | msgid "Cannot create the token."
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Nije moguće kreirati token."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Pogrešna lozinka"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Ne možete izbrisati token."
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Ponovno postavljanje lozinke za %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Ne možete izbrisati token."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Vaša lozinka je promijenjena."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Ime"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Ime ne smije biti prazno"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Prezime"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Prezime ne smije biti prazno"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Lokalizacija"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Lokalizacija ne smije biti prazna"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Lokalizacija mora biti ispravan kratki kod"
 
 # | msgid "IRC Nickname"
+#: noggin/form/edit_user.py:111
 #, fuzzy
 msgid "Chat Nicknames"
 msgstr "IRC Nadimak"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Vremenska zona"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Vremenska zona ne smije biti prazna"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Vremenska zona mora biti važeća vremenska zona"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub Korisničko ime"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab Korisničko ime"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Odjava"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "E-mail adresa"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "E-mail ne smije biti prazan"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "E-mail mora biti ispravan"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla E-mail"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH Ključevi"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG Ključevi"
 
 # | msgid "Token ID"
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 #, fuzzy
 msgid "Token name"
 msgstr "ID tokena"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Unesite svoju trenutnu lozinku"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Morate unijeti lozinku"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
 # | msgid "Confirm Password"
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 #, fuzzy
 msgid "One-Time Password"
 msgstr "Potvrdite lozinku"
 
 # | msgid "Enter your current password"
+#: noggin/form/edit_user.py:206
 #, fuzzy
 msgid "Enter your One-Time Password"
 msgstr "Unesite svoju trenutnu lozinku"
 
 # | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:209
 #, fuzzy
 msgid "Generate OTP Token"
 msgstr "Sinhronizacija OTP tokena"
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 #, fuzzy
 msgid "Could not find the token secret"
 msgstr "Nije se moguće prijaviti na IPA server."
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
 # | msgid "You must provide a second code"
+#: noggin/form/edit_user.py:223
 #, fuzzy
 msgid "You must provide a verification code"
 msgstr "Morate unijeti drugi kod"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
 # | msgid "Could not change password, please try again."
+#: noggin/form/edit_user.py:230
 #, fuzzy
 msgid "The code is wrong, please try again."
 msgstr "Nije moguće promijeniti lozinku. Pokušajte ponovo."
 
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 #, fuzzy
 msgid "Token must not be empty"
 msgstr "token ne smije biti prazan"
 
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Sinhronizacija OTP tokena"
+
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Sinhronizacija OTP tokena"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Unesite svoju trenutnu lozinku"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Lozinka ne smije biti prazna"
+
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:285
 #, fuzzy
 msgid "Agreement must not be empty"
 msgstr "token ne smije biti prazan"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Korisničko ime korisničkog naloga ne smije biti prazno"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Korisničko ime"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Korisničko ime ne smije biti prazno"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "E-mail adresa"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Morate unijeti korisničko ime"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Lozinka"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Prijava"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nova lozinka"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Lozinka ne smije biti prazna"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Lozinke se moraju podudarati"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Potvrdite novu lozinku"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Trenutna lozinka"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Trenutna lozinka ne smije biti prazna"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Korisničko ime"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Korisničko ime ne smije biti prazno"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Unesite vaše korisničko ime da resetujete svoju lozinku"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registracija"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Molimo odaberite jaku lozinku"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Potvrdite lozinku"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Prvi OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Morate unijeti prvi kod"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Drugi OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Morate unijeti drugi kod"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID tokena"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Ta stranica nije pronađena."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:21
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Zaboravljena lozinka?"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:23
 #, fuzzy
 msgid "Forgot Password or OTP?"
 msgstr "Zaboravljena lozinka?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sinhronizuj token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupe"
 
 # | msgid "Username"
+#: noggin/templates/base.html:29
 #, fuzzy
 msgid "Users"
 msgstr "Korisničko ime"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Obnavljanje lozinke"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Jeste li zaboravili lozinku?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Unesite svoje korisničko ime i vašu e-mail adresu na koju će biti poslan e-"
-"mail s daljnjim uputama."
+"Unesite svoje korisničko ime i vašu e-mail adresu na koju će biti poslan "
+"e-mail s daljnjim uputama."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Pošalji"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Resetuj lozinku"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Ponovno postavljanje lozinke za %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s grupa"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Za pridruživanje ovoj grupi kontaktirajte sponzora grupe."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponzori"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "nema sponzora"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Članovi"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "dodaj korisnika..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Još uvijek nema članova."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista grupa"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s članova"
 
 # | msgid "Groups"
+#: noggin/templates/groups.html:49
 #, fuzzy
 msgid "No groups."
 msgstr "Grupe"
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Prijava"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Ponovno postavljanje istekle lozinke"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Ponovno postavljanje istekle lozinke za %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Promjena lozinke"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 #, fuzzy
 msgid "Registering Users"
 msgstr "Registracija"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
 # | msgid "Register"
+#: noggin/templates/registering.html:53
 #, fuzzy
 msgid "Registered:"
 msgstr "Registracija"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/templates/registration-confirmation.html:16
 #, fuzzy, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
-"Čestitamo %(name)s, sada imate korisnički nalog! Samo naprijed i prijavite "
-"se za nastavak."
+"Čestitamo %(name)s, sada imate korisnički nalog! Samo naprijed i "
+"prijavite se za nastavak."
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 #, fuzzy
 msgid "Your account is being checked"
 msgstr "Vaša lozinka je promijenjena"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
 # | msgid "Your password has been changed."
+#: noggin/templates/registration-spamcheck-wait.html:32
 #, fuzzy
 msgid "Your account has been flagged as spam."
 msgstr "Vaša lozinka je promijenjena."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sinhronizacija OTP tokena"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sinhronizuj OTP token"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sinhronizuj"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Sačuvaj"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID GPG ključ a"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH javni ključ"
 
-msgid "Scan your new token"
-msgstr "Skenirajte svoj novi token"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Postavke za %(username)s"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
-msgstr ""
-"Vaš novi token je spreman. Kliknite na dugme ispod kako biste otkrili QR kod "
-"i skenirali ga."
-
-msgid "Reveal"
-msgstr "Otkrij"
-
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr "ili ako ne možete skenirati QR kod, kopirajte sljedeći URL tokena:"
-
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr "Dodaj OTP token"
+# | msgid "Could not change password, please try again."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Nije moguće promijeniti lozinku. Pokušajte ponovo."
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
+# | msgid "Sync OTP Token"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Sinhronizacija OTP tokena"
 
-msgid "OTP Tokens"
-msgstr "OTP Tokeni"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Nemate OTP tokena"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Lozinka"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "Skenirajte svoj novi token"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Vaš novi token je spreman. Kliknite na dugme ispod kako biste otkrili QR "
+"kod i skenirali ga."
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "Otkrij"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr "ili ako ne možete skenirati QR kod, kopirajte sljedeći URL tokena:"
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "Dodaj OTP token"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "OTP Tokeni"
+
 # | msgid "Username"
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 #, fuzzy
 msgid "Rename"
 msgstr "Korisničko ime"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Onemogući"
 
 # | msgid "Disable"
+#: noggin/templates/user-settings-otp.html:157
 #, fuzzy
 msgid "Enable"
 msgstr "Onemogući"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Nemate OTP tokena"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Sačuvaj"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Trenutna lozinka"
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH Ključevi"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Nemate OTP tokena"
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
 # | msgid "Change Password"
+#: noggin/templates/user-settings-profile.html:12
 #, fuzzy
 msgid "Change Avatar"
 msgstr "Promjena lozinke"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Postavke za %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
 # | msgid "E-mail Address"
+#: noggin/templates/user-settings.html:22
 #, fuzzy
 msgid "Emails"
 msgstr "E-mail adresa"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH i GPG ključevi"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil za %(username)s"
 
 # | msgid "Profile"
+#: noggin/templates/user.html:17
 #, fuzzy
 msgid "Edit Profile"
 msgstr "Profil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Prvi OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Prijava"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponzor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "član"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Korisnički nalog %(username)s ne postoji"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, fuzzy, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr "Da ponovo postavite lozinku %(username)s, kliknite na link ispod:"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, fuzzy, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Ako niste zatražili ponovno postavljanje lozinke, možete zanemariti ovu "
 "poruku."
 
 # | msgid "The Noggin team"
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "The AlmaLinux Team"
 msgstr "The Noggin tim"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 #, fuzzy
 msgid ""
 "Click the link below to reset your password. If you did not request a "
@@ -1037,26 +1749,47 @@ msgstr ""
 "Ako niste zatražili ponovno postavljanje lozinke, možete zanemariti ovu "
 "poruku."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "pretraga..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Postavke"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Odjava"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Pokretano %(noggin_link)s"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/almalinux/templates/main.html:88
 #, fuzzy
 msgid "AlmaLinux Accounts"
 msgstr "Fedora Korisnički Nalozi"
@@ -1064,15 +1797,20 @@ msgstr "Fedora Korisnički Nalozi"
 # | msgid ""
 # | "Fedora Accounts allows you to create and manage an account for Fedora "
 # | "Tools and Infrastructure."
+#: noggin/themes/almalinux/templates/main.html:90
 #, fuzzy
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 "Fedora korisnički nalozi vam omogućavaju da kreirate i upravljate "
 "korisničkim nalogom za Fedora alate i infrastrukturu."
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, fuzzy, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "Da ponovo postavite lozinku, kliknite na link ispod:"
@@ -1080,6 +1818,10 @@ msgstr "Da ponovo postavite lozinku, kliknite na link ispod:"
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, fuzzy, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
@@ -1088,80 +1830,114 @@ msgstr ""
 "Ako niste zatražili ponovno postavljanje lozinke, možete zanemariti ovu "
 "poruku."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "The Noggin tim"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Dobrodošli na noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Ovo je samouslužni portal otvorenog koda za FreeIPA sistem. Omogućava vam "
-"stvari poput kreiranja korisničkih naloga, promjene lozinke, upravljanje "
-"članstvima u grupama i još mnogo toga."
+"Ovo je samouslužni portal otvorenog koda za FreeIPA sistem. Omogućava vam"
+" stvari poput kreiranja korisničkih naloga, promjene lozinke, upravljanje"
+" članstvima u grupama i još mnogo toga."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 #, fuzzy
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Token je istekao. Molimo zatražite novi."
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "Fedora Accounts System"
 msgstr "Fedora Korisnički Nalozi"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora Korisnički Nalozi"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 "Fedora korisnički nalozi vam omogućavaju da kreirate i upravljate "
 "korisničkim nalogom za Fedora alate i infrastrukturu."
 
 # | msgid "Groups"
+#: noggin/themes/fas/templates/main.html:167
 #, fuzzy
 msgid "Edit Group"
 msgstr "Grupe"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Kreirajte PDR zahtjev da onemogućite svoj račun"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Zahtjev za brisanje računa"
 
 # | msgid "Did you lose your OTP token?"
+#: noggin/themes/fas/templates/main.html:190
 #, fuzzy
 msgid "Did you lose your last OTP token?"
 msgstr "Jeste li izgubili svoj OTP token?"
@@ -1172,52 +1948,76 @@ msgstr "Jeste li izgubili svoj OTP token?"
 # "
 # | "your account if possible, so that the administrator can verify your "
 # | "identity."
+#: noggin/themes/fas/templates/main.html:194
 #, fuzzy, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"Ako ste izgubili svoj OTP token, morate poslati e-mail na %(admin_email)s. "
-"Potpišite ovu poruku koristeći GPG ključ povezan s vašim korisničkim nalogom "
-"(ako je moguće), tako da administrator može potvrditi vaš identitet."
+"Ako ste izgubili svoj OTP token, morate poslati e-mail na "
+"%(admin_email)s. Potpišite ovu poruku koristeći GPG ključ povezan s vašim"
+" korisničkim nalogom (ako je moguće), tako da administrator može "
+"potvrditi vaš identitet."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Grupa %(groupname)s nije pronađena."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
@@ -1244,11 +2044,13 @@ msgstr ""
 #~ msgstr "Registracija"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Ovo vam se više nikada neće prikazati, nemojte zatvarati ovaj prozor dok "
-#~ "se vaš token ne spremi."
+#~ "Ovo vam se više nikada neće "
+#~ "prikazati, nemojte zatvarati ovaj prozor "
+#~ "dok se vaš token ne spremi."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Lozinka ili lozinka + jednokratna lozinka"
@@ -1263,10 +2065,14 @@ msgstr ""
 #~ msgstr "RHBZ E-mail"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "prijavite Fedora Infra ticket da promijenite/podesite detalje ili "
-#~ "sponzore ove grupe"
+#~ "prijavite Fedora Infra ticket da "
+#~ "promijenite/podesite detalje ili sponzore ove"
+#~ " grupe"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Zahtjev za promjenu detalja"
+

--- a/noggin/translations/ca/LC_MESSAGES/messages.po
+++ b/noggin/translations/ca/LC_MESSAGES/messages.po
@@ -8,1061 +8,1836 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2023-04-12 14:20+0000\n"
 "Last-Translator: josep constantí <iceberg.jcm@gmail.com>\n"
-"Language-Team: Catalan <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/ca/>\n"
 "Language: ca\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Catalan <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/ca/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "La contrasenya ha caducat. Cal que la restabliu."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "No s'ha pogut accedir al servidor IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Benvingut/da, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "No s'ha pogut accedir al servidor IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "La contrasenya ha caducat. Cal que la restabliu."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr ""
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr ""
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr ""
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr ""
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr ""
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "No s'ha pogut accedir al servidor IPA."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 #, fuzzy
 msgid "Could not find the token secret"
 msgstr "No s'ha pogut accedir al servidor IPA."
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
-msgstr ""
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Benvingut/da, %(username)s!"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
+msgstr ""
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/cs/LC_MESSAGES/messages.po
+++ b/noggin/translations/cs/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Czech translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: cs\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -887,12 +1072,13 @@ msgid_plural ""
 "you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1179,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1191,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1203,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1312,147 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1482,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1495,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1804,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1834,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/de/LC_MESSAGES/messages.po
+++ b/noggin/translations/de/LC_MESSAGES/messages.po
@@ -9,84 +9,161 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2026-04-16 18:58+0000\n"
 "Last-Translator: Mario Blättermann <mario.blaettermann@gmail.com>\n"
-"Language-Team: German <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/de/>\n"
 "Language: de\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: German <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/de/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.17\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Passwort abgelaufen. Bitte erneuern."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Anmeldung am IPA-Server ist fehlgeschlagen."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Hallo, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token erfolgreich synchronisiert"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Kein IPA-Server verfügbar"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Anmeldung am IPA-Server ist fehlgeschlagen."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Das Passwort konnte nicht geändert werden, bitte versuchen Sie es erneut."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Verifizierungscode"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Der Benutzer %(username)s wurde nicht im System gefunden."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
-"Der Benutzer %(username)s konnte nicht hinzugefügt werden: %(errormessage)s"
+"Der Benutzer %(username)s konnte nicht hinzugefügt werden: "
+"%(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Erfolg! %(username)s wurde zu %(groupname)s hinzugefügt."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Erfolg! %(username)s wurde von %(groupname)s entfernt."
 
 # | msgid "You got it! %(username)s has been removed from %(groupname)s."
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Erfolg! %(username)s ist kein Sponsor von %(groupname)s mehr."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Das alte Passwort oder der Benutzername waren nicht korrekt"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Passwortwechsel fehlgeschlagen."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Das Passwort wurde geändert"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Ein Passwortwechsel wurde bereits beantragt, ein erneuter Antrag ist in %"
-"(wait_min)s Minute(n) und %(wait_sec)s Sekunden wieder möglich."
+"Ein Passwortwechsel wurde bereits beantragt, ein erneuter Antrag ist in "
+"%(wait_min)s Minute(n) und %(wait_sec)s Sekunden wieder möglich."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Der Benutzer %(username)s existiert nicht"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Wir konnten keine E-Mail zustellen, bitte später erneut versuchen"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Ihre E-Mail-Adresse wurde vom SMTP-Server abgelehnt"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
@@ -94,48 +171,57 @@ msgstr ""
 "Es wurde eine E-Mail mit der Anleitung zum Zurücksetzen des Passworts "
 "versandt"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Das Token ist ungültig, bitte erneut anfordern."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Das Token ist abgelaufen, bitte erneut anfordern."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Ihr Passwort wurde geändert, seit Sie dieses Token angefordert haben. Bitte "
-"fordern Sie ein neues an."
+"Ihr Passwort wurde geändert, seit Sie dieses Token angefordert haben. "
+"Bitte fordern Sie ein neues an."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Ihr Passwort wurde geändert, entspricht aber nicht der Richtlinie "
 "(%(policy_error)s) und wurde daher als abgelaufen festgelegt. Sie werden "
 "nach dem Anmelden aufgefordert, es zu ändern."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Falscher Wert."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
-msgstr ""
-"Das Passwort konnte nicht geändert werden, bitte versuchen Sie es erneut."
+msgstr "Das Passwort konnte nicht geändert werden, bitte versuchen Sie es erneut."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Ihr Passwort wurde geändert."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifizieren Sie Ihre E-Mail-Adresse"
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Wir konnten keine E-Mail zur Validierung der Adresse zustellen, bitte später "
-"erneut versuchen"
+"Wir konnten keine E-Mail zur Validierung der Adresse zustellen, bitte "
+"später erneut versuchen"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
@@ -144,74 +230,84 @@ msgstr ""
 "Der Benutzername '%(username)s' oder die E-Mail-Adresse '%(email)s' sind "
 "bereits vergeben."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
-"Beim Erstellen des Kontos ist ein Fehler aufgetreten, bitte versuchen Sie es "
-"erneut."
+"Beim Erstellen des Kontos ist ein Fehler aufgetreten, bitte versuchen Sie"
+" es erneut."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 "Die Registrierung scheint fehlgeschlagen zu sein, bitte versuchen Sie es "
 "erneut."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"Die E-Mail zur Adressverifizierung wurde erneut versendet. Bitte schauen Sie "
-"auch in Ihren Spam-Ordner"
+"Die E-Mail zur Adressverifizierung wurde erneut versendet. Bitte schauen "
+"Sie auch in Ihren Spam-Ordner"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 "Es wurde kein Token bereitgestellt. Bitte überprüfen Sie den "
 "Bestätigungslink in Ihrer E-Mail."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Das Token ist ungültig, bitte erneut registrieren."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Das Token ist ungültig, bitte erneut registrieren."
 
 # | msgid "Could not change password, please try again."
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
-msgstr ""
-"Dieser Benutzer wurde nicht gefunden. Bitte registrieren Sie sich erneut."
+msgstr "Dieser Benutzer wurde nicht gefunden. Bitte registrieren Sie sich erneut."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Der Benutzername und die E-Mail-Adresse stimmen nicht mit dem verwendeten "
-"Token überein. Bitte registrieren Sie sich erneut."
+"Der Benutzername und die E-Mail-Adresse stimmen nicht mit dem verwendeten"
+" Token überein. Bitte registrieren Sie sich erneut."
 
 # | msgid "An error occurred while creating the account, please try again."
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
-"Beim Erstellen Ihres Kontos ist ein Fehler aufgetreten, bitte versuchen Sie "
-"es erneut."
+"Beim Erstellen Ihres Kontos ist ein Fehler aufgetreten, bitte versuchen "
+"Sie es erneut."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Ihr Konto wurde erstellt, aber das von Ihnen gewählte Passwort entspricht "
-"nicht den Richtlinien (%(policy_error)s) und wurde daher als abgelaufen "
+"Ihr Konto wurde erstellt, aber das von Ihnen gewählte Passwort entspricht"
+" nicht den Richtlinien (%(policy_error)s) und wurde daher als abgelaufen "
 "festgelegt. Sie werden nach dem Anmelden aufgefordert, es zu ändern."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Ihr Konto wurde erstellt, aber beim Festlegen des Passworts ist ein Fehler "
-"aufgetreten (%(message)s). Möglicherweise müssen Sie es nach dem Anmelden "
-"ändern."
+"Ihr Konto wurde erstellt, aber beim Festlegen des Passworts ist ein "
+"Fehler aufgetreten (%(message)s). Möglicherweise müssen Sie es nach dem "
+"Anmelden ändern."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Herzlichen Glückwunsch, Ihr Konto wurde erstellt! Willkommen, %(name)s."
@@ -219,6 +315,7 @@ msgstr "Herzlichen Glückwunsch, Ihr Konto wurde erstellt! Willkommen, %(name)s.
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
@@ -226,507 +323,818 @@ msgstr ""
 "Herzlichen Glückwunsch, Ihr Konto wurde erstellt! Melden Sie sich an, um "
 "fortzufahren."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Alle"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Unbekannt"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Kein Spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Wartend"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Die Registrierung ist momentan geschlossen."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"Die E-Mail-Adresse %(mail)s muss bestätigt werden. Bitte prüfen Sie Ihren "
-"Posteingang und klicken Sie auf den Link, um fortzufahren. Sollten Sie die E-"
-"Mail innerhalb weniger Minuten nicht finden, schauen Sie bitte in Ihren Spam-"
-"Ordner."
+"Die E-Mail-Adresse %(mail)s muss bestätigt werden. Bitte prüfen Sie Ihren"
+" Posteingang und klicken Sie auf den Link, um fortzufahren. Sollten Sie "
+"die E-Mail innerhalb weniger Minuten nicht finden, schauen Sie bitte in "
+"Ihren Spam-Ordner."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Keine Änderungen."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Das Token ist ungültig, bitte geben Sie die E-Mail-Adresse erneut ein."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 "Dieses Token ist nicht mehr gültig. Bitte geben Sie die E-Mail-Adresse "
 "erneut ein."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Dieses Token gehört Ihnen nicht."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Falsches Passwort"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Das Token kann nicht erstellt werden."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Das Token wurde erstellt."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Das Token-Secret konnte nicht gefunden werden"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
 # | msgid "Cannot create the token."
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Das Token kann nicht umbenannt werden."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
-msgstr ""
-"Entschuldigung, Sie können Ihr letztes aktives Token nicht deaktivieren."
+msgstr "Entschuldigung, Sie können Ihr letztes aktives Token nicht deaktivieren."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Das Token kann nicht deaktiviert werden."
 
 # | msgid "Cannot disable the token."
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Das Token kann nicht deaktiviert werden. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Entschuldigung, Sie können Ihr letztes aktives Token nicht löschen."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Das Token kann nicht gelöscht werden."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Das Token kann nicht erstellt werden."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+# | msgid "Cannot create the token."
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Das Token kann nicht umbenannt werden."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Falsches Passwort"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "OTP-Token verifizieren und aktivieren"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Passwort für %(username)s zurücksetzen"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Die Vereinbarung „%(name)s“ konnte nicht signiert werden: %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Sie haben die Vereinbarung „%(name)s“ signiert."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Das Token kann nicht gelöscht werden."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Das Token wurde erstellt."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Das sieht nicht nach einem gültigen Spitznamen aus."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Dies sieht nicht nach einem gültigen Servernamen aus."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Vorname"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Vorname darf nicht leer sein"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Nachname"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Nachname darf nicht leer sein"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Gebietsschema"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Gebietsschema darf nicht leer sein"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Das Gebietsschema muss ein gültiger Locale-Kurzcode sein"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Chat-Spitznamen"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Zeitzone"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Zeitzone darf nicht leer sein"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Zeitzone muss eine gültige Zeitzone sein"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub-Benutzername"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab-Benutzername"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Gültige URL erforderlich"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "Blog-URL"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "RSS-URL"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privat"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "E-Mail-Adresse"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "E-Mail darf nicht leer sein"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "E-Mail muss gültig sein"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "E-Mail für Red Hat Bugzilla"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH-Schlüssel"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG-Schlüssel"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Token-Name"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 "Fügen Sie optional einen Namen hinzu, damit Sie dieses Token leichter "
 "identifizieren können"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Geben Sie Ihr aktuelles Passwort ein"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Sie müssen ein Passwort angeben"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
-msgstr ""
-"Bitte authentifizieren Sie sich erneut, damit wir wissen, dass Sie es sind"
+msgstr "Bitte authentifizieren Sie sich erneut, damit wir wissen, dass Sie es sind"
 
 # | msgid "Confirm Password"
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Einmalpasswort"
 
 # | msgid "Enter your current password"
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Geben Sie Ihr Einmalpasswort ein"
 
 # | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "OTP-Token erzeugen"
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Das Token-Secret konnte nicht gefunden werden"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Verifizierungscode"
 
 # | msgid "You must provide a user name"
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Sie müssen einen Verifizierungscode angeben"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "OTP-Token verifizieren und aktivieren"
 
 # | msgid "Could not change password, please try again."
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Der Code ist falsch, bitte versuchen Sie es erneut."
 
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Token darf nicht leer sein"
 
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "OTP-Token erzeugen"
+
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "OTP-Token erzeugen"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Geben Sie Ihr aktuelles Passwort ein"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Passwort darf nicht leer sein"
+
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Vereinbarung darf nicht leer sein"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Benutzername des neuen Mitglieds darf nicht leer sein"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Benutzername"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Benutzername darf nicht leer sein"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Benutzername (oder E-Mail-Adresse)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Sie müssen einen Benutzernamen angeben"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Passwort"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Anmelden"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Neues Passwort"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Passwort darf nicht leer sein"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Passwörter müssen übereinstimmen"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Neues Passwort bestätigen"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 "Einmalpasswort (falls für Ihr Konto die Zwei-Faktor-Authentifizierung "
 "aktiviert ist)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Aktuelles Passwort"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Aktuelles Passwort darf nicht leer sein"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Benutzername oder E-Mail"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Benutzername darf nicht leer sein"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
-"Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein, um Ihr Passwort "
-"zurückzusetzen"
+"Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein, um Ihr "
+"Passwort zurückzusetzen"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Nur folgende Zeichen sind zulässig: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Ich bin über 16 Jahre alt"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Sie müssen mindestens 16 Jahre alt sein, um ein Konto zu erstellen"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registrieren"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "E-Mail erneut senden"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Bitte wählen Sie ein starkes Passwort aus"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Passwort bestätigen"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Aktivieren"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Erstes OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Sie müssen einen ersten Code eingeben"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Zweites OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Sie müssen einen zweiten Code eingeben"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Token-ID"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "E-Mail-Adressen dieser Domain sind nicht zulässig"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 "Gemischte Schreibweise ist nicht zulässig; versuchen Sie es mit "
 "Kleinschreibung."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Die Seite wurde nicht gefunden."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Vereinbarung anzeigen"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "Überprüfen"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Benutzervereinbarung signieren"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Passwort vergessen?"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Passwort oder Einmalpasswort vergessen?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Token synchronisieren"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Zurück"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Weiter"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Gruppen"
 
 # | msgid "Username"
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Benutzer"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Passwort-Wiederherstellung"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Haben Sie Ihr Passwort vergessen?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein, und eine E-Mail "
-"mit weiteren Anweisungen wird an Ihre Adresse gesendet."
+"Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein, und eine "
+"E-Mail mit weiteren Anweisungen wird an Ihre Adresse gesendet."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Senden"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Passwort zurücksetzen"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Passwort für %(username)s zurücksetzen"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Gruppe %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Gruppe verlassen"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Sie sind Sponsor dieser Gruppe, aber kein Mitglied. Tragen Sie sich selbst "
-"ein, wenn Sie Mitglied werden möchten."
+"Sie sind Sponsor dieser Gruppe, aber kein Mitglied. Tragen Sie sich "
+"selbst ein, wenn Sie Mitglied werden möchten."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
-"Um dieser Gruppe beizutreten, wenden Sie sich bitte an einen Gruppensponsor."
+"Um dieser Gruppe beizutreten, wenden Sie sich bitte an einen "
+"Gruppensponsor."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsoren"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "keine Sponsoren"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Mitglieder"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "Benutzer hinzufügen..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Noch keine Mitglieder."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Gruppenliste"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s Mitglieder"
 
 # | msgid "Groups"
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Keine Gruppen."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Anmeldung"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA-Fehler"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
-"Es gab ein Problem mit dem IPA-Backend. Bitte versuchen Sie es später erneut."
+"Es gab ein Problem mit dem IPA-Backend. Bitte versuchen Sie es später "
+"erneut."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Sie können sich auch <a href=\"%(url)s\">abmelden</a> und erneut anmelden, "
-"falls das Problem weiterhin besteht."
+"Sie können sich auch <a href=\"%(url)s\">abmelden</a> und erneut "
+"anmelden, falls das Problem weiterhin besteht."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Abgelaufenes Passwort zurücksetzen"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Abgelaufenes Passwort für %(username)s zurücksetzen"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Passwort ändern"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Benutzer registrieren"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Name:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "E-Mail:"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Registriert:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Status:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Auf Spam-Überprüfung warten"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Nicht als Spam markiert"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Als Spam markiert"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Spam-Status ist unbekannt"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Annehmen"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Als Spam markieren"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Löschen"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
@@ -734,505 +1142,900 @@ msgstr ""
 "Durch Klicken auf „Annehmen“ wird dem Benutzer eine Bestätigungs-E-Mail "
 "zugesendet. Andere Knöpfe senden gar nichts."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Momentan keine registrierten Benutzer in diesem Status."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Momentan keine registrierten Benutzer."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Aktivieren Sie Ihr Konto"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Kontenerstellung, Schritt 3 von 3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
-msgstr ""
-"Hallo %(name)s. Um Ihr Konto zu aktivieren, wählen Sie bitte ein Passwort."
+msgstr "Hallo %(name)s. Um Ihr Konto zu aktivieren, wählen Sie bitte ein Passwort."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Vereinbarungen signieren"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "Optionale Signierung der Vereinbarung"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
-"Hallo %(name)s. Bitte lesen Sie die untenstehende Vereinbarung sorgfältig "
-"durch und unterzeichnen Sie sie, wenn Sie mit ihrem Inhalt einverstanden "
-"sind."
+"Hallo %(name)s. Bitte lesen Sie die untenstehende Vereinbarung sorgfältig"
+" durch und unterzeichnen Sie sie, wenn Sie mit ihrem Inhalt einverstanden"
+" sind."
 msgstr[1] ""
-"Hallo %(name)s. Bitte lesen Sie die untenstehenden Vereinbarungen sorgfältig "
-"durch und unterzeichnen Sie sie, wenn Sie mit ihrem Inhalt einverstanden "
-"sind."
+"Hallo %(name)s. Bitte lesen Sie die untenstehenden Vereinbarungen "
+"sorgfältig durch und unterzeichnen Sie sie, wenn Sie mit ihrem Inhalt "
+"einverstanden sind."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Fortsetzen"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Überspringen"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Bestätigen Sie Ihre E-Mail-Adresse"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Kontenerstellung, Schritt 2 von 3"
 
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Herzlichen Glückwunsch, %(name)s, Ihr Konto wurde erstellt!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"Bevor Sie sich anmelden können, muss Ihre E-Mail-Adresse %(mail)s bestätigt "
-"werden. Bitte schauen Sie in Ihren Posteingang und klicken Sie auf den Link, "
-"um fortzufahren."
+"Bevor Sie sich anmelden können, muss Ihre E-Mail-Adresse %(mail)s "
+"bestätigt werden. Bitte schauen Sie in Ihren Posteingang und klicken Sie "
+"auf den Link, um fortzufahren."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 "Falls Sie die E-Mail innerhalb weniger Minuten nicht finden, schauen Sie "
-"bitte in Ihren Spam-Ordner. Sollten Sie sie dort auch nicht finden, können "
-"Sie über den Knopf unten eine weitere Bestätigungs-E-Mail anfordern."
+"bitte in Ihren Spam-Ordner. Sollten Sie sie dort auch nicht finden, "
+"können Sie über den Knopf unten eine weitere Bestätigungs-E-Mail "
+"anfordern."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Spam-Überprüfung läuft"
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Ihr Konto wird überprüft"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 "Bevor Sie sich anmelden können, wird Ihr Konto auf Spam überprüft. Dies "
 "dauert nur wenige Sekunden. Bitte warten Sie…"
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Für Ihr Konto ist eine Administratorgenehmigung erforderlich"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Ihr Konto muss von einem Administrator genehmigt werden."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Sie erhalten eine E-Mail, sobald die Entscheidung getroffen wurde."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Vielen Dank für Ihre Geduld."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Ihr Konto ist gesperrt"
 
 # | msgid "Your password has been changed."
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Ihr Konto wurde als Spam markiert."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 "Nicht unterstützter Spam-Status: %s, bitte kontaktieren Sie die "
 "Administratoren"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Einmalpasswort-Token synchronisieren"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Einmalpasswort-Token synchronisieren"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Synchronisieren"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Bestätigen Sie Ihre E-Mail-Adresse"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
-msgstr ""
-"Hallo %(user_name)s. Wollen Sie Ihren %(attr_name)s auf %(mail)s setzen?"
+msgstr "Hallo %(user_name)s. Wollen Sie Ihren %(attr_name)s auf %(mail)s setzen?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Ja, ich will"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Speichern"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG-Schlüsselkennung"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Öffentlicher SSH-Schlüssel"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Einstellungen für %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+# | msgid "Could not change password, please try again."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Der Code ist falsch, bitte versuchen Sie es erneut."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+# | msgid "Sync OTP Token"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "OTP-Token erzeugen"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(kein Name)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Sie haben keine OTP-Token"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Wartend"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Passwort"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Ihr neues Token einlesen"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Ihr neues Token ist bereit. Klicken Sie auf den Knopf unten, um den QR-Code "
-"anzuzeigen und lesen Sie ihn ein."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Ihr neues Token ist bereit. Klicken Sie auf den Knopf unten, um den QR-"
+"Code anzuzeigen und lesen Sie ihn ein."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Anzeigen"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"oder kopieren Sie die folgende Token-URL und fügen Sie sie ein, falls Sie "
-"den QR-Code nicht einlesen können:"
+"oder kopieren Sie die folgende Token-URL und fügen Sie sie ein, falls Sie"
+" den QR-Code nicht einlesen können:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"Nachdem Sie das Token in Ihrer Anwendung registriert haben, verifizieren Sie "
-"es, indem Sie Ihren ersten Code generieren und ihn unten eingeben:"
+"Nachdem Sie das Token in Ihrer Anwendung registriert haben, verifizieren "
+"Sie es, indem Sie Ihren ersten Code generieren und ihn unten eingeben:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "OTP-Token hinzufügen"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
 "Durch die Erstellung Ihres ersten OTP-Tokens wird die Zwei-Faktor-"
 "Authentifizierung mittels OTP aktiviert."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
-"Sobald die Zwei-Faktor-Authentifizierung aktiviert ist, kann sie nicht mehr "
-"deaktiviert werden."
+"Sobald die Zwei-Faktor-Authentifizierung aktiviert ist, kann sie nicht "
+"mehr deaktiviert werden."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "OTP-Token"
 
-msgid "(no name)"
-msgstr "(kein Name)"
-
 # | msgid "Username"
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Umbenennen"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Deaktivieren"
 
 # | msgid "Disable"
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Aktivieren"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Sie haben keine OTP-Token"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
-"Fügen Sie ein OTP-Token hinzu, um die Zwei-Faktor-Authentifizierung für Ihr "
-"Konto zu aktivieren."
+"Fügen Sie ein OTP-Token hinzu, um die Zwei-Faktor-Authentifizierung für "
+"Ihr Konto zu aktivieren."
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Aktivieren"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Aktuelles Passwort"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Kein Spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH-Schlüssel"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Sie haben keine OTP-Token"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Fügen Sie ein OTP-Token hinzu, um die Zwei-Faktor-Authentifizierung für "
+"Ihr Konto zu aktivieren."
 
 # | msgid "Change Password"
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Avatar ändern"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
-"Das Format ist entweder <code>Benutzername</code> oder <code>"
-"Benutzername:Servername</code>, wenn Sie nicht die Standardserver verwenden:"
+"Das Format ist entweder <code>Benutzername</code> oder "
+"<code>Benutzername:Servername</code>, wenn Sie nicht die Standardserver "
+"verwenden:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "Für %(title)s: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Einstellungen für %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
 # | msgid "E-mail Address"
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "E-Mails"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH- und GPG-Schlüssel"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "Einmalpasswort"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Vereinbarungen"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil für %(username)s"
 
 # | msgid "Profile"
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Erstes OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Erstellt am"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Aktuelle Zeit"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blog"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Gruppe(n), %(agreementcount)s Vereinbarung(en)"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "signiert"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "Sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "Mitglied"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Der Benutzer %(username)s existiert nicht"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Hallo %(name)s,"
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"Klicken Sie auf den unten stehenden Link, um Ihr Konto mit dem Benutzernamen "
-"%(username)s zu aktivieren:"
+"Klicken Sie auf den unten stehenden Link, um Ihr Konto mit dem "
+"Benutzernamen %(username)s zu aktivieren:"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Falls Sie kein Konto für den Benutzernamen %(username)s erstellt haben, "
 "können Sie diese E-Mail ignorieren."
 
 # | msgid "The Noggin team"
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "Das AlmaLinux-Team"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Hallo,"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Klicken Sie auf den unten stehenden Link, um Ihr Passwort zurückzusetzen. "
-"Falls Sie keine Passwortzurücksetzung angefordert haben, ignorieren Sie "
+"Klicken Sie auf den unten stehenden Link, um Ihr Passwort zurückzusetzen."
+" Falls Sie keine Passwortzurücksetzung angefordert haben, ignorieren Sie "
 "diese E-Mail bitte."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "AlmaLinux-Benutzerkontendienst"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "Suchen…"
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Einstellungen"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Hilfe"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Abmelden"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Angetrieben durch %(noggin_link)s"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux-Konten"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Mit einem AlmaLinux-Benutzerkonto haben Sie die Möglichkeit, Ihr Konto in "
-"der gesamten AlmaLinux-Infrastruktur zu erstellen und zu verwalten."
+"Mit einem AlmaLinux-Benutzerkonto haben Sie die Möglichkeit, Ihr Konto in"
+" der gesamten AlmaLinux-Infrastruktur zu erstellen und zu verwalten."
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
-"Klicken Sie auf den unten stehenden Link, um die E-Mail-Adresse %(address)s "
-"zurückzusetzen:"
+"Klicken Sie auf den unten stehenden Link, um die E-Mail-Adresse "
+"%(address)s zurückzusetzen:"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Wenn Sie die E-Mail-Adresse %(address)s nicht in Ihrem Konto %(username)s "
-"hinterlegt haben, können Sie diese E-Mail ignorieren."
+"Wenn Sie die E-Mail-Adresse %(address)s nicht in Ihrem Konto %(username)s"
+" hinterlegt haben, können Sie diese E-Mail ignorieren."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Das Noggin-Team"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Willkommen bei noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 "Dies ist das Open-Source-Community-Portal für FreeIPA. Hier können Sie "
 "beispielsweise ein Konto erstellen, Ihr Passwort ändern, "
 "Gruppenmitgliedschaften verwalten und vieles mehr."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"Wenn Sie Kerberos-Tickets verwenden, während OTP aktiviert ist, ist weitere "
-"Konfiguration erforderlich"
+"Wenn Sie Kerberos-Tickets verwenden, während OTP aktiviert ist, ist "
+"weitere Konfiguration erforderlich"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"In der <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>Dokumentation</a> finden Sie Details zur Konfiguration ihres Systems"
+"In der <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>Dokumentation</a> finden Sie Details zur "
+"Konfiguration ihres Systems"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Sie können sich hier auch mit Ihrem Fedora-Benutzerkonto anmelden."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr "Dieser Link ist %(ttl)s Minuten gültig (bis %(valid_until)s UTC)."
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Falls der Link abgelaufen ist, können Sie hier einen neuen anfordern: "
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora-Kontensystem"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora-Konten"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora People"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
 # | msgid "Groups"
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Gruppe bearbeiten"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Kontolöschung beantragen"
 
 # | msgid "Did you lose your OTP token?"
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Haben Sie Ihr OTP-Token verloren?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Sie können sich hier auch mit Ihrem CentOS-Benutzerkonto anmelden."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Gruppe %(groupname)s konnte nicht gefunden werden."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 "Es wurden keine Benutzer mit der E-Mail-Adresse %(username_or_email)s "
 "gefunden"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Rückgängig"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s auf %(server)s"
@@ -1253,10 +2056,12 @@ msgstr "%(protocol)s auf %(server)s"
 #~ msgstr "Registrierung"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Dies wird Ihnen nie wieder angezeigt. Schließen Sie dieses Fenster erst, "
+#~ "Dies wird Ihnen nie wieder angezeigt."
+#~ " Schließen Sie dieses Fenster erst, "
 #~ "wenn Ihr Token gespeichert ist."
 
 #~ msgid "Password or Password + One-Time-Password"
@@ -1267,3 +2072,4 @@ msgstr "%(protocol)s auf %(server)s"
 
 #~ msgid "Disabled"
 #~ msgstr "Deaktiviert"
+

--- a/noggin/translations/en_GB/LC_MESSAGES/messages.po
+++ b/noggin/translations/en_GB/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# English (United Kingdom) translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -8,41 +8,96 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2026-03-02 14:58+0000\n"
 "Last-Translator: Andi Chandler <andi@gowling.com>\n"
-"Language-Team: English (United Kingdom) <https://translate.fedoraproject.org/"
-"projects/fedora-infra/noggin/en_GB/>\n"
 "Language: en_GB\n"
+"Language-Team: English (United Kingdom) "
+"<https://translate.fedoraproject.org/projects/fedora-infra/noggin/en_GB/>"
+"\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.16.1\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Password expired. Please reset it."
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Could not log in to the IPA server."
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Welcome, %(username)s!"
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token successfully synchronised"
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "No IPA server available"
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Could not log in to the IPA server."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Password expired. Please reset it."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
 
 #: noggin/controller/group.py:65
 #, python-format
@@ -142,62 +197,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -205,49 +260,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -255,246 +315,366 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Could not log in to the IPA server."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -503,22 +683,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -526,11 +706,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -554,7 +734,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -562,36 +742,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -632,15 +812,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -654,6 +834,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -876,7 +1064,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -891,11 +1079,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -996,6 +1184,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1006,7 +1196,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1018,8 +1208,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Welcome, %(username)s!"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1042,60 +1317,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1125,7 +1486,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1138,45 +1499,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1438,12 +1808,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1456,3 +1838,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/es/LC_MESSAGES/messages.po
+++ b/noggin/translations/es/LC_MESSAGES/messages.po
@@ -12,560 +12,923 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-06-05 15:00+0000\n"
 "Last-Translator: \"Fco. Javier F. Serrador\" <fserrador@gmail.com>\n"
-"Language-Team: Spanish <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/es/>\n"
 "Language: es\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Spanish <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/es/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Contraseña caducada. Restablécela."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "No pudo acceder al servidor IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Bienvenido, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Vale sincronizado correctamente"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "No pudo acceder al servidor IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "No se pudo cambiar la contraseña. Inténtelo de nuevo."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Código de verificación"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "El usuario %(username)s no fue encontrado en el sistema."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "No es capaz de añadir usuario %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
-msgstr ""
-"Correcto. El usuario %(username)s ha sido agregado al grupo %(groupname)s."
+msgstr "Correcto. El usuario %(username)s ha sido agregado al grupo %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
-"Correcto. El usuario %(username)s ha sido retirado del grupo %(groupname)s."
+"Correcto. El usuario %(username)s ha sido retirado del grupo "
+"%(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 "Correcto. El usuario %(username)s ya no es más un patrocinador de "
 "%(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "La contraseña anterior o el nombre del usuario no es correcto"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "No se pudo modificar la contraseña."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Su contraseña ha sido cambiada"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Ya ha solicitado un restablecimiento de contraseña, necesita esperar "
 "%(wait_min)s minuto(s) y %(wait_sec)s segundos antes que pueda solicitar "
 "otra."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "El usuario %(username)s no existe"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "No pudimos enviarle un correo-e, reinténtelo más tarde"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Su dirección de correo-e ha sido rechazada por el servidor smtp"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Ha sido enviado un correo-e a su dirección con instrucciones acerca de como "
-"restablecer su contraseña"
+"Ha sido enviado un correo-e a su dirección con instrucciones acerca de "
+"como restablecer su contraseña"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "El vale no es válido. Debe solicitar uno nuevo."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "El vale ha caducado, solicite uno nuevo."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Su contraseña ha sido modificada desde que solicitó este vale, por favor, "
-"solicite uno nuevo."
+"Su contraseña ha sido modificada desde que solicitó este vale, por favor,"
+" solicite uno nuevo."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Su contraseña ha sido modificada, pero no cumple con la normativa "
 "(%(policy_error)s) y, por tanto, ha sido caducada. Se le solicitará "
 "cambiarla tras su acceso."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Valor incorrecto."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "No se pudo cambiar la contraseña. Inténtelo de nuevo."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Su contraseña ha sido modificada."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifique su dirección de correo-e"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"No pudimos enviarle la dirección de validación del correo-e, inténtelo más "
-"tarde"
+"No pudimos enviarle la dirección de validación del correo-e, inténtelo "
+"más tarde"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"El nombre de usuario '%(username)s' o la dirección de correo-e %(email)s ya "
-"está introducida."
+"El nombre de usuario '%(username)s' o la dirección de correo-e %(email)s "
+"ya está introducida."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Ha sucedido un error mientras creaba la cuenta; inténtelo de nuevo."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "El registro parece haber fallado; inténtelo de nuevo."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 "La validación de la dirección del correo-e ha sido enviado de nuevo. "
 "Asegúrese que no acabe en su carpeta de spam"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
-msgstr ""
-"Ningún vale proporcionado, compruebe su enlace de validez del correo-e."
+msgstr "Ningún vale proporcionado, compruebe su enlace de validez del correo-e."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "El vale no es válido; regístrese otra vez."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Este vale no es válido más; regístrese de nuevo."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Este usuario no puede ser encontrado; regístrelo de nuevo."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 "No coincide el nombre de usuario y la dirección de correo-e con el vale "
 "utilizado; regístrese de nuevo."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Algo fue mal mientras creaba su cuenta; inténtelo más tarde."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Su cuenta ha sido creada, pero la contraseña escogida no cumple con la "
-"normativa (%(policy_error)s) y por tanto ha sido fijado como caducado. Se le "
-"solicitará que lo cambie tras acceder."
+"normativa (%(policy_error)s) y por tanto ha sido fijado como caducado. Se"
+" le solicitará que lo cambie tras acceder."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Su cuenta ha sido creada, pero ha sucedido un error mientras configuraba su "
-"contraseña (%(message)s). Puede necesitar cambiarlo tras acceder."
+"Su cuenta ha sido creada, pero ha sucedido un error mientras configuraba "
+"su contraseña (%(message)s). Puede necesitar cambiarlo tras acceder."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "¡Felicitaciones!, su cuenta ha sido creada. Bienvenido, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
-msgstr ""
-"¡Enhorabuena!, su cuenta ha sido creada. Continúe y entre en el sistema."
+msgstr "¡Enhorabuena!, su cuenta ha sido creada. Continúe y entre en el sistema."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Todos"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Desconocido"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "No Spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "En espera"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "La inscripción está cerrada en el momento."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "La dirección de correo-e %(mail)s necesita ser validado. Compruebe su "
 "bandeja de entrada y pulse en el enlace para continuar. Si no puede "
-"encontrar el correo-e en un par de minutos, examine vuestra carpeta de spam."
+"encontrar el correo-e en un par de minutos, examine vuestra carpeta de "
+"spam."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Sin modificaciones."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "El vale no es válido, fije el correo-e de nuevo."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Este vale no es válido más, establezca el correo-e otra vez."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Este vale no te pertenece."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Contraseña incorrecta"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "No se puede crear el vale."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "El vale ha sido creado."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "No pudo encontrar el vale secreto"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "No se puede renombrar el vale."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Disculpe, no se puede desactivar su último vale activo."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "No se puede desactivar el vale."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "No se puede habilitar el vale. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Disculpe, no se puede borrar su último vale activo."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "No se puede borrar el vale."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "No se puede crear el vale."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "No se puede renombrar el vale."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Contraseña incorrecta"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Verificar y Habilitar Vale OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Restablecer Contraseña para %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "No se puede firmar el acuerdo «%(name)s»: %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Ha firmado el acuerdo de «%(name)s»."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "No se puede borrar el vale."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "El vale ha sido creado."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Esto no parece un apodo válido."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Esto no parece un nombre de servidor válido."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Nombre"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "El nombre no puede estar vacío"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Apellido"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "El apellido no debe estar vacío"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Lugar"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "El lugar no debe estar vacío"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "El lugar debe ser un código breve válido del lugar"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Apodos de chat"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Zona horaria"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "La zona horaria debe no estar vacía"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "La zona horaria debe ser un timezone válido"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Usuario de GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Usuario de GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Se requiere URL válida"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Salir"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privado"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Oculta información desde otros usuarios, consulte la Normativa Privativa "
 "para detalles."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronombres"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Direc. de correo-e"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "El correo-e no debe estar vacío"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "El correo-e debe ser válido"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Correo del Bugzilla Red Hat"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Claves SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Claves GPG"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nombre de vale"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Añada un nombre opcional para ayudar a identificarle este vale"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Introduzca su contraseña actual"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Debe proporcionar una contraseña"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "reautentique tal que sepamos que eres tú"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Contraseña de un solo uso"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Introduzca su Contraseña de Un Solo Uso"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Genera Vale de OTP"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "No pudo encontrar el vale secreto"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Código de verificación"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Debe proporcionar un código de verificación"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Verificar y Habilitar Vale OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "El código es incorrecto, inténtelo de nuevo."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "El vale no debe estar vacío"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Genera Vale de OTP"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Genera Vale de OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Introduzca su contraseña actual"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "La contraseña debe no estar vacía"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "El acuerdo debe no estar vacío"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "El miembro de usuario nuevo no debe estar vacío"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Usuario"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "El usuario debe no estar vacío"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Verifique su dirección de correo-e"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Debe proporcionar un nombre de usuario"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Contraseña"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Iniciar sesión"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Contraseña Nueva"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "La contraseña debe no estar vacía"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Las contraseñas deben coincidir"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Confirmar Contraseña Nueva"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
-"Contraseña de Una-Vez (si su cuenta tiene activada la Autenticación de Dos-"
-"Factores)"
+"Contraseña de Una-Vez (si su cuenta tiene activada la Autenticación de "
+"Dos-Factores)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Contraseña Actual"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "La contraseña actual no debe estar vacía"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Usuario"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Nombre de usuario debe no estar vacío"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Introduzca su Usuario para restablecer su contraseña"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Solo están permitidos estos caracteres: «%(chars)s»."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Tengo más de 16 años"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Debe tener una edad de más de 16 años para crear una cuenta"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registrar"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Reenviar correo-e"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Elija una contraseña fuerte"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Confirmar Contraseña"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Activar"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "OTP Primero"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Debe proporcionar un primer código"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "OTP Segundo"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Debe proporcionar un segundo código"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID de Vale"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Direcciones de correo-e desde ese dominio no están permitidos"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "Mezcla de MAYÚS/minús no está permitido, intente solo minúsculas."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "El campo no coincide con «%(pattern)s»."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Esa página no fue encontrada."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Vista de acuerdo"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Firma de Acuerdo del Usuario"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "¿Olvidó la contraseña?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "¿Olvidó la contraseña o el OTP?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sinc Vale"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Anterior"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "actual"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Siguiente"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupos"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Usuarios"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Recuperar Contraseña"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "¿Olvidaste su contraseña?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
@@ -574,336 +937,624 @@ msgstr ""
 "Introduzca su usuario y un correo será enviado a su dirección con más "
 "instrucciones."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Enviar"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Restablecer Contraseña"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Restablecer Contraseña para %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Grupo %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Abandonar grupo"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Eres un patrocinador de este grupo, pero no un miembro. Añádase usted mismo "
-"si desea ser un miembro."
+"Eres un patrocinador de este grupo, pero no un miembro. Añádase usted "
+"mismo si desea ser un miembro."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Para unirse a este grupo, contacte con un patrocinador del grupo."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "sin patrocinadores"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Miembros"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "añadir usuario…"
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Aún sin miembros."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista de grupo"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s miembros"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Ningún grupo."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Iniciar sesión"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Error IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Hubo un problema con el backend IPA, intente otra vez más tarde."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Además puede <a href=\"%(url)s\">salir</a> y volver a entrar si el problema "
-"persiste."
+"Además puede <a href=\"%(url)s\">salir</a> y volver a entrar si el "
+"problema persiste."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Restablecer Contraseña Caducada"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Restablecer Contraseña Caducada para %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Cambiar Contraseña"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Registrando Usuarios"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nombre:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Correo-e:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Registrado:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Estado:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Esperando comprobante de spam"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "No indicado como spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Indicado como spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Estado de spam desconocido"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Aceptar"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Indicar como spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Eliminar"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Pulse en Aceptar enviará el correo de validación a este usuario. Los otros "
-"botones no enviarán nada."
+"Pulse en Aceptar enviará el correo de validación a este usuario. Los "
+"otros botones no enviarán nada."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "En este estado en este momento no registra usuarios."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "En este momento no registra usuarios."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Active su cuenta"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Creación de cuenta, paso 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Hola %(name)s. Para activar su cuenta, elija una contraseña."
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "Firma de Acuerdo del Usuario"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Valida su dirección de correo-e"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Creación de cuenta, paso 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "¡Enhorabuena %(name)s, su cuenta ha sido creada!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 "Antes que pueda acceder, su dirección de correo: %(mail)s necesita ser "
 "validada. Compruebe su bandeja y pulse en el enlace para comenzar."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Si no puede encontrar el correo-e en un par de minutos, compruebe su carpeta "
-"spam. Si no está allí, puedes pedir otra validación de correo-e pulsando en "
-"el botón de abajo."
+"Si no puede encontrar el correo-e en un par de minutos, compruebe su "
+"carpeta spam. Si no está allí, puedes pedir otra validación de correo-e "
+"pulsando en el botón de abajo."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Comprobante de spam en progreso"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Su cuenta está siendo comprobada"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 "Antes que pueda acceder, su cuenta necesita ser comprobada para la "
 "probabilidad de spam. Solamente tendría que tomar unos pocos segundos, "
 "espera…"
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Su cuenta requiere aprobación administrativa"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Su cuenta necesita ser aprobada por un administrador."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Recibirá un correo-e cuando la decisión haya sido tomada."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Gracias por su paciencia."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Su cuenta está bloqueada"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Su cuenta ha sido marcada como spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Algo fue incorrecto"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Estado de spam no mantenido: %s, contacte con los administradores"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sinc. vale OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sincroniza Vale OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sinc"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Validar su correo-e"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr "Hola %(user_name)s. ¿Quieres poner vuestro %(attr_name)s a %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Hazlo"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Guardar"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID Clave GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Clave SSL Pública"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Configurar para %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "El código es incorrecto, inténtelo de nuevo."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Genera Vale de OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(sin nombre)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "No tienes ningún vale OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "En espera"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Contraseña"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Analiza su vale nuevo"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Su vale nuevo está listo. Pulse en el botón de abajo para revelar el código "
-"QR y analícelo."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Su vale nuevo está listo. Pulse en el botón de abajo para revelar el "
+"código QR y analícelo."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Revelar"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"o copiar y pegar la URL del vale siguiente si no puede analizar el código QR:"
+"o copiar y pegar la URL del vale siguiente si no puede analizar el código"
+" QR:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Añadir vale OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
-"Crea su primer vale OTP habilita autenticación de dos factores utilizando "
-"OTP."
+"Crea su primer vale OTP habilita autenticación de dos factores utilizando"
+" OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 "Una vez habilitado, la autenticación de dos factores no puede ser "
 "deshabilitada."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Vales OTP"
 
-msgid "(no name)"
-msgstr "(sin nombre)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Renombrar"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Desactivar"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Activar"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "No tienes ningún vale OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
-"Añada un vale OTP para habilitar autenticación de dos factores en su cuenta."
+"Añada un vale OTP para habilitar autenticación de dos factores en su "
+"cuenta."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Activar"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Contraseña Actual"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "No Spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Claves SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "No tienes ningún vale OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Añada un vale OTP para habilitar autenticación de dos factores en su "
+"cuenta."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Cambiar Avatar"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
 "            El formato es tampoco <code>username</code> o "
@@ -911,260 +1562,409 @@ msgstr ""
 "servidores:\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              Para %(title)s: <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Configurar para %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Perfil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Correos-e"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Claves SSH y GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Acuerdos"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Perfil para %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Editar Perfil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "OTP Primero"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Hora Actual"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Charla"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Iniciar sesión"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Grupo(s), %(agreementcount)s Acuerdo(s)"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "firmado"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "patrocinador"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "miembro"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "El usuario %(username)s no existe"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Hola %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 "Para activar su cuenta con usuario %(username)s, pulse en el enlace a "
 "continuación:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Si no creó una cuenta para el usuario %(username)s, puede ignorar este "
 "correo-e."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "El Equipo AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Hola,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Pulse el enlace de abajo para restablecer su contraseña. Si no solicitó un "
-"restablecimiento de cuenta, ignore este correo-e."
+"Pulse el enlace de abajo para restablecer su contraseña. Si no solicitó "
+"un restablecimiento de cuenta, ignore este correo-e."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Servicios de Cuenta AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "buscar…"
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Configuración"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Ayuda"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Salir"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Manufacturado por %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Cuentas AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Cuentas AlmaLinux proporcionan la habilidad de crear y gestionar su cuenta a "
-"través de la completa infraestructura de AlmaLinux."
+"Cuentas AlmaLinux proporcionan la habilidad de crear y gestionar su "
+"cuenta a través de la completa infraestructura de AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
-"Para validar la dirección de correo-e %(address)s, pulse sobre el enlace de "
-"abajo:"
+"Para validar la dirección de correo-e %(address)s, pulse sobre el enlace "
+"de abajo:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 "Se requiere configuración adicional cuando utilice tickets de Kerberos "
 "cuando OTP esté activado"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Lea la <a href='https://docs.fedoraproject.org/es/fedora-accounts/user/"
-"#pkinit'>documentación</a> para detalles con la configuración de su sistema"
+"Lea la <a href='https://docs.fedoraproject.org/es/fedora-"
+"accounts/user/#pkinit'>documentación</a> para detalles con la "
+"configuración de su sistema"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
@@ -1180,3 +1980,4 @@ msgstr ""
 
 #~ msgid "Website"
 #~ msgstr "Sitio web"
+

--- a/noggin/translations/fi/LC_MESSAGES/messages.po
+++ b/noggin/translations/fi/LC_MESSAGES/messages.po
@@ -9,946 +9,1653 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-04-23 09:53+0000\n"
 "Last-Translator: Ricky Tigg <ricky.tigg@gmail.com>\n"
-"Language-Team: Finnish <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/fi/>\n"
 "Language: fi\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Finnish <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/fi/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Salasana vanhentunut. Nollaa se."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "IPA-palvelimeen ei voitu kirjautua."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Tervetuloa, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Tunnuksen synkronointi onnistui"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "IPA-palvelimeen ei voitu kirjautua."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Salasanan vaihtaminen epäonnistui. Yritä uudelleen."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Käyttäjää %(username)s ei löydetty järjestelmästä."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Käyttäjää %(username)s: %(errormessage)s ei voi lisätä"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "%(username)s lisättiin %(groupname)s:een."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "%(username)s poistettiin %(groupname)s:sta."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Valmista! %(username)s ei ole enää %(groupname)s:n sponsori."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Vanha salasana tai käyttäjänimi ei ole oikein"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Salasanan vaihto epäonnistui."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Salasanasi on vaihdettu"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Olet jo pyytänyt salasanan vaihtamista. Sinun on odotettava %(wait_min)s "
 "minuutti(a) ja s %(wait_sec)s ekuntia, ennen kuin voit pyytää uutta."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Käyttäjää %(username)s ei ole olemassa"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Emme voineet lähettää sinulle sähköpostia. Yritä myöhemmin uudelleen"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Smtp-palvelin hylkäsi sähköpostiosoitteesi"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Osoitteeseesi on lähetetty sähköposti, jossa on ohjeet salasanan vaihtamiseen"
+"Osoitteeseesi on lähetetty sähköposti, jossa on ohjeet salasanan "
+"vaihtamiseen"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Tunnus on virheellinen. Pyydä uutta."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Tunnus on vanhentunut. Pyydä uutta."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr "Salasanasi on vaihdettu, koska pyysit tätä tunnusta. Pyydä uusi."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Salasanasi on vaihdettu, mutta se ei ole käytännön (%(policy_error)s) "
-"mukainen ja on siten asetettu vanhentuneeksi. Sinua pyydetään vaihtamaan se "
-"sisäänkirjautumisen jälkeen."
+"mukainen ja on siten asetettu vanhentuneeksi. Sinua pyydetään vaihtamaan "
+"se sisäänkirjautumisen jälkeen."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Virheellinen arvo."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Salasanan vaihtaminen epäonnistui. Yritä uudelleen."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Salasanasi on vaihdettu."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Vahvista sähköpostiosoitteesi"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 "Emme voineet lähettää sinulle osoitteen vahvistussähköpostia, yritä "
 "myöhemmin uudelleen"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Käyttäjänimi '%(username)s' tai sähköpostiosoite '%(email)s' on jo varattu."
+"Käyttäjänimi '%(username)s' tai sähköpostiosoite '%(email)s' on jo "
+"varattu."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Tilin luomisessa tapahtui virhe. Yritä uudelleen."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "Rekisteröinti vaikuttaa epäonnistuneen, yritä uudelleen."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 "Osoitteen vahvistussähköposti lähetetty uudelleen. Varmista, että se ei "
 "päätynyt roskapostikansioon"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "Tunnusta ei ole toimitettu, tarkista sähköpostisi vahvistuslinkki."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Tunnus on virheellinen, rekisteröidy uudelleen."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Tämä tunnus ei ole enää voimassa, rekisteröidy uudelleen."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Tätä käyttäjää ei löydy, rekisteröidy uudelleen."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 "Käyttäjätunnus ja sähköpostiosoite eivät täsmää tunnuksesi kanssa, "
 "rekisteröidy uudelleen."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Jotain meni pieleen tiliäsi luotaessa. Yritä myöhemmin uudelleen."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Tilisi on luotu, mutta valitsemasi salasana ei ole käytännön "
 "(%(policy_error)s) mukainen ja on siten asetettu vanhentuneeksi. Sinua "
 "pyydetään vaihtamaan se kirjautumisen jälkeen."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Tilisi on luotu, mutta salasanaa (%(message)s) asetettaessa tapahtui virhe. "
-"Saatat joutua muuttamaan sitä sisäänkirjautumisen jälkeen."
+"Tilisi on luotu, mutta salasanaa (%(message)s) asetettaessa tapahtui "
+"virhe. Saatat joutua muuttamaan sitä sisäänkirjautumisen jälkeen."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Onnittelut, tilisi on nyt luotu! Tervetuloa, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "Onnittelut, tilisi on luotu! Jatka kirjautumalla sisään."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Kaikki"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Tuntematon"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Ei roskapostia"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Roskapostia"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Odottaa"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Rekisteröiminen on tällä hetkellä suljettuna."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "Sähköpostiosoite %(mail)s on vahvistettava. Tarkista postilaatikkosi ja "
-"napsauta linkkiä jatkaaksesi. Jos sähköposti ei löydy muutamassa minuutissa, "
-"tarkista roskapostikansiosi."
+"napsauta linkkiä jatkaaksesi. Jos sähköposti ei löydy muutamassa "
+"minuutissa, tarkista roskapostikansiosi."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Ei muokkauksia."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Tunnus on virheellinen, aseta sähköpostiosoite uudelleen."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Tämä tunnus ei ole enää voimassa. Aseta sähköpostiosoite uudelleen."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Tämä tunniste ei kuulu sinulle."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Väärä salasana"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Tunnusta ei voi luoda."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Tunnus luotu."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Tunnussalaisuutta ei löytynyt"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Tunnusta ei voi uudelleen nimetä."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Valitettavasti et voi poistaa viimeistä aktiivista tunnusta."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Tunnusta ei voi poistaa käytöstä."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Tunnusta ei voi ottaa käyttöön. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Valitettavasti et voi poistaa viimestä aktiivista tunnusta."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Tunnusta ei voi poistaa."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Tunnusta ei voi luoda."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Tunnusta ei voi uudelleen nimetä."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Väärä salasana"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Tunnusta ei voi poistaa."
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Salasanan nollaus %(username)s:lle"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Sopimusta ei saatu allekirjoitettua \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Allekirjoitit \"%(name)s\" sopimuksen."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Tunnusta ei voi poistaa."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Tunnus luotu."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Tämä ei näytä kelvolliselta lempinimeltä."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Tämä ei näytä kelvolliselta palvelinnimeltä."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Etunimi"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Etunimi ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Sukunimi"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Sukunimi ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Maa-asetusto"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Kielialue ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Kielialueen on oltava kelvollinen kielialueen lyhyt koodi"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Chattien nimimerkit"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Aikavyöhyke"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Aikavyöhyke ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Aikavyöhykkeen on oltava kelvollinen aikavyöhyke"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub-käyttäjänimi"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab-käyttäjänimi"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Kelvollinen verkko-osoite vaaditaan"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Kirjaudu ulos"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Yksityinen"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Piilota tiedot muilta käyttäjiltä, katso lisätietoja "
 "tietosuojakäytäntöosiosta."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronominit"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Sähköpostiosoite"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "Sähköposti ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "Sähköpostin on oltava kelvollinen"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla -sähköposti"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH-avaimet"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG-avaimet"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Tokenin nimi"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Lisää valinnainen nimi, joka auttaa sinua tunnistamaan tämän tunnuksen"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Syötä nykyinen salasanasi"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Sinun on annettava salasana"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Kertakäyttöinen salasana"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Kirjoita kertakäyttöinen salasanasi"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Luo kertakäyttöinen tunnus"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Tunnussalaisuutta ei löytynyt"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Sinun on annettava vahvistuskoodi"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Koodi on väärä, yritä uudelleen."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Tokeni ei saa olla tyhjä"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Luo kertakäyttöinen tunnus"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Luo kertakäyttöinen tunnus"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Syötä nykyinen salasanasi"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Salasana ei saa olla tyhjä"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Hyväksyntä ei saa olla tyhjä"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Uuden jäsenen käyttäjätunnus ei saa olla tyhjä"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Käyttäjänimi"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Käyttäjänimi ei saa olla tyhjä"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Vahvista sähköpostiosoitteesi"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Sinun on annettava käyttäjänimi"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Salasana"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Kirjaudu sisään"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Uusi salasana"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Salasana ei saa olla tyhjä"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Salasanojen täytyy täsmätä"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Vahvista uusi salasana"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Nykyinen salasana"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Nykyinen salasana ei saa olla tyhjä"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Käyttäjänimi"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Käyttäjänimi ei voi olla tyhjä"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Anna käyttäjätunnuksesi palauttaaksesi salasanasi"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Rekisteröi"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Valitse vahva salasana"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Vahvista salasana"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Aktivoi"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Ensimmäinen OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Sinun on annettava ensimmäinen koodi"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Toinen OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Sinun on annettava toiinen koodi"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Token-tunniste"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Sitä sivua ei löytynyt."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Unohtuiko salasana?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Unohtuiko salasana tai kertakäyttöinen salasana?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Synkronointitunnus"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Edellinen"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "nykyinen"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Seuraava"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Ryhmät"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Käyttäjät"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Salasanan palautus"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Unohditko salasanasi?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
-msgstr ""
-"Syötä käyttäjänimesi ja lähetetään osoitteeseesi sähköposti lisäohjeineen."
+msgstr "Syötä käyttäjänimesi ja lähetetään osoitteeseesi sähköposti lisäohjeineen."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Lähetä"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Nollaa salasana"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Salasanan nollaus %(username)s:lle"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s ryhmä"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Liity tähän ryhmään ottamalla yhteyttä ryhmän sponsoriin."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsorit"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "ei sponsoreita"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Jäsenet"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "lisää käyttäjä..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Ei vielä jäseniä."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Ryhmäluettelo"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s jäsentä"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Ei ryhmiä."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Sisäänkirjautuminen"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Salasanan nollaus on vanhentunut"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Vanhentunut salasanan nollaus %(username)s:lle"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Vaihda salasana"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Rekisteröidään käyttäjiä"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nimi:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Sähköposti:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Rekisteröity:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Tila:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Hyväksy"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Poista"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Onnittelut %(name)s, tilisi on luotu!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Tiliäsi tarkistetaan"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Tilisi on merkitty häiriköksi."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Synkronointi-OTP-tunnus"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Synkronoi OTP-tunnus"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Synkronointi"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Peru"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Tallenna"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG-avaimen tunniste"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Julkinen SSH-avain"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Asetukset %(username)s:lle"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Koodi on väärä, yritä uudelleen."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Luo kertakäyttöinen tunnus"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Sinulla ei ole OTP-tunnuksia"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Odottaa"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Salasana"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Skannaa uusi tunnuksesi"
 
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
 msgstr ""
 "Uusi tunnuksesi on valmis. Napsauta alla olevaa painiketta paljastaa QR-"
 "koodi ja skannata se."
 
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Paljasta"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr ""
-"tai kopioi ja liitä seuraava tunnuksen URL, jos et voi skannata QR-koodia:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr "tai kopioi ja liitä seuraava tunnuksen URL, jos et voi skannata QR-koodia:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Lisää OTP-tunnus"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "OTP-tunnukset"
 
-msgid "(no name)"
-msgstr ""
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Nimeä uudelleen"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Poista käytöstä"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Ota käyttöön"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Sinulla ei ole OTP-tunnuksia"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Aktivoi"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Nykyinen salasana"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Ei roskapostia"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH-avaimet"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Sinulla ei ole OTP-tunnuksia"
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Profiilikuva"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Asetukset %(username)s:lle"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profiili"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Sähköpostit"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG-avaimet"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "Kertakäyttöinen salasana"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profiili %(username)s:lle"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Muokkaa profiilia"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Ensimmäinen OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Pikakeskustelu"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Sisäänkirjautuminen"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsori"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "jäsen"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Käyttäjää %(username)s ei ole olemassa"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Tervetuloa %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 "Aktivoidaksesi tilisi käyttäjänimellä %(username)s, napsauta alla olevaa "
 "linkkiä:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Jos et luonut tiliä käyttäjätunnukselle %(username)s, voit jättää tämän "
 "sähköpostin huomioimatta."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "AlmaLinux-tiimi"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
@@ -956,40 +1663,69 @@ msgstr ""
 "Napsauta alla olevaa linkkiä vaihtaaksesi salasanasi. Jos et pyytänyt "
 "salasanan vaihtoa, jätä tämä sähköposti huomiotta."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "haku.."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Asetukset"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Ohje"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Kirjaudu ulos"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Voimanlähteenä %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux-tilit"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 "AlmaLinux-tilit tarjoavat mahdollisuuden luoda ja hallita tiliäsi "
 "AlmaLinuxin koko infrastruktuurissa."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
-msgstr ""
-"Vahvista sähköpostiosoite %(address)s napsauttamalla alla olevaa linkkiä:"
+msgstr "Vahvista sähköpostiosoite %(address)s napsauttamalla alla olevaa linkkiä:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
@@ -998,123 +1734,180 @@ msgstr ""
 "Jos et asettanut sähköpostiosoitetta %(address)s tilillesi %(username)s, "
 "voit jättää tämän sähköpostin huomioimatta."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin-joukkue"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Tervetuloa nogginiin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Tämä on FreeIPA:n avoimen lähdekoodin yhteisöportaali. Sen avulla voit tehdä "
-"esimerkiksi tilin luomisen, salasanan vaihtamisen, ryhmäjäsenyyden hallinnan "
-"ja paljon muuta."
+"Tämä on FreeIPA:n avoimen lähdekoodin yhteisöportaali. Sen avulla voit "
+"tehdä esimerkiksi tilin luomisen, salasanan vaihtamisen, ryhmäjäsenyyden "
+"hallinnan ja paljon muuta."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Jos linkki on vanhentunut, voit pyytää uuden täältä: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora-tilijärjestelmä"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora-tilit"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 "Fedora-tilien avulla voit luoda ja hallita tiliä Fedora-työkaluille ja "
 "infrastruktuurille."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Muokkaa ryhmää"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Luo PDR-pyyntö tilisi poistamiseksi käytöstä"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Tilin poistamispyyntö"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Kadotitko viimeisimmän OTP-tunnuksesi?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Jos olet kadottanut viimeisimmän OTP-tunnuksesi, sinun on lähetettävä "
 "sähköposti%(admin_email)s:een. Ole hyvä ja allekirjoita tämä sähköposti "
-"käyttämällä tilisi GPG-avainta, jos mahdollista, jotta järjestelmänvalvoja "
-"voi vahvistaa henkilöllisyytesi."
+"käyttämällä tilisi GPG-avainta, jos mahdollista, jotta "
+"järjestelmänvalvoja voi vahvistaa henkilöllisyytesi."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Ryhmää %(groupname)s ei löytynyt."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Kumoa"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
@@ -1141,10 +1934,12 @@ msgstr ""
 #~ msgstr "Rekisteröinti"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Tätä ei enää näytetä sinulle enää, älä sulje tätä ikkunaa, ennen kuin "
+#~ "Tätä ei enää näytetä sinulle enää, "
+#~ "älä sulje tätä ikkunaa, ennen kuin "
 #~ "tunnuksesi on tallennettu."
 
 #~ msgid "Password or Password + One-Time-Password"
@@ -1160,9 +1955,12 @@ msgstr ""
 #~ msgstr "RHBZ-Sähköpostil"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "jätä Fedora Infra -lippu muuttaaksesi tämän ryhmän tietoja tai sponsoreita"
+#~ "jätä Fedora Infra -lippu muuttaaksesi "
+#~ "tämän ryhmän tietoja tai sponsoreita"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Yksityiskohtien muutoksen pyyntö"
@@ -1175,3 +1973,4 @@ msgstr ""
 
 #~ msgid "Website"
 #~ msgstr "Verkkosivut"
+

--- a/noggin/translations/fr_FR/LC_MESSAGES/messages.po
+++ b/noggin/translations/fr_FR/LC_MESSAGES/messages.po
@@ -18,97 +18,175 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-12-10 11:23+0000\n"
 "Last-Translator: Aurélien Bompard <aurelien@bompard.org>\n"
-"Language-Team: French <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/fr/>\n"
 "Language: fr_FR\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: French <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/fr/>\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 5.14.3\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Le mot de passe a expiré. Veuillez le réinitialiser."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Impossible de se connecter au serveur IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Bienvenue, %(username)s !"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Le jeton a été synchronisé avec succès"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Aucun serveur IPA n'est disponible"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Impossible de se connecter au serveur IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Impossible de modifier le mot de passe, veuillez réessayer."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Code de vérification"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Le compte %(username)s n'a pas été trouvé sur le système."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Impossible d’ajouter l’utilisateur %(username)s : %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Vous avez réussi ! %(username)s a été ajouté à %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Vous avez réussi ! %(username)s a été retiré de %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Vous avez réussi ! %(username)s a été retiré de %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "L’ancien mot de passe ou nom d’utilisateur n’est pas correct"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Impossible de modifier le mot de passe."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Votre mot de passe a été modifié"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Vous avez déjà demandé une réinitialisation du mot de passe, vous devez "
-"attendre %(wait_min)s minute(s) et %(wait_sec)s seconde(s) avant de pouvoir "
-"faire une nouvelle demande."
+"attendre %(wait_min)s minute(s) et %(wait_sec)s seconde(s) avant de "
+"pouvoir faire une nouvelle demande."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "L’utilisateur %(username)s n’existe pas"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
-msgstr ""
-"Nous n’avons pas pu vous envoyer de courriel, veuillez réessayer plus tard"
+msgstr "Nous n’avons pas pu vous envoyer de courriel, veuillez réessayer plus tard"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Votre adresse email est rejetée par le serveur smtp"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Un courrier électronique a été envoyé à votre adresse avec des instructions "
-"pour réinitialiser votre mot de passe"
+"Un courrier électronique a été envoyé à votre adresse avec des "
+"instructions pour réinitialiser votre mot de passe"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Le jeton n’est pas valide, veuillez en demander un nouveau."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Le jeton a expiré, veuillez en demander un nouveau."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
@@ -116,93 +194,112 @@ msgstr ""
 "Votre mot de passe a été modifié depuis que vous avez demandé ce jeton, "
 "veuillez en demander un nouveau."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"Votre mot de passe a été modifié, mais il n’est pas conforme à la politique "
-"(%(policy_error)s) et a donc été défini comme expiré. Il vous sera demandé "
-"de le changer après vous être connecté."
+"Votre mot de passe a été modifié, mais il n’est pas conforme à la "
+"politique (%(policy_error)s) et a donc été défini comme expiré. Il vous "
+"sera demandé de le changer après vous être connecté."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Valeur incorrecte."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Impossible de modifier le mot de passe, veuillez réessayer."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Votre mot de passe a été modifié."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Vérifiez votre adresse email"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 "Nous n’avons pas pu vous envoyer le courriel de validationl, veuillez "
 "réessayer plus tard"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Le nom d'utilisateur '%(username)s' ou l'adresse email '%(email)s' sont déjà "
-"pris."
+"Le nom d'utilisateur '%(username)s' ou l'adresse email '%(email)s' sont "
+"déjà pris."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
-"Une erreur s'est produite lors de la création du compte, veuillez réessayer."
+"Une erreur s'est produite lors de la création du compte, veuillez "
+"réessayer."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "L'enregistrement semble avoir échoué, veuillez réessayer."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 "L'email de validation de l'adresse a été envoyé de nouveau. Assurez-vous "
 "qu'il ne se trouve pas dans votre dossier spam"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 "Pas de code-clé, veuillez vérifier votre lien de vérification reçu par "
 "courriel."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Le jeton n’est pas valide, veuillez vous enregistrer de nouveau."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Le jeton n'est plus utilisable, veuillez vous enregistrer de nouveau."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
-"Cet utilisateur n'a pas pu être trouvé, veuillez vous enregistrer de nouveau."
+"Cet utilisateur n'a pas pu être trouvé, veuillez vous enregistrer de "
+"nouveau."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Le nom d'utilisateur et l'adresse courriel ne correspondent pas au jeton que "
-"vous avez utilisé, veuillez vous enregistrer de nouveau."
+"Le nom d'utilisateur et l'adresse courriel ne correspondent pas au jeton "
+"que vous avez utilisé, veuillez vous enregistrer de nouveau."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 "Une erreur s'est produite lors de la création de votre compte, veuillez "
 "réessayer plus tard."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Votre compte à été créé, mais le mot de passe choisi n’est pas conforme à la "
-"politique (%(policy_error)s) et a donc été défini comme expiré. Il vous sera "
-"demandé de le changer après vous être connecté."
+"Votre compte à été créé, mais le mot de passe choisi n’est pas conforme à"
+" la politique (%(policy_error)s) et a donc été défini comme expiré. Il "
+"vous sera demandé de le changer après vous être connecté."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
@@ -212,814 +309,1429 @@ msgstr ""
 "définition de votre mot de passe (%(message)s). Vous devrez peut-être le "
 "modifier après vous être connecté."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Félicitations, votre compte a été créé ! Bienvenue, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
-msgstr ""
-"Félicitations, votre compte a été créé ! Connectez-vous pour continuer."
+msgstr "Félicitations, votre compte a été créé ! Connectez-vous pour continuer."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Tous"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Inconnu"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Pas de Spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "En attente"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "L'enregistrement est fermé pour l'instant."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"L'addresse courriel %(mail)s doit être vérifiée. Veuillez consulter votre "
-"boîte aux lettres et cliquer sur le lien pour continuer. Si vous n'arrivez "
-"pas à trouver le courriel pendant les prochaines minutes, vérifiez votre "
-"dossier spam."
+"L'addresse courriel %(mail)s doit être vérifiée. Veuillez consulter votre"
+" boîte aux lettres et cliquer sur le lien pour continuer. Si vous "
+"n'arrivez pas à trouver le courriel pendant les prochaines minutes, "
+"vérifiez votre dossier spam."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Pas de modifications."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
-"Le jeton n’est pas valide, veuillez choisir de nouveau l'addresse courriel."
+"Le jeton n’est pas valide, veuillez choisir de nouveau l'addresse "
+"courriel."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
-"Le jeton n'est plus valide, veuillez choisir l'adresse courriel de nouveau."
+"Le jeton n'est plus valide, veuillez choisir l'adresse courriel de "
+"nouveau."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Ce jeton ne vous appartient pas."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Mot de passe incorrect"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Impossible de créer le jeton."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Le jeton a été créé."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Impossible de trouver le secret du jeton"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Impossible de renommer le jeton."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Désolé, vous ne pouvez pas désactiver votre dernier jeton actif."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Impossible de désactiver le jeton."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Impossible d'activer le jeton. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Désolé, vous ne pouvez pas désactiver votre dernier jeton actif."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Impossible de supprimer le jeton."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Impossible de créer le jeton."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Impossible de renommer le jeton."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Mot de passe incorrect"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Vérifier et activer le jeton OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Réinitialisation du mot de passe pour %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Impossible de signer le contrat \"%(name)s\" : %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Vous avez signé le contrat \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Impossible de supprimer le jeton."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Le jeton a été créé."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Ceci n'a pas l'air d'un pseudonyme valable."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Ceci n'a pas l'air d'un nom de serveur valable."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Prénom"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Le prénom ne doit pas être vide"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Nom"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Le nom de famille ne doit pas être vide"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Paramètre linguistique"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Le paramètre linguistique ne doit pas être vide"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Le paramètre linguistique doit être un code court et valide"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Pseudo de Chat"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Le fuseau horaire ne doit pas être vide"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Le fuseau horaire doit être valide"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nom d'utilisateur GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nom d'utilisateur GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "URL valide requise"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "Adresse de blog"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "Adresse RSS"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privé"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Masquer vos informations aux autres utilisateurs. Pour plus de détails, "
 "consultez la Politique de confidentialité."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronoms"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Adresse de courriel"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "L'adresse de courriel ne doit pas être vide"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "L'adresse électronique doit être valide"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "E-mail de Red Hat Bugzilla"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Clés SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Clés GPG"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nom du jeton"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Ajoutez un nom facultatif pour vous aider à reconnaître ce jeton"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Saisissez votre mot de passe actuel"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Vous devez fournir un mot de passe"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
-"veuillez vous authentifier de nouveau pour que nous sachions qu'il s'agit de "
-"vous"
+"veuillez vous authentifier de nouveau pour que nous sachions qu'il s'agit"
+" de vous"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Mot de passe à usage unique"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Entrez votre mot de passe à usage unique"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Générer un jeton OTP"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Impossible de trouver le secret du jeton"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Code de vérification"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Vous devez fournir un code de vérification"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Vérifier et activer le jeton OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Le code est faux, veuillez réessayer."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Le jeton ne doit pas être vide"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Générer un jeton OTP"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Générer un jeton OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Saisissez votre mot de passe actuel"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Le mot de passe ne doit pas être vide"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Le contrat ne doit pas être vide"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Le nom d'utilisateur du nouveau membre ne doit pas être vide"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nom d’utilisateur"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Le nom d’utilisateur ne doit pas être vide"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Nom d'utilisateur (ou adresse email)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Vous devez fournir un nom d'utilisateur"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Mot de passe"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Connexion"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nouveau mot de passe"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Le mot de passe ne doit pas être vide"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Les mots de passe doivent correspondre"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Confirmer le nouveau mot de passe"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
-"Mot de passe à usage unique (si votre compte a activé l'authentification à "
-"deux facteurs)"
+"Mot de passe à usage unique (si votre compte a activé l'authentification "
+"à deux facteurs)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Mot de passe actuel"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Le mot de passe actuel ne doit pas être vide"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Nom d’utilisateur ou email"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Le nom d’utilisateur ne doit pas être vide"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
-"Entrez votre nom d'utilisateur ou votre email pour réinitialiser votre mot "
-"de passe"
+"Entrez votre nom d'utilisateur ou votre email pour réinitialiser votre "
+"mot de passe"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Seuls les caractères suivants sont autorisés : \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "J'ai plus de 16 ans"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Vous devez avoir au moins 16 ans pour pouvoir créer un compte"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "S'inscrire"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Envoyer le courriel de nouveau"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Choisissez un mot de passe fort"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Confirmer le mot de passe"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Activer"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Premier OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Vous devez fournir un premier code"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Deuxième OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Vous devez fournir un deuxième code"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID du jeton"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Les adresses courriel de ce domaine ne sont pas autorisées"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "La casse mixte n'est pas autorisée, essayez la casse basse."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Le champ ne doit pas correspondre à \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Cette page n'a pas été trouvée."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Voir le contrat"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Signer le contrat d'utilisateur"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Mot de passe oublié ?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Mot de passe oublié ?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Synchroniser un jeton"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Précédent"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "actuel"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Prochain"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Groupes"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Utilisateurs"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Récupération de mot de passe"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Avez-vous oublié votre mot de passe ?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Saisissez votre nom d'utilisateur ou votre adresse e-mail et un e-mail vous "
-"sera envoyé avec des instructions supplémentaires."
+"Saisissez votre nom d'utilisateur ou votre adresse e-mail et un e-mail "
+"vous sera envoyé avec des instructions supplémentaires."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Envoyer"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Réinitialisation du mot de passe pour %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Groupe %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Quitter le groupe"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Vous êtes un sponsor de ce groupe, mais pas un membre. Ajoutez-vous si vous "
-"voulez être membre."
+"Vous êtes un sponsor de ce groupe, mais pas un membre. Ajoutez-vous si "
+"vous voulez être membre."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Pour rejoindre ce groupe, contactez un parrain de groupe."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsors"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "Pas de sponsors"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Membres"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "Ajouter un utilisateur..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Pas encore de membres."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Liste des groupes"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s membres"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Pas de groupes."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "S’identifier"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Erreur IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 "Il y a eu un problème avec l'infrastructure IPA, veuillez réessayer plus "
 "tard."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 "Vous pouvez aussi vous <a href=\"%(url)s\">déconnecter</a> et vous "
 "reconnecter si le problème persiste."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Réinitialisation du mot de passe expiré"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Réinitialisation du mot de passe expiré pour %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Modifier le mot de passe"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Enregistrement d'utilisateurs"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nom :"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Courriel :"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Inscrit :"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Statut :"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "En attente du contrôle pour spam"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Pas marqué en tant que spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Marqué comme spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Statut de spam inconnu"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Accepter"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Marquer comme spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Supprimer"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Cliquer sur Accepter enverra le courriel de validation à cet utilisateur. "
-"Les autres boutons n'enverront rien."
+"Cliquer sur Accepter enverra le courriel de validation à cet utilisateur."
+" Les autres boutons n'enverront rien."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
-msgstr ""
-"Pas d'utilisateur en cours d'enregistrement dans cet état pour l'instant."
+msgstr "Pas d'utilisateur en cours d'enregistrement dans cet état pour l'instant."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Pas d'utilisateurs en cours d'enregistrement pour l'instant."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Activer votre compte"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Création d'un compte, étape 3 sur 3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 "Bonjour %(name)s. Pour activer votre compte, veuillez choisir un mot de "
 "passe."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Signer les contrats d'utilisateur"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "Signature optionnelle des accords"
 
+# | msgid ""
+# | "Hello %(name)s. Please sign the agreement below if you agree with it."
+# | msgid_plural ""
+# | "Hello %(name)s. Please sign the agreements below if you agree with them."
+#: noggin/templates/registration-agreements.html:16
 #, fuzzy, python-format
-#| msgid ""
-#| "Hello %(name)s. Please sign the agreement below if you agree with it."
-#| msgid_plural ""
-#| "Hello %(name)s. Please sign the agreements below if you agree with them."
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 "Bonjour %(name)s. Veuillez signer le contrat utilisateur ci-dessous s'il "
 "vous convient."
 msgstr[1] ""
-"Bonjour %(name)s. Veuillez signer les contrats utilisateur ci-dessous s'ils "
-"vous conviennent."
+"Bonjour %(name)s. Veuillez signer les contrats utilisateur ci-dessous "
+"s'ils vous conviennent."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Continuer"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Sauter"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Validez votre adresse courriel"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Création d'un compte, étape 2 sur 3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Félicitations %(name)s, votre compte a été créé !"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"Avant de pouvoir vous connecter, votre adresse courriel : %(mail)s doit être "
-"validée. Veuillez consulter votre boîte aux lettres et cliquez sur le lien "
-"pour continuer."
+"Avant de pouvoir vous connecter, votre adresse courriel : %(mail)s doit "
+"être validée. Veuillez consulter votre boîte aux lettres et cliquez sur "
+"le lien pour continuer."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 "Si vous n'arrivez pas à trouver le courriel pendant les minutes à venir, "
-"consultez votre dossier spam. Si il n'est pas là, vous pouvez demander un "
-"nouveau courriel de validation en cliquant sur le bouton ci-dessous."
+"consultez votre dossier spam. Si il n'est pas là, vous pouvez demander un"
+" nouveau courriel de validation en cliquant sur le bouton ci-dessous."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Vérification spam en cours"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Votre compte est en train d'être vérifié"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Avant de pouvoir vous connecter, votre compte doit être contrôlé s'il est "
-"susceptible au spam. Ceci ne devrait prendre que quelques secondes, attendez "
-"un instant..."
+"Avant de pouvoir vous connecter, votre compte doit être contrôlé s'il est"
+" susceptible au spam. Ceci ne devrait prendre que quelques secondes, "
+"attendez un instant..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Votre compte requiert l'approuvement d'un administrateur"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Votre compte doit être approuvé par un administrateur."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Vous recevrez un courriel quand la décision sera prise."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Merci pour votre patience."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Votre compte est bloqué"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Votre compte a été signalé comme spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Quelque chose s’est mal passé"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 "Statut de spam pas pris en charge : %s, veuillez contacter les "
 "administrateurs"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Synchroniser le jeton OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Synchroniser un jeton OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Synchronisation"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Validez votre courriel"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
-"Bonjour %(user_name)s. Voulez-vous changer votre %(attr_name)s sur %(mail)s?"
+"Bonjour %(user_name)s. Voulez-vous changer votre %(attr_name)s sur "
+"%(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Annuler"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Le faire"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Enregistrer"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID de clé GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Clé publique SSH"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Paramètres pour %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Le code est faux, veuillez réessayer."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Générer un jeton OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(pas de nom)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Vous n'avez pas de jetons OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "En attente"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Mot de passe"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Scannez votre nouveau jeton"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Votre nouveau jeton est prêt. Cliquez sur le bouton ci-dessous pour révéler "
-"le code QR et le scanner."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Votre nouveau jeton est prêt. Cliquez sur le bouton ci-dessous pour "
+"révéler le code QR et le scanner."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Révéler"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"ou copiez et collez l'URL de jeton suivante si vous ne pouvez pas scanner le "
-"code QR :"
+"ou copiez et collez l'URL de jeton suivante si vous ne pouvez pas scanner"
+" le code QR :"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"Après avoir utilisé le jeton dans votre application, vérifiez-le en générant "
-"votre premier code et l'entrant ici :"
+"Après avoir utilisé le jeton dans votre application, vérifiez-le en "
+"générant votre premier code et l'entrant ici :"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Ajouter un jeton OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
 "La création de votre premier jeton OTP permet l'authentification à deux "
 "facteurs par OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 "Une fois activée, l'authentification à deux facteurs ne peut pas être "
 "désactivée."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Jetons OTP"
 
-msgid "(no name)"
-msgstr "(pas de nom)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Renommer"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Désactiver"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Activer"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Vous n'avez pas de jetons OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 "Ajoutez un jeton OTP pour activer l'authentification à deux facteurs sur "
 "votre compte."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Activer"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Mot de passe actuel"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Pas de Spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Clés SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Vous n'avez pas de jetons OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Ajoutez un jeton OTP pour activer l'authentification à deux facteurs sur "
+"votre compte."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Changer l'avatar"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "Le format est soit <code>nomdutilisateur</code> soit "
-"<code>nomdutilisateur:serveur.nom</code> si vous n'utilisez pas les serveurs "
-"par défaut :"
+"<code>nomdutilisateur:serveur.nom</code> si vous n'utilisez pas les "
+"serveurs par défaut :"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "Pour %(title)s : <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Paramètres pour %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Courriel"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Clés SSH et GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Contrats"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil pour %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Modifier le profil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Premier OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Créé le"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Heure actuelle"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blog"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s groupe(s), %(agreementcount)s contrat(s)"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "signé"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "parrain"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "Membre"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "L’utilisateur %(username)s n’existe pas"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Bienvenue %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"Pour activer votre compte avec le nom %(username)s, cliquez sur le lien ci-"
-"dessous :"
+"Pour activer votre compte avec le nom %(username)s, cliquez sur le lien "
+"ci-dessous :"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Si vous n'avez pas créé un compte pour le nom d'utilisateur %(username)s, "
-"vous pouvez ignorer ce courriel."
+"Si vous n'avez pas créé un compte pour le nom d'utilisateur %(username)s,"
+" vous pouvez ignorer ce courriel."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "L'équipe AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Bonjour,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
@@ -1027,185 +1739,273 @@ msgstr ""
 "Cliquez sur le lien ci-dessous pour réinitialiser votre mot de passe. Si "
 "vous n'avez pas demandé cela, veuillez ignorer ce courriel."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Service de compte AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "Rechercher..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Paramètres"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Aide"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Déconnexion"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Fonctionne avec %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Comptes AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Les comptes AlmaLinux vous permettent de créer et de gérer votre compte sur "
-"toute l'infrastructure AlmaLinux."
+"Les comptes AlmaLinux vous permettent de créer et de gérer votre compte "
+"sur toute l'infrastructure AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 "Pour valider votre adresse courriel %(address)s, cliquez sur le lien ci-"
 "dessous :"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Si vous n'avez pas choisi l'adresse courriel %(address)s sur votre compte "
-"%(username)s, vous pouvez ignorer ce courriel."
+"Si vous n'avez pas choisi l'adresse courriel %(address)s sur votre compte"
+" %(username)s, vous pouvez ignorer ce courriel."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "L'équipe Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Bienvenue sur noggin !"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Ceci est le portail open source, communautaire en self-service pour FreeIPA. "
-"Il vous permet de faire des choses comme créer un compte, changer votre mot "
-"de passe, gérer l'appartenance à un groupe, etc."
+"Ceci est le portail open source, communautaire en self-service pour "
+"FreeIPA. Il vous permet de faire des choses comme créer un compte, "
+"changer votre mot de passe, gérer l'appartenance à un groupe, etc."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 "Des configurations supplémentaires sont requises quand vous utilisez des "
 "tickets Kerberos et que l'OTP est activé"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Lisez la <a href='https://docs.fedoraproject.org/fr-FR/fedora-accounts/user/"
-"#pkinit'>documentation</a> pour plus de détails à propos de la configuration "
-"de votre système"
+"Lisez la <a href='https://docs.fedoraproject.org/fr-FR/fedora-"
+"accounts/user/#pkinit'>documentation</a> pour plus de détails à propos de"
+" la configuration de votre système"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
-msgstr ""
-"Vous pouvez aussi utiliser votre compte Fedora pour vous connecter ici."
+msgstr "Vous pouvez aussi utiliser votre compte Fedora pour vous connecter ici."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
-"Ce lien restera valide pendant %(ttl)s minutes (jusqu'à %(valid_until)s UTC)."
+"Ce lien restera valide pendant %(ttl)s minutes (jusqu'à %(valid_until)s "
+"UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Si le lien a expiré, vous pouvez en demander un nouveau ici : "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Compte infrastructure Fedora (FAS)"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Comptes Fedora"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Personnes Fedora"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Comptes Fedora vous permet de créer et de gérer un compte pour les outils et "
-"l'infrastructure Fedora."
+"Comptes Fedora vous permet de créer et de gérer un compte pour les outils"
+" et l'infrastructure Fedora."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Éditer le groupe"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 "Pour changer les détails du groupe ou ajouter des sponsors, soumettez un "
 "ticket avec"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Créez une demande PDR pour désactiver votre compte"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Demander la suppression du compte"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Avez-vous perdu votre dernier jeton OTP ?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"Si vous avez perdu votre dernier jeton OTP, vous devez envoyer un e-mail à "
-"%(admin_email)s. Si possible, veuillez signer cet e-mail en utilisant la clé "
-"GPG associée à votre compte, afin que l'administrateur puisse vérifier votre "
-"identité."
+"Si vous avez perdu votre dernier jeton OTP, vous devez envoyer un e-mail "
+"à %(admin_email)s. Si possible, veuillez signer cet e-mail en utilisant "
+"la clé GPG associée à votre compte, afin que l'administrateur puisse "
+"vérifier votre identité."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Si vous aviez plusieurs jetons et en avez perdu un, vous pouvez en utiliser "
-"un autre pour vous connecter et effacer le jeton perdu de votre compte."
+"Si vous aviez plusieurs jetons et en avez perdu un, vous pouvez en "
+"utiliser un autre pour vous connecter et effacer le jeton perdu de votre "
+"compte."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
-"Si vous n'avez pas utilisé de jeton OTP, vous n'en avez pas et ceci ne vous "
-"concerne pas."
+"Si vous n'avez pas utilisé de jeton OTP, vous n'en avez pas et ceci ne "
+"vous concerne pas."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 "Afin que les administrateurs sachent que vous n'êtes pas un spammeur, "
-"veuillez envoyer un courriel à %(email_link)s et expliquez votre situation."
+"veuillez envoyer un courriel à %(email_link)s et expliquez votre "
+"situation."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"En utilisant un compte Fedora, vous acceptez de suivre le <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-conduct/'>Code de conduite "
-"Fedora</a>."
+"En utilisant un compte Fedora, vous acceptez de suivre le <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-conduct/'>Code"
+" de conduite Fedora</a>."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
-msgstr ""
-"Vous pouvez aussi utiliser votre compte CentOS pour vous connecter ici."
+msgstr "Vous pouvez aussi utiliser votre compte CentOS pour vous connecter ici."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Groupe %(groupname)s introuvable."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "Aucun utilisateur trouvé avec l'email %(username_or_email)s"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Défaire"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s sur %(server)s"
@@ -1226,8 +2026,7 @@ msgstr "%(protocol)s sur %(server)s"
 #~ msgstr "Saisissez votre jeton OTP si vous en avez enregistré un"
 
 #~ msgid "Just the password, don't add the OTP token if you have one"
-#~ msgstr ""
-#~ "Juste le mot de passe, n'ajoutez pas le jeton OTP si vous en avez un"
+#~ msgstr "Juste le mot de passe, n'ajoutez pas le jeton OTP si vous en avez un"
 
 #~ msgid "Forgotten password or lost OTP token?"
 #~ msgstr "Mot de passe oublié ou jeton OTP perdu ?"
@@ -1236,11 +2035,14 @@ msgstr "%(protocol)s sur %(server)s"
 #~ msgstr "Enregistrement"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Cela ne vous sera plus jamais montré à nouveau, ne fermez pas cette "
-#~ "fenêtre tant que votre jeton n'est pas enregistré."
+#~ "Cela ne vous sera plus jamais "
+#~ "montré à nouveau, ne fermez pas "
+#~ "cette fenêtre tant que votre jeton "
+#~ "n'est pas enregistré."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Mot de passe ou Mot de passe + OTP"
@@ -1255,10 +2057,13 @@ msgstr "%(protocol)s sur %(server)s"
 #~ msgstr "E-mail RHBZ"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "Soumettez un ticket Fedora infrastructure pour modifier les détails ou "
-#~ "les sponsors de ce groupe"
+#~ "Soumettez un ticket Fedora infrastructure "
+#~ "pour modifier les détails ou les "
+#~ "sponsors de ce groupe"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Demande de modification de détails"
@@ -1271,3 +2076,4 @@ msgstr "%(protocol)s sur %(server)s"
 
 #~ msgid "Website"
 #~ msgstr "Site internet"
+

--- a/noggin/translations/gu/LC_MESSAGES/messages.po
+++ b/noggin/translations/gu/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Gujarati translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: gu\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,11 +1073,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1178,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1190,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1202,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1311,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1480,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1493,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1802,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1832,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/he/LC_MESSAGES/messages.po
+++ b/noggin/translations/he/LC_MESSAGES/messages.po
@@ -7,1085 +7,1866 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2021-05-05 11:02+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
-"Language-Team: Hebrew <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/he/>\n"
 "Language: he\n"
+"Language-Team: Hebrew <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/he/>\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 "
+"&& n % 10 == 0) ? 2 : 3));\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
-"n % 10 == 0) ? 2 : 3));\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "תוקף הססמה פג. נא לאפס אותה."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "לא ניתן להיכנס לשרת ה־IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "ברוך בואך, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "האסימון סונכרן בהצלחה"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "לא ניתן להיכנס לשרת ה־IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "תוקף הססמה פג. נא לאפס אותה."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "המשתמש %(username)s לא נמצא במערכת."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "לא ניתן להוסיף את המשתמש %(username)s:‏ %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "בוצע! %(username)s התווסף אל %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "בוצע! %(username)s הוסר מתוך %(groupname)s."
 
 # | msgid "You got it! %(username)s has been removed from %(groupname)s."
+#: noggin/controller/group.py:194
 #, fuzzy, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "בוצע! %(username)s הוסר מתוך %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "הססמה הישנה או שם המשתמשים שגויים"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "לא ניתן להחליף ססמה."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "הססמה שלך הוחלפה"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"כבר ביקשת לאפס את הססמה, עליך להמתין %(wait_min)s דקות ו־%(wait_sec)s שניות "
-"לפני הגשת בקשה נוספת."
+"כבר ביקשת לאפס את הססמה, עליך להמתין %(wait_min)s דקות ו־%(wait_sec)s "
+"שניות לפני הגשת בקשה נוספת."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "המשתמש %(username)s לא קיים"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "לא הצלחנו לשלוח לך הודעה בדוא״ל, נא לנסות שוב מאוחר יותר"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr "נשלחה הודעת דוא״ל לכתובת שלך עם הנחיות כיצד לאפס את הססמה שלך"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "תוקף האסימון פג, נא לבקש אחד חדש."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr "הססמה שלך הוחלפה מאז שביקשת אסימון, נא לבקש אחת חדשה."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 #, fuzzy
 msgid "We could not send you the address validation email, please retry later"
 msgstr "לא הצלחנו לשלוח לך הודעה בדוא״ל, נא לנסות שוב מאוחר יותר"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 #, fuzzy
 msgid "The token is invalid, please register again."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 #, fuzzy
 msgid "This token is no longer valid, please register again."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 #, fuzzy
 msgid "The token is invalid, please set the email again."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 #, fuzzy
 msgid "This token is no longer valid, please set the email again."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "לא ניתן להיכנס לשרת ה־IPA."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 #, fuzzy
 msgid "Could not find the token secret"
 msgstr "לא ניתן להיכנס לשרת ה־IPA."
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/form/edit_user.py:230
 #, fuzzy
 msgid "The code is wrong, please try again."
 msgstr "האסימון שגוי, נא לבקש אחד חדש."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 #, fuzzy
 msgid "Your account is being checked"
 msgstr "הססמה שלך הוחלפה"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:32
 #, fuzzy
 msgid "Your account has been flagged as spam."
 msgstr "הססמה שלך הוחלפה"
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
-msgstr ""
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "ברוך בואך, %(username)s!"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+# | msgid "The token is invalid, please request a new one."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "האסימון שגוי, נא לבקש אחד חדש."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "הססמה שלך הוחלפה"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "לא ניתן להחליף ססמה."
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "המשתמש %(username)s לא קיים"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 #, fuzzy
 msgid "If the link has expired, you can request a new one here: "
 msgstr "תוקף האסימון פג, נא לבקש אחד חדש."
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/hi/LC_MESSAGES/messages.po
+++ b/noggin/translations/hi/LC_MESSAGES/messages.po
@@ -7,1151 +7,1966 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2024-07-08 05:36+0000\n"
 "Last-Translator: Scrambled 777 <weblate.scrambled777@simplelogin.com>\n"
-"Language-Team: Hindi <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/hi/>\n"
 "Language: hi\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Hindi <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/hi/>\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "पासवर्ड समाप्त हो गया है। कृपया इसे रीसेट करें।"
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "IPA सर्वर में लॉग इन नहीं किया जा सका।"
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "%(username)s, आपका स्वागत है!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "टोकन सफलतापूर्वक समन्वयित किया गया"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "IPA सर्वर में लॉग इन नहीं किया जा सका।"
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "पासवर्ड बदला नहीं जा सका, कृपया पुनः प्रयास करें।"
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "सत्यापन कोड"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "उपयोक्ता %(username)s सिस्टम में नहीं मिला।"
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "उपयोक्ता %(username)s को जोड़ने में असमर्थ: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "आप समझ गए! %(username)s को %(groupname)s में जोड़ दिया गया है।"
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "आप समझ गए! %(username)s को %(groupname)s से हटा दिया गया है।"
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "आप समझ गए! %(username)s अब %(groupname)s का प्रायोजक नहीं है।"
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "पुराना पासवर्ड या उपयोक्ता नाम सही नहीं है"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "पासवर्ड नहीं बदला जा सका।"
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "आपका पासवर्ड बदल दिया गया है"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"आपने पहले ही पासवर्ड रीसेट का अनुरोध कर दिया है, आपको दूसरा अनुरोध करने से पहले "
-"%(wait_min)s मिनट और %(wait_sec)s सेकंड प्रतीक्षा करनी होगी।"
+"आपने पहले ही पासवर्ड रीसेट का अनुरोध कर दिया है, आपको दूसरा अनुरोध करने "
+"से पहले %(wait_min)s मिनट और %(wait_sec)s सेकंड प्रतीक्षा करनी होगी।"
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "उपयोक्ता %(username)s मौजूद नहीं है"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "हम आपको ईमेल नहीं भेज सके, कृपया बाद में पुनः प्रयास करें"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "आपका ईमेल पता smtp सर्वर द्वारा अस्वीकार कर दिया गया है"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
-msgstr "आपके पते पर एक ईमेल भेजा गया है जिसमें आपका पासवर्ड रीसेट करने के निर्देश दिए गए हैं"
+msgstr ""
+"आपके पते पर एक ईमेल भेजा गया है जिसमें आपका पासवर्ड रीसेट करने के निर्देश"
+" दिए गए हैं"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "टोकन अमान्य है, कृपया नया टोकन मांगें।"
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "टोकन की अवधि समाप्त हो गई है, कृपया नया टोकन मांगें।"
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"जब से आपने यह टोकन मांगा है, आपका पासवर्ड बदल दिया गया है, कृपया नया पासवर्ड मांगें।"
+"जब से आपने यह टोकन मांगा है, आपका पासवर्ड बदल दिया गया है, कृपया नया "
+"पासवर्ड मांगें।"
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"आपका पासवर्ड बदल दिया गया है, लेकिन यह नीति (%(policy_error)s) का अनुपालन नहीं "
-"करता है और इसलिए इसे समाप्त मान लिया गया है। लॉग इन करने के बाद आपको इसे बदलने के लिए "
-"कहा जाएगा।"
+"आपका पासवर्ड बदल दिया गया है, लेकिन यह नीति (%(policy_error)s) का अनुपालन"
+" नहीं करता है और इसलिए इसे समाप्त मान लिया गया है। लॉग इन करने के बाद "
+"आपको इसे बदलने के लिए कहा जाएगा।"
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "ग़लत मान।"
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "पासवर्ड बदला नहीं जा सका, कृपया पुनः प्रयास करें।"
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "आपका पासवर्ड बदल दिया गया है।"
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "अपना ईमेल पता सत्यापित करें"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr "हम आपको पता सत्यापन ईमेल नहीं भेज सके, कृपया बाद में पुनः प्रयास करें"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"ईमेल पता '%(email)s' के लिए उपयोक्ता नाम '%(username)s' पहले से ही लिया जा चुका है।"
+"ईमेल पता '%(email)s' के लिए उपयोक्ता नाम '%(username)s' पहले से ही लिया "
+"जा चुका है।"
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "खाता बनाते समय कोई त्रुटि हुई, कृपया पुनः प्रयास करें।"
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "ऐसा लगता है कि पंजीकरण असफल हो गया है, कृपया पुनः प्रयास करें।"
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
-msgstr "पता सत्यापन ईमेल फिर से भेजा गया है। सुनिश्चित करें कि यह आपके स्पैम फोल्डर में न जाए"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
+msgstr ""
+"पता सत्यापन ईमेल फिर से भेजा गया है। सुनिश्चित करें कि यह आपके स्पैम "
+"फोल्डर में न जाए"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "कोई टोकन उपलब्ध नहीं कराया गया है, कृपया अपना ईमेल सत्यापन लिंक जांचें।"
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "टोकन अमान्य है, कृपया पुनः पंजीकरण करें।"
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "यह टोकन अब मान्य नहीं है, कृपया पुनः पंजीकरण करें।"
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "यह उपयोक्ता नहीं मिल सका, कृपया पुनः पंजीकरण करें।"
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"उपयोक्तानाम और ईमेल पता आपके द्वारा उपयोग किए गए टोकन से मेल नहीं खाता है, कृपया पुनः "
-"पंजीकरण करें।"
+"उपयोक्तानाम और ईमेल पता आपके द्वारा उपयोग किए गए टोकन से मेल नहीं खाता "
+"है, कृपया पुनः पंजीकरण करें।"
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "आपका खाता बनाते समय कुछ गड़बड़ी हुई है, कृपया बाद में पुनः प्रयास करें।"
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "आपका खाता बना दिया गया है, लेकिन आपके द्वारा चुना गया पासवर्ड नीति "
-"(%(policy_error)s) का अनुपालन नहीं करता है और इसलिए इसे समाप्त मान लिया गया है। "
-"लॉग इन करने के बाद आपको इसे बदलने के लिए कहा जाएगा।"
+"(%(policy_error)s) का अनुपालन नहीं करता है और इसलिए इसे समाप्त मान लिया "
+"गया है। लॉग इन करने के बाद आपको इसे बदलने के लिए कहा जाएगा।"
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"आपका खाता बना दिया गया है, लेकिन आपका पासवर्ड निर्धारित करते समय एक त्रुटि हुई "
-"(%(message)s)। लॉग इन करने के बाद आपको इसे बदलने की आवश्यकता हो सकती है।"
+"आपका खाता बना दिया गया है, लेकिन आपका पासवर्ड निर्धारित करते समय एक "
+"त्रुटि हुई (%(message)s)। लॉग इन करने के बाद आपको इसे बदलने की आवश्यकता "
+"हो सकती है।"
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "बधाई हो, आपका खाता बन गया है! स्वागत है, %(name)s।"
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "बधाई हो, आपका खाता बन गया है! आगे बढ़ें और आगे बढ़ने के लिए साइन इन करें।"
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "सभी"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "अज्ञात"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "स्पैम नहीं"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "स्पैम"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "प्रतीक्षारत"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "फिलहाल पंजीकरण बंद है।"
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"ईमेल पता %(mail)s को सत्यापित करने की आवश्यकता है। कृपया अपना इनबॉक्स देखें और आगे बढ़ने "
-"के लिए लिंक पर क्लिक करें। यदि आपको कुछ मिनटों में ईमेल नहीं मिलता है, तो अपने स्पैम फोल्डर "
-"की जांच करें।"
+"ईमेल पता %(mail)s को सत्यापित करने की आवश्यकता है। कृपया अपना इनबॉक्स "
+"देखें और आगे बढ़ने के लिए लिंक पर क्लिक करें। यदि आपको कुछ मिनटों में "
+"ईमेल नहीं मिलता है, तो अपने स्पैम फोल्डर की जांच करें।"
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "कोई संशोधन नहीं।"
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "टोकन अमान्य है, कृपया ईमेल पुनः निर्धारित करें।"
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "यह टोकन अब मान्य नहीं है, कृपया ईमेल दोबारा निर्धारित करें।"
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "यह टोकन आपका नहीं है।"
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "गलत पासवर्ड"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "टोकन नहीं बनाया जा सकता।"
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "टोकन बना दिया गया है।"
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "टोकन रहस्य नहीं मिल सका"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "टोकन का नाम बदला नहीं जा सकता।"
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "क्षमा करें, आप अपना अंतिम सक्रिय टोकन अक्षम नहीं कर सकते।"
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "टोकन को अक्षम नहीं किया जा सकता।"
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "टोकन सक्षम नहीं किया जा सकता। %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "क्षमा करें, आप अपना अंतिम सक्रिय टोकन नहीं मिटा सकते।"
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "टोकन मिटाया नहीं जा सकता।"
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "टोकन नहीं बनाया जा सकता।"
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "टोकन का नाम बदला नहीं जा सकता।"
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "गलत पासवर्ड"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "OTP टोकन सत्यापित करें और सक्षम करें"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "%(username)s के लिए पासवर्ड रीसेट करें"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "\"%(name)s\" समझौते पर हस्ताक्षर नहीं किया जा सकता: %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "आपने \"%(name)s\" समझौते पर हस्ताक्षर किए हैं।"
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "टोकन मिटाया नहीं जा सकता।"
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "टोकन बना दिया गया है।"
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "यह कोई मान्य उपनाम नहीं लगता।"
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "यह मान्य सर्वर नाम जैसा नहीं दिखता।"
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "प्रथम नाम"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "प्रथम नाम रिक्त नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "अंतिम नाम"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "अंतिम नाम रिक्त नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "लोकेल"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "लोकेल रिक्त नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "लोकेल एक मान्य लोकेल शॉर्ट-कोड होना चाहिए"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "चैट उपनाम"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "समयक्षेत्र"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "समयक्षेत्र रिक्त नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "समयक्षेत्र एक मान्य समयक्षेत्र होना चाहिए"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub उपयोक्तानाम"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab उपयोक्तानाम"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "मान्य URL आवश्यक है"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "लॉग आउट"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "निजी"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr "अन्य उपयोक्ताओं से जानकारी छुपाएं, विवरण के लिए गोपनीयता नीति देखें।"
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "सर्वनाम"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "ई-मेल पता"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "ईमेल खाली नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "ईमेल मान्य होना चाहिए"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "रेड हैट बगज़िला ईमेल"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH कुंजियां"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG कुंजियां"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "टोकन नाम"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "इस टोकन को पहचानने में आपकी सहायता के लिए एक वैकल्पिक नाम जोड़ें"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "अपने वर्तमान पासवर्ड को दर्ज करें"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "आपको पासवर्ड प्रदान करना होगा"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "कृपया पुनः प्रमाणित करें ताकि हमें पता चले कि यह आप ही हैं"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "OTP"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "अपना OTP दर्ज करें"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "OTP टोकन उत्पन्न करें"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "टोकन रहस्य नहीं मिल सका"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "सत्यापन कोड"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "आपको एक सत्यापन कोड प्रदान करना होगा"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "OTP टोकन सत्यापित करें और सक्षम करें"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "कोड ग़लत है, कृपया पुनः प्रयास करें।"
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "टोकन खाली नहीं होना चाहिए"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "OTP टोकन उत्पन्न करें"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "OTP टोकन उत्पन्न करें"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "अपने वर्तमान पासवर्ड को दर्ज करें"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "पासवर्ड खाली नहीं होना चाहिए"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "समझौता खाली नहीं होना चाहिए"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "नये सदस्य का उपयोक्तानाम रिक्त नहीं होना चाहिए"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "उपयोक्तानाम"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "उपयोक्तानाम रिक्त नहीं होना चाहिए"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "अपना ईमेल पता सत्यापित करें"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "आपको एक उपयोक्तानाम प्रदान करना होगा"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "पासवर्ड"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "लॉगिन"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "नया पासवर्ड"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "पासवर्ड खाली नहीं होना चाहिए"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "पासवर्ड मेल खाने चाहिए"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "नए पासवर्ड की पुष्टि करें"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr "OTP (यदि आपके खाते में दो-कारक प्रमाणीकरण सक्षम है)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "वर्तमान पासवर्ड"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "वर्तमान पासवर्ड खाली नहीं होना चाहिए"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "उपयोक्तानाम"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "उपयोक्ता नाम रिक्त नहीं होना चाहिए"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "अपना पासवर्ड रीसेट करने के लिए अपना उपयोक्ता नाम दर्ज करें"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "केवल इन वर्णों की अनुमति है: \"%(chars)s\"।"
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "मेरी उम्र 16 वर्ष से अधिक है"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "खाता बनाने के लिए आपकी आयु 16 वर्ष से अधिक होनी चाहिए"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "पंजीकृत करें"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "ईमेल पुनः भेजें"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "कृपया एक मजबूत पासवर्ड चुनें"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "पासवर्ड की पुष्टि करें"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "सक्रिय करें"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "पहला OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "आपको पहला कोड प्रदान करना होगा"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "दूसरा OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "आपको दूसरा कोड प्रदान करना होगा"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "टोकन आईडी"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "उस डोमेन से ईमेल पते की अनुमति नहीं है"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "मिश्रित अक्षर की अनुमति नहीं है, छोटे अक्षर का प्रयास करें।"
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "क्षेत्र \"%(pattern)s\" से मेल नहीं खाना चाहिए।"
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "वह पृष्ठ नहीं मिला।"
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "समझौता देखें"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "उपयोक्ता समझौते पर हस्ताक्षर करें"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "पासवर्ड भूल गए?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "पासवर्ड या OTP भूल गए?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "टोकन समन्वयन"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "पिछला"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "वर्तमान"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "अगला"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "समूह"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "उपयोक्ता"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "पासवर्ड पुनर्प्राप्ति"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "क्या आप अपना पासवर्ड भूल गए हैं?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"अपना उपयोक्ता नाम दर्ज करें और आगे के निर्देशों के साथ एक ईमेल आपके पते पर भेजा जाएगा।"
+"अपना उपयोक्ता नाम दर्ज करें और आगे के निर्देशों के साथ एक ईमेल आपके पते "
+"पर भेजा जाएगा।"
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "भेजें"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "पासवर्ड रीसेट करें"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "%(username)s के लिए पासवर्ड रीसेट करें"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s समूह"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "समूह छोड़ें"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"आप इस समूह के प्रायोजक हैं, लेकिन सदस्य नहीं हैं। यदि आप सदस्य बनना चाहते हैं तो खुद को जोड़ें।"
+"आप इस समूह के प्रायोजक हैं, लेकिन सदस्य नहीं हैं। यदि आप सदस्य बनना चाहते"
+" हैं तो खुद को जोड़ें।"
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "इस समूह में शामिल होने के लिए समूह प्रायोजक से संपर्क करें।"
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "प्रायोजक"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "कोई प्रायोजक नहीं"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "सदस्य"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "उपयोक्ता जोड़ें..।"
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "अभी तक कोई सदस्य नहीं।"
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "समूह सूची"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s सदस्य"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "कोई समूह नहीं।"
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "लॉगिन"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA त्रुटि"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "IPA बैकएंड में कोई समस्या थी, कृपया बाद में पुनः प्रयास करें।"
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"यदि समस्या बनी रहती है तो आप <a href=\"%(url)s\">लॉग आउट</a> भी कर सकते हैं और "
-"पुनः लॉग इन भी कर सकते हैं।"
+"यदि समस्या बनी रहती है तो आप <a href=\"%(url)s\">लॉग आउट</a> भी कर सकते "
+"हैं और पुनः लॉग इन भी कर सकते हैं।"
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "पासवर्ड रीसेट की समय-सीमा समाप्त हो गई"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "%(username)s के लिए पासवर्ड रीसेट की समय-सीमा समाप्त हो गई"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "पासवर्ड बदलें"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "उपयोक्ताओं का पंजीकरण"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "नाम:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "ईमेल:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "पंजीकृत:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "स्थिति:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "स्पैम जांच की प्रतीक्षा की जा रही है"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "स्पैम चिह्नित नहीं"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "स्पैम चिह्नित"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "स्पैम स्थिति अज्ञात"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "स्वीकारें"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "स्पैम चिह्नित करें"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "मिटाएं"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"स्वीकार करें पर क्लिक करने से इस उपयोक्ता को सत्यापन ईमेल भेजा जाएगा। अन्य बटन कुछ भी "
-"नहीं भेजेंगे।"
+"स्वीकार करें पर क्लिक करने से इस उपयोक्ता को सत्यापन ईमेल भेजा जाएगा। "
+"अन्य बटन कुछ भी नहीं भेजेंगे।"
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "इस समय इस स्थिति में कोई पंजीकृत उपयोक्ता नहीं है।"
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "इस समय कोई पंजीकृत उपयोक्ता नहीं है।"
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "अपना खाता सक्रिय करें"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "खाता निर्माण, चरण 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "नमस्ते %(name)s। अपना खाता सक्रिय करने के लिए, कृपया एक पासवर्ड चुनें।"
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "उपयोक्ता समझौते पर हस्ताक्षर करें"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "अपना ईमेल पता सत्यापित करें"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "खाता निर्माण, चरण 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "बधाई हो %(name)s, आपका खाता बन गया है!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"लॉग इन करने से पहले, आपके ईमेल पते: %(mail)s को सत्यापित किया जाना चाहिए। कृपया अपना "
-"इनबॉक्स देखें और आगे बढ़ने के लिए लिंक पर क्लिक करें।"
+"लॉग इन करने से पहले, आपके ईमेल पते: %(mail)s को सत्यापित किया जाना चाहिए।"
+" कृपया अपना इनबॉक्स देखें और आगे बढ़ने के लिए लिंक पर क्लिक करें।"
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"अगर आपको कुछ मिनटों में ईमेल नहीं मिलता है, तो अपने स्पैम फोल्डर की जांच करें। अगर यह वहां "
-"नहीं है, तो आप नीचे दिए गए बटन पर क्लिक करके दूसरे सत्यापन ईमेल के लिए पूछ सकते हैं।"
+"अगर आपको कुछ मिनटों में ईमेल नहीं मिलता है, तो अपने स्पैम फोल्डर की जांच "
+"करें। अगर यह वहां नहीं है, तो आप नीचे दिए गए बटन पर क्लिक करके दूसरे "
+"सत्यापन ईमेल के लिए पूछ सकते हैं।"
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "स्पैम जांच जारी है"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "आपके खाते की जांच की जा रही है"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"इससे पहले कि आप लॉग इन कर सकें, आपके खाते को स्पैम की संभावना के लिए जांचना होगा। इसमें "
-"केवल कुछ सेकंड लगेंगे, कृपया प्रतीक्षा करें..।"
+"इससे पहले कि आप लॉग इन कर सकें, आपके खाते को स्पैम की संभावना के लिए "
+"जांचना होगा। इसमें केवल कुछ सेकंड लगेंगे, कृपया प्रतीक्षा करें..।"
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "आपके खाते को प्रशासकीय स्वीकृति की आवश्यकता है"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "आपके खाते को प्रशासक द्वारा अनुमोदित होना आवश्यक है।"
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "निर्णय लिये जाने पर आपको एक ईमेल प्राप्त होगा।"
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "आपके धैर्य के लिए धन्यवाद।"
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "आपका खाता अवरुद्ध है"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "आपके खाते को स्पैम के रूप में चिह्नित किया गया है।"
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "कुछ गलत हुआ"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "असमर्थित स्पैम स्थिति: %s, कृपया प्रशासकों से संपर्क करें"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "OTP टोकन समन्वयन"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "OTP टोकन समन्वयित करें"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "समन्वयन"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "अपना ईमेल सत्यापित करें"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
-"नमस्ते %(user_name)s। क्या आप अपना %(attr_name)s %(mail)s पर निर्धारित करना चाहते "
-"हैं?"
+"नमस्ते %(user_name)s। क्या आप अपना %(attr_name)s %(mail)s पर निर्धारित "
+"करना चाहते हैं?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "रद्द करें"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "इसे करें"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "सहेजें"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG कुंजी आईडी"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH सार्वजनिक कुंजी"
 
-msgid "Scan your new token"
-msgstr "अपना नया टोकन स्कैन करें"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "%(username)s के लिए सेटिंग्स"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
-"आपका नया टोकन तैयार है। QR कोड देखने के लिए नीचे दिए गए बटन पर क्लिक करें और उसे स्कैन "
-"करें।"
 
-msgid "Reveal"
-msgstr "प्रकट करें"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "कोड ग़लत है, कृपया पुनः प्रयास करें।"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr "या यदि आप QR कोड स्कैन नहीं कर सकते हैं तो निम्न टोकन URL को कॉपी और पेस्ट करें:"
-
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
 msgstr ""
-"अपने अनुप्रयोग में टोकन नामांकित करने के बाद, अपना पहला कोड उत्पन्न करके और उसे नीचे दर्ज "
-"करके उसे सत्यापित करें:"
 
-msgid "Add OTP Token"
-msgstr "OTP टोकन जोड़ें"
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
 msgstr ""
-"अपना पहला OTP टोकन बनाने से OTP का उपयोग करके दो-कारक प्रमाणीकरण सक्षम हो जाता है।"
 
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr "एक बार सक्षम होने के बाद, दो-कारक प्रमाणीकरण को अक्षम नहीं किया जा सकता।"
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
 
-msgid "OTP Tokens"
-msgstr "OTP टोकन"
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "OTP टोकन उत्पन्न करें"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr "(कोई नाम नहीं)"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "आपके पास कोई OTP टोकन नहीं है"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "प्रतीक्षारत"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "पासवर्ड"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "अपना नया टोकन स्कैन करें"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"आपका नया टोकन तैयार है। QR कोड देखने के लिए नीचे दिए गए बटन पर क्लिक करें"
+" और उसे स्कैन करें।"
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "प्रकट करें"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+"या यदि आप QR कोड स्कैन नहीं कर सकते हैं तो निम्न टोकन URL को कॉपी और "
+"पेस्ट करें:"
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+"अपने अनुप्रयोग में टोकन नामांकित करने के बाद, अपना पहला कोड उत्पन्न करके "
+"और उसे नीचे दर्ज करके उसे सत्यापित करें:"
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "OTP टोकन जोड़ें"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+"अपना पहला OTP टोकन बनाने से OTP का उपयोग करके दो-कारक प्रमाणीकरण सक्षम हो"
+" जाता है।"
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr "एक बार सक्षम होने के बाद, दो-कारक प्रमाणीकरण को अक्षम नहीं किया जा सकता।"
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "OTP टोकन"
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "नाम बदलें"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "अक्षम करें"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "सक्षम करें"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "आपके पास कोई OTP टोकन नहीं है"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr "अपने खाते पर दो-कारक प्रमाणीकरण सक्षम करने के लिए एक OTP टोकन जोड़ें।"
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "सक्रिय करें"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "वर्तमान पासवर्ड"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "स्पैम नहीं"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH कुंजियां"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "आपके पास कोई OTP टोकन नहीं है"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr "अपने खाते पर दो-कारक प्रमाणीकरण सक्षम करने के लिए एक OTP टोकन जोड़ें।"
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "अवतार बदलें"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
-"            यदि आप तयशुदा सर्वर का उपयोग नहीं कर रहे हैं तो प्रारूप <code>username</"
-"code> या <code>username:server.name</code> है:\n"
+"            यदि आप तयशुदा सर्वर का उपयोग नहीं कर रहे हैं तो प्रारूप "
+"<code>username</code> या <code>username:server.name</code> है:\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              %(title)s के लिए: <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "%(username)s के लिए सेटिंग्स"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "प्रोफाइल"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "ईमेल"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG कुंजियां"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "समझौते"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "%(username)s के लिए प्रोफाइल"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "प्रोफाइल संपादित करें"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "पहला OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "वर्तमान समय"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "चैट"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "लॉगिन"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s समूह, %(agreementcount)s समझौते"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "हस्ताक्षरित"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "प्रायोजक"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "सदस्य"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "उपयोक्ता %(username)s मौजूद नहीं है"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "नमस्ते %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"उपयोक्ता नाम %(username)s के साथ अपना खाता सक्रिय करने के लिए, नीचे दिए गए लिंक पर "
-"क्लिक करें:"
+"उपयोक्ता नाम %(username)s के साथ अपना खाता सक्रिय करने के लिए, नीचे दिए "
+"गए लिंक पर क्लिक करें:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"यदि आपने उपयोक्ता नाम %(username)s के लिए खाता नहीं बनाया है, तो आप इस ईमेल को "
-"अनदेखा कर सकते हैं।"
+"यदि आपने उपयोक्ता नाम %(username)s के लिए खाता नहीं बनाया है, तो आप इस "
+"ईमेल को अनदेखा कर सकते हैं।"
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "AlmaLinux टीम"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "नमस्ते,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"अपना पासवर्ड रीसेट करने के लिए नीचे दिए गए लिंक पर क्लिक करें। यदि आपने पासवर्ड रीसेट "
-"करने का अनुरोध नहीं किया है, तो कृपया इस ईमेल को अनदेखा करें।"
+"अपना पासवर्ड रीसेट करने के लिए नीचे दिए गए लिंक पर क्लिक करें। यदि आपने "
+"पासवर्ड रीसेट करने का अनुरोध नहीं किया है, तो कृपया इस ईमेल को अनदेखा "
+"करें।"
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "AlmaLinux खाता सेवाएं"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "खोजें..।"
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "सेटिंग"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "सहायता"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "लॉग आउट"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "%(noggin_link)s द्वारा संचालित"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux खाते"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"AlmaLinux खाते, AlmaLinux के संपूर्ण बुनियादी ढांचे में आपके खाते को बनाने और प्रबंधित करने "
-"की क्षमता प्रदान करता है।"
+"AlmaLinux खाते, AlmaLinux के संपूर्ण बुनियादी ढांचे में आपके खाते को "
+"बनाने और प्रबंधित करने की क्षमता प्रदान करता है।"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "ईमेल पता %(address)s को मान्य करने के लिए नीचे दिए गए लिंक पर क्लिक करें:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"यदि आपने अपने खाते %(username)s में ईमेल पता %(address)s निर्धारित नहीं किया है, तो "
-"आप इस ईमेल को अनदेखा कर सकते हैं।"
+"यदि आपने अपने खाते %(username)s में ईमेल पता %(address)s निर्धारित नहीं "
+"किया है, तो आप इस ईमेल को अनदेखा कर सकते हैं।"
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "नोगिन टीम"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "नोगिन में आपका स्वागत है!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"यह FreeIPA के लिए ओपन सोर्स, सामुदायिक स्व-सेवा पोर्टल है। यह आपको खाता बनाने, अपना "
-"पासवर्ड बदलने, समूह सदस्यता प्रबंधित करने और बहुत कुछ करने की अनुमति देता है।"
+"यह FreeIPA के लिए ओपन सोर्स, सामुदायिक स्व-सेवा पोर्टल है। यह आपको खाता "
+"बनाने, अपना पासवर्ड बदलने, समूह सदस्यता प्रबंधित करने और बहुत कुछ करने की"
+" अनुमति देता है।"
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"OTP सक्षम होने पर Kerberos टिकट का उपयोग करते समय अतिरिक्त विन्यास की आवश्यकता "
-"होती है"
+"OTP सक्षम होने पर Kerberos टिकट का उपयोग करते समय अतिरिक्त विन्यास की "
+"आवश्यकता होती है"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"अपने सिस्टम को विन्यस्त करने के विवरण के लिए <a href='https://"
-"docs.fedoraproject.org/en-US/fedora-accounts/user/#pkinit'>दस्तावेज़</a> पढ़ें"
+"अपने सिस्टम को विन्यस्त करने के विवरण के लिए <a "
+"href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>दस्तावेज़</a> पढ़ें"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "यहां लॉगिन करने के लिए आप अपने Fedora खाते का भी उपयोग कर सकते हैं।"
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr "यह लिंक %(ttl)s मिनट (%(valid_until)s UTC तक) के लिए मान्य रहेगा।"
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
-"यदि लिंक की समय-सीमा समाप्त हो गई है, तो आप यहां नए लिंक का अनुरोध कर सकते हैं: "
+"यदि लिंक की समय-सीमा समाप्त हो गई है, तो आप यहां नए लिंक का अनुरोध कर "
+"सकते हैं: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora खाता प्रणाली"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora खाते"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "विकि"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora लोग"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Fedora खाते आपको Fedora टूल्स और इन्फ्रास्ट्रक्चर के लिए खाता बनाने और प्रबंधित करने की "
-"अनुमति देता है।"
+"Fedora खाते आपको Fedora टूल्स और इन्फ्रास्ट्रक्चर के लिए खाता बनाने और "
+"प्रबंधित करने की अनुमति देता है।"
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "समूह संपादित करें"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr "समूह विवरण बदलने या प्रायोजक जोड़ने के लिए, टिकट दर्ज करें"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "अपना खाता अक्षम करने के लिए PDR अनुरोध बनाएं"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "खाता मिटाने का अनुरोध करें"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "क्या आपने अपना अंतिम OTP टोकन खो दिया है?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"यदि आपने अपना अंतिम OTP टोकन खो दिया है, तो आपको %(admin_email)s को एक ईमेल भेजना "
-"होगा। यदि संभव हो तो कृपया अपने खाते से जुड़ी GPG कुंजी का उपयोग करके इस ईमेल पर "
-"हस्ताक्षर करें, ताकि प्रशासक आपकी पहचान सत्यापित कर सके।"
+"यदि आपने अपना अंतिम OTP टोकन खो दिया है, तो आपको %(admin_email)s को एक "
+"ईमेल भेजना होगा। यदि संभव हो तो कृपया अपने खाते से जुड़ी GPG कुंजी का "
+"उपयोग करके इस ईमेल पर हस्ताक्षर करें, ताकि प्रशासक आपकी पहचान सत्यापित कर"
+" सके।"
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"यदि आपके पास एक से अधिक टोकन थे और आपने उनमें से एक खो दिया है, तो आप लॉगइन करने के "
-"लिए दूसरे टोकन का उपयोग कर सकते हैं और अपने खाते से खोए हुए टोकन को मिटा सकते हैं।"
+"यदि आपके पास एक से अधिक टोकन थे और आपने उनमें से एक खो दिया है, तो आप "
+"लॉगइन करने के लिए दूसरे टोकन का उपयोग कर सकते हैं और अपने खाते से खोए हुए"
+" टोकन को मिटा सकते हैं।"
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
-"यदि आपने OTP टोकन पंजीकृत नहीं किया है, तो आपके पास OTP टोकन नहीं है और यह आप पर लागू "
-"नहीं होगा।"
+"यदि आपने OTP टोकन पंजीकृत नहीं किया है, तो आपके पास OTP टोकन नहीं है और "
+"यह आप पर लागू नहीं होगा।"
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"प्रशासकों को यह बताने के लिए कि आप स्पैमर नहीं हैं, कृपया %(email_link)s को ईमेल भेजें और "
-"स्थिति स्पष्ट करें।"
+"प्रशासकों को यह बताने के लिए कि आप स्पैमर नहीं हैं, कृपया %(email_link)s "
+"को ईमेल भेजें और स्थिति स्पष्ट करें।"
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Fedora खाते का उपयोग करके, आप <a href='https://docs.fedoraproject.org/en-US/"
-"project/code-of-conduct/'>Fedora&nbsp;आचार&nbsp;संहिता</a> का पालन करने के लिए "
-"सहमत होते हैं।"
+"Fedora खाते का उपयोग करके, आप <a href='https://docs.fedoraproject.org/en-"
+"US/project/code-of-conduct/'>Fedora&nbsp;आचार&nbsp;संहिता</a> का पालन "
+"करने के लिए सहमत होते हैं।"
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "आप यहां लॉगइन करने के लिए अपने CentOS खाते का भी उपयोग कर सकते हैं।"
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "समूह %(groupname)s नहीं मिला।"
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "पूर्ववत करें"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s %(server)s पर"
@@ -1167,3 +1982,4 @@ msgstr "%(protocol)s %(server)s पर"
 
 #~ msgid "Website"
 #~ msgstr "वेबसाइट"
+

--- a/noggin/translations/hu/LC_MESSAGES/messages.po
+++ b/noggin/translations/hu/LC_MESSAGES/messages.po
@@ -7,1061 +7,1836 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2023-10-08 16:36+0000\n"
 "Last-Translator: Hoppár Zoltán <hopparz@gmail.com>\n"
-"Language-Team: Hungarian <https://translate.fedoraproject.org/projects/"
-"fedora-infra/noggin/hu/>\n"
 "Language: hu\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Hungarian <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/hu/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "A jelszó lejárt. Kérem újítsa meg."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Nem sikerült bejelentkezni az IPA szerverre."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Üdvözöljük,%(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token sikeresen szinkronizálva"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Nem sikerült bejelentkezni az IPA szerverre."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "A jelszó lejárt. Kérem újítsa meg."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "A %(username)s felhasználó nem található a rendszerben."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr ""
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr ""
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr ""
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr ""
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Nem sikerült bejelentkezni az IPA szerverre."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 #, fuzzy
 msgid "Could not find the token secret"
 msgstr "Nem sikerült bejelentkezni az IPA szerverre."
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
-msgstr ""
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Üdvözöljük,%(username)s!"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Csevegés"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
+msgstr ""
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/id/LC_MESSAGES/messages.po
+++ b/noggin/translations/id/LC_MESSAGES/messages.po
@@ -8,82 +8,159 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2026-01-09 01:58+0000\n"
 "Last-Translator: Arif Budiman <arifpedia@gmail.com>\n"
-"Language-Team: Indonesian <https://translate.fedoraproject.org/projects/"
-"fedora-infra/noggin/id/>\n"
 "Language: id\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Indonesian <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/id/>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 5.15.1\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Kata sandi kedaluwarsa. Silakan setel ulang."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Tidak dapat masuk ke server IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Selamat datang, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token berhasil disinkronkan"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Tidak ada server IPA yang tersedia"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Tidak dapat masuk ke server IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Tidak dapat mengubah kata sandi, silakan coba lagi."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Kode Verifikasi"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Pengguna %(username)s tidak ditemukan di sistem."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Tidak dapat menambahkan pengguna %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Berhasil! %(username)s telah ditambahkan ke %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Berhasil! %(username)s telah dihapus dari %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Berhasil! %(username)s bukan lagi sponsor dari %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Kata sandi lama atau nama pengguna tidak benar"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Tidak dapat mengubah kata sandi."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Kata sandi Anda telah diubah"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Anda sudah meminta pengaturan ulang kata sandi, Anda perlu menunggu %"
-"(wait_min)s menit dan %(wait_sec)s detik sebelum dapat meminta yang lain."
+"Anda sudah meminta pengaturan ulang kata sandi, Anda perlu menunggu "
+"%(wait_min)s menit dan %(wait_sec)s detik sebelum dapat meminta yang "
+"lain."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Pengguna %(username)s tidak ada"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Kami tidak dapat mengirim email kepada Anda, silakan coba lagi nanti"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Alamat email Anda ditolak oleh server SMTP"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
@@ -91,588 +168,920 @@ msgstr ""
 "Sebuah email telah dikirim ke alamat Anda dengan petunjuk cara mengatur "
 "ulang kata sandi Anda"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Token tidak valid, silakan minta yang baru."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Token telah kedaluwarsa, silakan minta yang baru."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Kata sandi Anda telah berubah sejak Anda meminta token ini, silakan minta "
-"yang baru."
+"Kata sandi Anda telah berubah sejak Anda meminta token ini, silakan minta"
+" yang baru."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"Kata sandi Anda telah diubah, tetapi tidak mematuhi kebijakan (%"
-"(policy_error)s) sehingga ditetapkan sebagai kedaluwarsa. Anda akan diminta "
-"mengubahnya setelah masuk."
+"Kata sandi Anda telah diubah, tetapi tidak mematuhi kebijakan "
+"(%(policy_error)s) sehingga ditetapkan sebagai kedaluwarsa. Anda akan "
+"diminta mengubahnya setelah masuk."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Nilai tidak benar."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Tidak dapat mengubah kata sandi, silakan coba lagi."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Kata sandi Anda telah diubah."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifikasi alamat email Anda"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Kami tidak dapat mengirim email validasi alamat kepada Anda, silakan coba "
-"lagi nanti"
+"Kami tidak dapat mengirim email validasi alamat kepada Anda, silakan coba"
+" lagi nanti"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Nama pengguna '%(username)s' atau alamat email '%(email)s' sudah digunakan."
+"Nama pengguna '%(username)s' atau alamat email '%(email)s' sudah "
+"digunakan."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Terjadi kesalahan saat membuat akun, silakan coba lagi."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "Pendaftaran tampaknya gagal, silakan coba lagi."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 "Email validasi alamat telah dikirim ulang. Pastikan email tersebut tidak "
 "masuk ke folder spam Anda"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
-"Tidak ada token yang diberikan, silakan periksa tautan validasi email Anda."
+"Tidak ada token yang diberikan, silakan periksa tautan validasi email "
+"Anda."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Token tidak valid, silakan daftar lagi."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Token ini tidak lagi valid, silakan daftar lagi."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Pengguna ini tidak dapat ditemukan, silakan daftar lagi."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Nama pengguna dan alamat email tidak cocok dengan token yang Anda gunakan, "
-"silakan daftar lagi."
+"Nama pengguna dan alamat email tidak cocok dengan token yang Anda "
+"gunakan, silakan daftar lagi."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Terjadi kesalahan saat membuat akun Anda, silakan coba lagi nanti."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Akun Anda telah dibuat, tetapi kata sandi yang Anda pilih tidak mematuhi "
-"kebijakan (%(policy_error)s) sehingga ditetapkan sebagai kedaluwarsa. Anda "
-"akan diminta mengubahnya setelah masuk."
+"kebijakan (%(policy_error)s) sehingga ditetapkan sebagai kedaluwarsa. "
+"Anda akan diminta mengubahnya setelah masuk."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Akun Anda telah dibuat, tetapi terjadi kesalahan saat menyetel kata sandi "
-"Anda (%(message)s). Anda mungkin perlu mengubahnya setelah masuk."
+"Akun Anda telah dibuat, tetapi terjadi kesalahan saat menyetel kata sandi"
+" Anda (%(message)s). Anda mungkin perlu mengubahnya setelah masuk."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Selamat, akun Anda telah dibuat! Selamat datang, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "Selamat, akun Anda telah dibuat! Silakan masuk untuk melanjutkan."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Semua"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Bukan Spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Menunggu"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Pendaftaran saat ini ditutup."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"Alamat email %(mail)s perlu divalidasi. Silakan periksa kotak masuk Anda dan "
-"klik tautan untuk melanjutkan. Jika Anda tidak dapat menemukan email "
+"Alamat email %(mail)s perlu divalidasi. Silakan periksa kotak masuk Anda "
+"dan klik tautan untuk melanjutkan. Jika Anda tidak dapat menemukan email "
 "tersebut dalam beberapa menit, periksa folder spam Anda."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Tidak ada perubahan."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Token tidak valid, silakan setel email lagi."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Token ini tidak lagi valid, silakan setel email lagi."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Token ini bukan milik Anda."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Kata sandi salah"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Tidak dapat membuat token."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Token telah dibuat."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Tidak dapat menemukan rahasia token"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Tidak dapat mengganti nama token."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Maaf, Anda tidak dapat menonaktifkan token aktif terakhir Anda."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Tidak dapat menonaktifkan token."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Tidak dapat mengaktifkan token. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Maaf, Anda tidak dapat menghapus token aktif terakhir Anda."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Tidak dapat menghapus token."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Tidak dapat membuat token."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Tidak dapat mengganti nama token."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Kata sandi salah"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Verifikasi dan Aktifkan Token OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Pengaturan Ulang Kata Sandi untuk %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Tidak dapat menandatangani persetujuan \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Anda telah menandatangani persetujuan \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Tidak dapat menghapus token."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Token telah dibuat."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Ini tidak tampak seperti nama panggilan yang valid."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Ini tidak tampak seperti nama server yang valid."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Nama Depan"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Nama depan tidak boleh kosong"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Nama Belakang"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Nama belakang tidak boleh kosong"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Lokal"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Lokal tidak boleh kosong"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Lokal harus berupa kode singkat lokal yang valid"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Nama Panggilan Chat"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Zona Waktu"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Zona waktu tidak boleh kosong"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Zona waktu harus berupa zona waktu yang valid"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nama Pengguna GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nama Pengguna GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Diperlukan URL yang valid"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "URL Blog"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "URL RSS"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Pribadi"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Sembunyikan informasi dari pengguna lain, lihat Kebijakan Privasi untuk "
 "detail."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Kata Ganti"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Alamat E-mail"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "Email tidak boleh kosong"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "Email harus valid"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Email Red Hat Bugzilla"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Kunci SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Kunci GPG"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nama token"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Tambahkan nama opsional untuk membantu Anda mengidentifikasi token ini"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Masukkan kata sandi Anda saat ini"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Anda harus memberikan kata sandi"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "silakan autentikasi ulang agar kami tahu bahwa itu Anda"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Kata Sandi Sekali Pakai"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Masukkan Kata Sandi Sekali Pakai Anda"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Buat Token OTP"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Tidak dapat menemukan rahasia token"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Kode Verifikasi"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Anda harus memberikan kode verifikasi"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Verifikasi dan Aktifkan Token OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Kode salah, silakan coba lagi."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Token tidak boleh kosong"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Buat Token OTP"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Buat Token OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Masukkan kata sandi Anda saat ini"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Kata sandi tidak boleh kosong"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Persetujuan tidak boleh kosong"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Nama pengguna anggota baru tidak boleh kosong"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nama Pengguna"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Nama pengguna tidak boleh kosong"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Nama pengguna (atau alamat email)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Anda harus memberikan nama pengguna"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Kata Sandi"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Masuk"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Kata Sandi Baru"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Kata sandi tidak boleh kosong"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Kata sandi harus sama"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Konfirmasi Kata Sandi Baru"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
-"Kata Sandi Sekali Pakai (jika akun Anda mengaktifkan Autentikasi Dua Faktor)"
+"Kata Sandi Sekali Pakai (jika akun Anda mengaktifkan Autentikasi Dua "
+"Faktor)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Kata Sandi Saat Ini"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Kata sandi saat ini tidak boleh kosong"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Nama Pengguna atau Email"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Nama pengguna tidak boleh kosong"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr "Masukkan nama pengguna atau email Anda untuk mengatur ulang kata sandi"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Hanya karakter ini yang diizinkan: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Saya berusia di atas 16 tahun"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Anda harus berusia di atas 16 tahun untuk membuat akun"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Daftar"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Kirim ulang email"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Silakan pilih kata sandi yang kuat"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Konfirmasi Kata Sandi"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Aktifkan"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "OTP Pertama"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Anda harus memberikan kode pertama"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "OTP Kedua"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Anda harus memberikan kode kedua"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID Token"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Alamat email dari domain tersebut tidak diizinkan"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "Huruf besar-kecil campuran tidak diizinkan, coba huruf kecil."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Kolom tidak boleh cocok dengan \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Halaman tersebut tidak ditemukan."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Lihat persetujuan"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "Tinjau"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Tandatangani Persetujuan Pengguna"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Lupa Kata Sandi?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Lupa Kata Sandi atau OTP?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sinkronkan Token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Sebelumnya"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "saat ini"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Berikutnya"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grup"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Pengguna"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Pemulihan Kata Sandi"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Apakah Anda lupa kata sandi Anda?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Masukkan nama pengguna atau alamat email Anda dan sebuah email akan dikirim "
-"ke alamat Anda dengan instruksi lebih lanjut."
+"Masukkan nama pengguna atau alamat email Anda dan sebuah email akan "
+"dikirim ke alamat Anda dengan instruksi lebih lanjut."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Kirim"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Atur Ulang Kata Sandi"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Pengaturan Ulang Kata Sandi untuk %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Grup %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Keluar dari grup"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Anda adalah sponsor grup ini, tetapi bukan anggota. Tambahkan diri Anda jika "
-"Anda ingin menjadi anggota."
+"Anda adalah sponsor grup ini, tetapi bukan anggota. Tambahkan diri Anda "
+"jika Anda ingin menjadi anggota."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Untuk bergabung dengan grup ini, hubungi sponsor grup."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsor"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "tidak ada sponsor"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Anggota"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "tambah pengguna..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Belum ada anggota."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Daftar Grup"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s anggota"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Tidak ada grup."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Masuk"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Kesalahan IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Terjadi masalah dengan backend IPA, silakan coba lagi nanti."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 "Anda juga dapat <a href=\"%(url)s\">keluar</a> lalu masuk kembali jika "
 "masalah tetap berlanjut."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Pengaturan Ulang Kata Sandi Kedaluwarsa"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Pengaturan Ulang Kata Sandi Kedaluwarsa untuk %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Ubah Kata Sandi"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Pendaftaran Pengguna"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nama:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Email:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Terdaftar:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Status:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Menunggu pemeriksaan spam"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Tidak ditandai sebagai spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Ditandai sebagai spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Status spam tidak diketahui"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Terima"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Tandai sebagai spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Hapus"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
@@ -680,303 +1089,611 @@ msgstr ""
 "Mengklik Terima akan mengirim email validasi kepada pengguna ini. Tombol "
 "lainnya tidak akan mengirim apa pun."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Tidak ada pengguna yang mendaftar dalam status ini saat ini."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Tidak ada pengguna yang mendaftar saat ini."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Aktifkan akun Anda"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Pembuatan akun, langkah 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
-"Halo %(name)s. Untuk mengaktifkan akun Anda, silakan pilih sebuah kata sandi."
+"Halo %(name)s. Untuk mengaktifkan akun Anda, silakan pilih sebuah kata "
+"sandi."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Tandatangani persetujuan"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "Penandatanganan persetujuan opsional"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
-"Halo %(name)s. Silakan tinjau perjanjian di bawah ini dan tandatangani jika "
-"Anda setuju dengan isinya."
+"Halo %(name)s. Silakan tinjau perjanjian di bawah ini dan tandatangani "
+"jika Anda setuju dengan isinya."
 msgstr[1] ""
 "Halo %(name)s. Silakan tinjau perjanjian-perjanjian di bawah ini dan "
 "tandatangani jika Anda setuju dengan isinya."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Lanjutkan"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Lewati"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Validasi alamat email Anda"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Pembuatan akun, langkah 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Selamat %(name)s, akun Anda telah dibuat!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 "Sebelum Anda dapat masuk, alamat email Anda: %(mail)s perlu divalidasi. "
 "Silakan periksa kotak masuk Anda dan klik tautan untuk melanjutkan."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Jika Anda tidak dapat menemukan email tersebut dalam beberapa menit, periksa "
-"folder spam Anda. Jika tidak ada di sana, Anda dapat meminta email validasi "
-"lain dengan mengklik tombol di bawah ini."
+"Jika Anda tidak dapat menemukan email tersebut dalam beberapa menit, "
+"periksa folder spam Anda. Jika tidak ada di sana, Anda dapat meminta "
+"email validasi lain dengan mengklik tombol di bawah ini."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Pemeriksaan spam sedang berlangsung"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Akun Anda sedang diperiksa"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Sebelum Anda dapat masuk, akun Anda perlu diperiksa kemungkinan spam-nya. "
-"Ini seharusnya hanya memakan beberapa detik, mohon tunggu..."
+"Sebelum Anda dapat masuk, akun Anda perlu diperiksa kemungkinan spam-nya."
+" Ini seharusnya hanya memakan beberapa detik, mohon tunggu..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Akun Anda memerlukan persetujuan admin"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Akun Anda perlu disetujui oleh administrator."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Anda akan menerima email ketika keputusan telah diambil."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Terima kasih atas kesabaran Anda."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Akun Anda diblokir"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Akun Anda telah ditandai sebagai spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Terjadi kesalahan"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Status spam tidak didukung: %s, silakan hubungi administrator"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sinkronkan Token OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sinkronkan Token OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sinkronkan"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Validasi email Anda"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
-"Halo %(user_name)s. Apakah Anda ingin menyetel %(attr_name)s Anda menjadi %"
-"(mail)s?"
+"Halo %(user_name)s. Apakah Anda ingin menyetel %(attr_name)s Anda menjadi"
+" %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Batal"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Lakukan"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Simpan"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID Kunci GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Kunci Publik SSH"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Pengaturan untuk %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Kode salah, silakan coba lagi."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Buat Token OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(tanpa nama)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Anda tidak memiliki token OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Menunggu"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Kata Sandi"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Pindai token baru Anda"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Token baru Anda sudah siap. Klik tombol di bawah ini untuk menampilkan kode "
-"QR dan memindainya."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Token baru Anda sudah siap. Klik tombol di bawah ini untuk menampilkan "
+"kode QR dan memindainya."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Tampilkan"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"atau salin dan tempel URL token berikut jika Anda tidak dapat memindai kode "
-"QR:"
+"atau salin dan tempel URL token berikut jika Anda tidak dapat memindai "
+"kode QR:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
 "Setelah mendaftarkan token di aplikasi Anda, verifikasikan dengan "
 "menghasilkan kode pertama Anda dan memasukkannya di bawah ini:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Tambahkan Token OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
 "Membuat token OTP pertama Anda mengaktifkan autentikasi dua faktor "
 "menggunakan OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr "Setelah diaktifkan, autentikasi dua faktor tidak dapat dinonaktifkan."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Token OTP"
 
-msgid "(no name)"
-msgstr "(tanpa nama)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Ubah Nama"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Nonaktifkan"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Aktifkan"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Anda tidak memiliki token OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
-"Tambahkan token OTP untuk mengaktifkan autentikasi dua faktor pada akun Anda."
+"Tambahkan token OTP untuk mengaktifkan autentikasi dua faktor pada akun "
+"Anda."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Aktifkan"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Kata Sandi Saat Ini"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Bukan Spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Kunci SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Anda tidak memiliki token OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Tambahkan token OTP untuk mengaktifkan autentikasi dua faktor pada akun "
+"Anda."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Ubah Avatar"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
-"Formatnya adalah <code>username</code> atau <code>username:server.name</"
-"code> jika Anda tidak menggunakan server bawaan:"
+"Formatnya adalah <code>username</code> atau "
+"<code>username:server.name</code> jika Anda tidak menggunakan server "
+"bawaan:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "Untuk %(title)s: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Pengaturan untuk %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Email"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Kunci SSH &amp; GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Persetujuan"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil untuk %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Sunting Profil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "OTP Pertama"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Dibuat pada"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Waktu Saat Ini"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blog"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Grup, %(agreementcount)s Persetujuan"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "ditandatangani"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "anggota"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Pengguna %(username)s tidak ada"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Halo %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"Untuk mengaktifkan akun Anda dengan nama pengguna %(username)s, klik tautan "
-"di bawah ini:"
+"Untuk mengaktifkan akun Anda dengan nama pengguna %(username)s, klik "
+"tautan di bawah ini:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Jika Anda tidak membuat akun untuk nama pengguna %(username)s, Anda dapat "
-"mengabaikan email ini."
+"Jika Anda tidak membuat akun untuk nama pengguna %(username)s, Anda dapat"
+" mengabaikan email ini."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "Tim AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Halo,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
@@ -984,179 +1701,267 @@ msgstr ""
 "Klik tautan di bawah ini untuk mengatur ulang kata sandi Anda. Jika Anda "
 "tidak meminta pengaturan ulang kata sandi, silakan abaikan email ini."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Layanan Akun AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "cari..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Pengaturan"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Bantuan"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Keluar"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Didukung oleh %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Akun AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Akun AlmaLinux menyediakan kemampuan untuk membuat dan mengelola akun Anda "
-"di seluruh infrastruktur AlmaLinux."
+"Akun AlmaLinux menyediakan kemampuan untuk membuat dan mengelola akun "
+"Anda di seluruh infrastruktur AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "Untuk memvalidasi alamat email %(address)s, klik tautan di bawah ini:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Jika Anda tidak menyetel alamat email %(address)s di akun %(username)s Anda, "
-"Anda dapat mengabaikan email ini."
+"Jika Anda tidak menyetel alamat email %(address)s di akun %(username)s "
+"Anda, Anda dapat mengabaikan email ini."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Tim Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Selamat datang di noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Ini adalah portal swadaya komunitas open source untuk FreeIPA. Portal ini "
-"memungkinkan Anda melakukan hal-hal seperti membuat akun, mengubah kata "
+"Ini adalah portal swadaya komunitas open source untuk FreeIPA. Portal ini"
+" memungkinkan Anda melakukan hal-hal seperti membuat akun, mengubah kata "
 "sandi, mengelola keanggotaan grup, dan lainnya."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"Diperlukan konfigurasi tambahan saat menggunakan tiket Kerberos ketika OTP "
-"diaktifkan"
+"Diperlukan konfigurasi tambahan saat menggunakan tiket Kerberos ketika "
+"OTP diaktifkan"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Baca <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>dokumentasi</a> untuk detail tentang mengonfigurasi sistem Anda"
+"Baca <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>dokumentasi</a> untuk detail tentang "
+"mengonfigurasi sistem Anda"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Anda juga dapat menggunakan akun Fedora Anda untuk masuk di sini."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
-msgstr ""
-"Tautan ini akan valid selama %(ttl)s menit (sampai %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgstr "Tautan ini akan valid selama %(ttl)s menit (sampai %(valid_until)s UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Jika tautan telah kedaluwarsa, Anda dapat meminta yang baru di sini: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Sistem Akun Fedora"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Akun Fedora"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora People"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 "Akun Fedora memungkinkan Anda membuat dan mengelola akun untuk Alat dan "
 "Infrastruktur Fedora."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Sunting Grup"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr "Untuk mengubah detail grup atau menambahkan sponsor, ajukan tiket ke"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Buat permintaan PDR untuk menonaktifkan akun Anda"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Minta penghapusan akun"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Apakah Anda kehilangan token OTP terakhir Anda?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Jika Anda telah kehilangan token OTP terakhir Anda, Anda perlu mengirim "
-"email ke %(admin_email)s. Jika memungkinkan, silakan tandatangani email ini "
-"menggunakan kunci GPG yang terkait dengan akun Anda, agar administrator "
-"dapat memverifikasi identitas Anda."
+"email ke %(admin_email)s. Jika memungkinkan, silakan tandatangani email "
+"ini menggunakan kunci GPG yang terkait dengan akun Anda, agar "
+"administrator dapat memverifikasi identitas Anda."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Jika Anda memiliki beberapa token dan kehilangan salah satunya, Anda dapat "
-"menggunakan token lain untuk masuk dan menghapus token yang hilang dari akun "
-"Anda."
+"Jika Anda memiliki beberapa token dan kehilangan salah satunya, Anda "
+"dapat menggunakan token lain untuk masuk dan menghapus token yang hilang "
+"dari akun Anda."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
-"Jika Anda belum mendaftarkan token OTP, berarti Anda tidak memilikinya dan "
-"ini tidak berlaku untuk Anda."
+"Jika Anda belum mendaftarkan token OTP, berarti Anda tidak memilikinya "
+"dan ini tidak berlaku untuk Anda."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"Agar admin tahu bahwa Anda bukan pengirim spam, silakan kirim email ke %"
-"(email_link)s dan jelaskan situasinya."
+"Agar admin tahu bahwa Anda bukan pengirim spam, silakan kirim email ke "
+"%(email_link)s dan jelaskan situasinya."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Dengan menggunakan akun Fedora, Anda setuju untuk mengikuti <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-conduct/'>"
-"Kode&nbsp;Etik&nbsp;Fedora</a>."
+"Dengan menggunakan akun Fedora, Anda setuju untuk mengikuti <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
+"conduct/'>Kode&nbsp;Etik&nbsp;Fedora</a>."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Anda juga dapat menggunakan akun CentOS Anda untuk masuk di sini."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Grup %(groupname)s tidak dapat ditemukan."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "Tidak ditemukan pengguna dengan email %(username_or_email)s"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Urungkan"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s pada %(server)s"
+

--- a/noggin/translations/it/LC_MESSAGES/messages.po
+++ b/noggin/translations/it/LC_MESSAGES/messages.po
@@ -9,83 +9,161 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-06-28 11:50+0000\n"
 "Last-Translator: Salvatore Cocuzza <info@salvatorecocuzza.it>\n"
-"Language-Team: Italian <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/it/>\n"
 "Language: it\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Italian <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/it/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Password scaduta, per favore esegui il reset."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "impossibile accedere al server IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Benvenuto, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token sincronizzato con successo"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "impossibile accedere al server IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Impossibile cambiare la password, per favore riprova."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Codice di verifica"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "L'utente %(username)s non è stato trovato nel sistema."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Impossibile aggiunger l'utente %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Ce lai fatta! %(username)s è stato creato in %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Ce l'ha fatta! %(username)s è stato rimosso da %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Hai indovinato! %(username)s non è più sponsor di %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "La vecchia password o il vecchio nome utente non sono corretti"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Impossibile modificare la password."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "La tua password è stata modifica"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "È già stata richiesta una reimpostazione della password; è necessario "
 "attendere %(wait_min)s minuti e %(wait_sec)s secondi prima di poterne "
 "richiedere un'altra."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "L'utente %(username)s non esiste"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
-"Non è stato possibile inviarle un'e-mail, la preghiamo di riprovare più tardi"
+"Non è stato possibile inviarle un'e-mail, la preghiamo di riprovare più "
+"tardi"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Il tuo indirizzo email è stato rifiutato dal server smtp"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
@@ -93,12 +171,15 @@ msgstr ""
 "È stata inviata un'e-mail al vostro indirizzo con le istruzioni per "
 "reimpostare la password"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Il token non è valido, richiederne uno nuovo."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Il token è scaduto, richiederne uno nuovo."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
@@ -106,92 +187,108 @@ msgstr ""
 "La password è stata modificata da quando si è richiesto questo token; si "
 "prega di richiederne una nuova."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "La password è stata modificata, ma non è conforme alla policy "
-"(%(policy_error)s) e quindi è stata impostata come scaduta. Vi verrà chiesto "
-"di cambiarla dopo l'accesso."
+"(%(policy_error)s) e quindi è stata impostata come scaduta. Vi verrà "
+"chiesto di cambiarla dopo l'accesso."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Valore non corretto."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Impossibile cambiare la password, per favore riprova."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "La password è stata modificata."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifica il tuo indirizzo email"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Non siamo riusciti a inviarti l'email di convalida dell'indirizzo, riprova "
-"più tardi"
+"Non siamo riusciti a inviarti l'email di convalida dell'indirizzo, "
+"riprova più tardi"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Il nome utente '%(username)s' o l'indirizzo email '%(email)s' sono già stati "
-"utilizzati."
+"Il nome utente '%(username)s' o l'indirizzo email '%(email)s' sono già "
+"stati utilizzati."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
-msgstr ""
-"Si è verificato un errore durante la creazione dell'account, riprovare."
+msgstr "Si è verificato un errore durante la creazione dell'account, riprovare."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "La registrazione sembra essere fallita, ti preghiamo di riprovare."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"L'email di convalida dell'indirizzo è stata inviata nuovamente. Assicurati "
-"che non sia finita nella cartella dello spam"
+"L'email di convalida dell'indirizzo è stata inviata nuovamente. "
+"Assicurati che non sia finita nella cartella dello spam"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
-msgstr ""
-"Nessun token fornito, controlla il link di convalida presente nell'email."
+msgstr "Nessun token fornito, controlla il link di convalida presente nell'email."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Il token non è valido, ti preghiamo di registrarti nuovamente."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Questo token non è più valido, ti preghiamo di registrarti nuovamente."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
-"Questo utente non può essere trovato, ti preghiamo di registrarti nuovamente."
+"Questo utente non può essere trovato, ti preghiamo di registrarti "
+"nuovamente."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Il nome utente e l'indirizzo email non corrispondono al token utilizzato, ti "
-"preghiamo di registrarti nuovamente."
+"Il nome utente e l'indirizzo email non corrispondono al token utilizzato,"
+" ti preghiamo di registrarti nuovamente."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
-"Si è verificato un errore durante la creazione del tuo account, ti preghiamo "
-"di riprovare più tardi."
+"Si è verificato un errore durante la creazione del tuo account, ti "
+"preghiamo di riprovare più tardi."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Il vostro account è stato creato, ma la password che avete scelto non è "
 "conforme alla policy (%(policy_error)s) e quindi è stata impostata come "
 "scaduta. Vi verrà chiesto di cambiarla dopo l'accesso."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
@@ -201,821 +298,1435 @@ msgstr ""
 "l’impostazione della password (%(message)s). Potrebbe essere necessario "
 "cambiarla dopo aver effettuato l’accesso."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Congratulazioni, il tuo account è stato creato! Benvenuto, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
-"Congratulazioni, il tuo account è stato creato! Procedi con l’accesso per "
-"continuare."
+"Congratulazioni, il tuo account è stato creato! Procedi con l’accesso per"
+" continuare."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Tutti"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Sconosciuto"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Non spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "In attesa"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Le registrazioni sono chiuse in questo momento."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"L'indirizzo email %(mail)s deve essere convalidato. Controlla la tua casella "
-"di posta e clicca sul link per procedere. Se non trovi l'email entro qualche "
-"minuto, controlla la cartella dello spam."
+"L'indirizzo email %(mail)s deve essere convalidato. Controlla la tua "
+"casella di posta e clicca sul link per procedere. Se non trovi l'email "
+"entro qualche minuto, controlla la cartella dello spam."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Nessuna modifica."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Il token non è valido, si prega di impostare nuovamente l'email."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
-msgstr ""
-"Questo token non è più valido, si prega di impostare nuovamente l'email."
+msgstr "Questo token non è più valido, si prega di impostare nuovamente l'email."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Questo token non ti appartiene."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Password errata"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Impossibile creare il token."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Il token è stato creato."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Impossibile trovare il token segreto."
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Impossibile rinominare il token."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Spiacenti, non puoi disabilitare il tuo ultimo token attivo."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Impossibile disabilitare il token."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Impossibile abilitare il token. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Spiacenti, non puoi eliminare il tuo ultimo token attivo."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Impossibile eliminare il token."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Impossibile creare il token."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Impossibile rinominare il token."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Password errata"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Verifica e abilita il token OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Reimpostazione password per %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Impossibile firmare l'accordo \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Hai firmato l'accordo \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Impossibile eliminare il token."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Il token è stato creato."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Questo non sembra un nickname valido."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Questo non sembra un nome server valido."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Nome"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Il nome non può essere vuoto"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Cognome"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Il cognome non può essere vuoto"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Locale"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "La località non può essere vuota"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "La località deve essere un codice locale valido"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Soprannomi in chat"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Fuso orario"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Il fuso orario non può essere vuoto"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Il fuso orario deve essere valido"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nome utente GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nome utente GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "È richiesto un URL valido"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Esci"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privato"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Nascondi le informazioni agli altri utenti, consulta la Politica sulla "
 "Privacy per i dettagli."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronomi"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Indirizzo email"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "L'email non può essere vuota"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "L'email deve essere valida"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Email di Red Hat Bugzilla"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Chiavi SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Chiavi GPS"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nome del token"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Aggiungi un nome opzionale per aiutarti"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Inserisci la tua password attuale"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Devi fornire una password"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
-msgstr ""
-"Per favore, effettua nuovamente l'autenticazione così sappiamo che sei tu"
+msgstr "Per favore, effettua nuovamente l'autenticazione così sappiamo che sei tu"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Password monouso"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Inserisci la tua password monouso"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Genera token OTP"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Impossibile trovare il token segreto."
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Codice di verifica"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Devi fornire un codice di verifica"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Verifica e abilita il token OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Il codice è sbagliato, riprova per favore."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Il nome non deve essere vuoto"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Genera token OTP"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Genera token OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Inserisci la tua password attuale"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "La password non deve essere vuota"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "L'accordo non deve essere vuoto"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Il nome utente del nuovo membro non deve essere vuoto"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nome utente"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Il nome utente non deve essere vuoto"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Verifica il tuo indirizzo email"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Devi fornire un nome utente"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Password"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Accedi"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nuova password"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "La password non deve essere vuota"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Le password devono corrispondere"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Conferma nuova password"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 "Password monouso (se il tuo account ha l'autenticazione a due fattori "
 "abilitata)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Password corrente"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "La password attuale non deve essere vuota"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Nome utente"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Il nome utente non deve essere vuoto"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Inserisci il tuo nome utente per reimpostare la password"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Sono consentiti solo questi caratteri: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Ho più di 16 anni"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Devi avere più di 16 anni per creare un account"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registrati"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Invia di nuovo l'email"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Si prega di scegliere una password sicura"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Conferma password"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Attiva"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Primo OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Devi fornire un primo codice"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Secondo OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Devi fornire un secondo codice"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID del token"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Gli indirizzi email di quel dominio non sono consentiti"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
-"Il testo con lettere maiuscole e minuscole non è consentito, prova con tutte "
-"minuscole."
+"Il testo con lettere maiuscole e minuscole non è consentito, prova con "
+"tutte minuscole."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Il campo non deve corrispondere a \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Pagina non trovata."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Vedi accordo"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Firma l'accordo utente"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Password dimenticata?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Password o OTP dimenticati?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sincronizza Token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Indietro"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "Corrente"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Avanti"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Gruppi"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Utenti"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Recupero password"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Hai dimenticato la password?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Inserisci il tuo nome utente e verrà inviata un'email al tuo indirizzo con "
-"ulteriori istruzioni."
+"Inserisci il tuo nome utente e verrà inviata un'email al tuo indirizzo "
+"con ulteriori istruzioni."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Invia"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Resetta password"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Reimpostazione password per %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Gruppo %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Esci dal gruppo"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Sei sponsor di questo gruppo, ma non un membro. Aggiungiti se vuoi diventare "
-"membro."
+"Sei sponsor di questo gruppo, ma non un membro. Aggiungiti se vuoi "
+"diventare membro."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Per unirti a questo gruppo, contatta uno sponsor del gruppo."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsor"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "nessuno sponsor"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Membri"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "aggiungi utente.."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Nessun membro ancora."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista gruppo"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s membri"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Nessun gruppo."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Accesso"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Errore IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Si è verificato un problema con il backend IPA, riprova più tardi."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Puoi anche <a href=\"%(url)s\">disconnetterti</a> e accedere di nuovo se il "
-"problema persiste."
+"Puoi anche <a href=\"%(url)s\">disconnetterti</a> e accedere di nuovo se "
+"il problema persiste."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Reimpostazione password scaduta"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Reimpostazione password scaduta per %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Cambia password"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Registrazioni utenti"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nome:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Email"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Registrato."
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Stato:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "In attesa del controllo antispam"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Non segnalato come spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Segnalato come spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Stato spam sconosciuto"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "accetta"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Segnala come spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Cancella"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Cliccando su Accetta verrà inviata l’email di convalida a questo utente. Gli "
-"altri pulsanti non invieranno nulla."
+"Cliccando su Accetta verrà inviata l’email di convalida a questo utente. "
+"Gli altri pulsanti non invieranno nulla."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Al momento non ci sono utenti in registrazione in questo stato."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Al momento non ci sono utenti in registrazione."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Attiva il tuo account"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Creazione account, step 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Ciao %(name)s. Per attivare il tuo account, scegli una password."
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "Firma l'accordo utente"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Convalida il tuo indirizzo email"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Creazione account, step 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Congratulazioni %(name)s, il tuo account è stato creato!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"Prima di poter effettuare il login, il tuo indirizzo email: %(mail)s deve "
-"essere convalidato. Controlla la tua casella di posta e clicca sul link per "
-"procedere."
+"Prima di poter effettuare il login, il tuo indirizzo email: %(mail)s deve"
+" essere convalidato. Controlla la tua casella di posta e clicca sul link "
+"per procedere."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Se non trovi l'email entro qualche minuto, controlla la cartella dello spam. "
-"Se non è lì, puoi richiedere un'altra email di convalida cliccando sul "
-"pulsante qui sotto."
+"Se non trovi l'email entro qualche minuto, controlla la cartella dello "
+"spam. Se non è lì, puoi richiedere un'altra email di convalida cliccando "
+"sul pulsante qui sotto."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Controllo antispam in corso."
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Il tuo account è in fase di controllo"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Prima di poter effettuare il login, il tuo account deve essere verificato "
-"per la probabilità di spam. Dovrebbe richiedere solo pochi secondi, ti "
+"Prima di poter effettuare il login, il tuo account deve essere verificato"
+" per la probabilità di spam. Dovrebbe richiedere solo pochi secondi, ti "
 "preghiamo di attendere..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Il tuo account richiede l'approvazione dell'amministratore"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Il tuo account deve essere approvato da un amministratore."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Riceverai un'email quando la decisione sarà stata presa."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Grazie per la tua pazienza."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Il tuo account è bloccato"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Il tuo account è stato contrassegnato come spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Qualcosa non ha funzionato"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
-"Stato spam non supportato: %s, ti preghiamo di contattare gli amministratori"
+"Stato spam non supportato: %s, ti preghiamo di contattare gli "
+"amministratori"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sincronizza il token OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sincronizza il token OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sincronizza"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Verifica la tua email"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr "Ciao %(user_name)s. Vuoi impostare il tuo %(attr_name)s su %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Annulla"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Fallo"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Salva"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID Chiave GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Chiave pubblica SSH"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Impostazioni per %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Il codice è sbagliato, riprova per favore."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Genera token OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(nessun nome)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Non hai token OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "In attesa"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Password"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Scansiona il tuo nuovo token"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Il tuo nuovo token è pronto. Clicca sul pulsante qui sotto per visualizzare "
-"il codice QR e scansionarlo."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Il tuo nuovo token è pronto. Clicca sul pulsante qui sotto per "
+"visualizzare il codice QR e scansionarlo."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Reveal"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"oppure copia e incolla il seguente URL del token se non riesci a scansionare "
-"il codice QR:"
+"oppure copia e incolla il seguente URL del token se non riesci a "
+"scansionare il codice QR:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"Dopo aver registrato il token nella tua applicazione, verifica generando il "
-"tuo primo codice e inserendolo qui sotto:"
+"Dopo aver registrato il token nella tua applicazione, verifica generando "
+"il tuo primo codice e inserendolo qui sotto:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Aggiungi OTP Token"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
-"Creare il tuo primo token OTP abilita l’autenticazione a due fattori tramite "
-"OTP."
+"Creare il tuo primo token OTP abilita l’autenticazione a due fattori "
+"tramite OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 "Una volta abilitata, l’autenticazione a due fattori non può essere "
 "disattivata."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Token OTP"
 
-msgid "(no name)"
-msgstr "(nessun nome)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Rinomina"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Disabilita"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Abilita"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Non hai token OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
-"Aggiungi un token OTP per abilitare l’autenticazione a due fattori sul tuo "
-"account."
+"Aggiungi un token OTP per abilitare l’autenticazione a due fattori sul "
+"tuo account."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Attiva"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Password corrente"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Non spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Chiavi SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Non hai token OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Aggiungi un token OTP per abilitare l’autenticazione a due fattori sul "
+"tuo account."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Cambia Avatar"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
 "            The format is either <code>username</code> or "
-"<code>username:server.name</code> if you're not using the default servers:Il "
-"formato è <code>username</code> oppure <code>username\\:server.name</code> "
-"se non stai usando i server predefiniti:\n"
+"<code>username:server.name</code> if you're not using the default "
+"servers:Il formato è <code>username</code> oppure "
+"<code>username\\:server.name</code> se non stai usando i server "
+"predefiniti:\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              Per %(title)s: <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Impostazioni per %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profilo"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Email"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Chiavi SSH e GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Contratto"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profilo di %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Edita profilo"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Primo OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Orario corrente"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Accesso"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Gruppo(i), %(agreementcount)s Accordo(i)"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "firmato"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "membri"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "L'utente %(username)s non esiste"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Benvenuto %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"Per attivare il tuo account con nome utente %(username)s, fai clic sul link "
-"qui sotto:"
+"Per attivare il tuo account con nome utente %(username)s, fai clic sul "
+"link qui sotto:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Se non hai creato un account con il nome utente %(username)s, puoi ignorare "
-"questa email."
+"Se non hai creato un account con il nome utente %(username)s, puoi "
+"ignorare questa email."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "Il team AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Ciao,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
@@ -1023,40 +1734,71 @@ msgstr ""
 "Fai clic sul link qui sotto per reimpostare la tua password. Se non hai "
 "richiesto il reset della password, ignora questa email."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Servizi Account AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "Cerca..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Impostazioni"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Aiuto"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Esci"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Supportato da %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Account AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 "AlmaLinux Accounts consente di creare e gestire il tuo account su tutta "
 "l'infrastruttura di AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
-"Per convalidare l'indirizzo email %(address)s, fare clic sul link qui sotto:"
+"Per convalidare l'indirizzo email %(address)s, fare clic sul link qui "
+"sotto:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
@@ -1065,102 +1807,141 @@ msgstr ""
 "Se non hai impostato l'indirizzo email %(address)s nel tuo account "
 "%(username)s, puoi ignorare questa email."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Il Noggin Team"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Benvenuto in noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Questo è il portale open source e self-service della community per FreeIPA. "
-"Ti consente di fare cose come creare un account, cambiare la password, "
-"gestire l'appartenenza ai gruppi e altro ancora."
+"Questo è il portale open source e self-service della community per "
+"FreeIPA. Ti consente di fare cose come creare un account, cambiare la "
+"password, gestire l'appartenenza ai gruppi e altro ancora."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 "È necessaria una configurazione aggiuntiva quando si utilizzano i ticket "
 "Kerberos con OTP abilitato"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Leggi la <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentazione</a> per i dettagli sulla configurazione del tuo "
-"sistema"
+"Leggi la <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentazione</a> per i dettagli sulla "
+"configurazione del tuo sistema"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Puoi anche usare il tuo account Fedora per accedere qui."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
-"Questo link sarà valido per %(ttl)s minuti (fino alle %(valid_until)s UTC)."
+"Questo link sarà valido per %(ttl)s minuti (fino alle %(valid_until)s "
+"UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Se il link è scaduto, puoi richiederne uno nuovo qui: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora Account System"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora Accounts"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora People"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Fedora Accounts ti consente di creare e gestire un account per gli strumenti "
-"e l’infrastruttura di Fedora."
+"Fedora Accounts ti consente di creare e gestire un account per gli "
+"strumenti e l’infrastruttura di Fedora."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Modifica Gruppo"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
-"Per modificare i dettagli di un gruppo o aggiungere sponsor, apri un ticket "
-"con"
+"Per modificare i dettagli di un gruppo o aggiungere sponsor, apri un "
+"ticket con"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Crea una richiesta PDR per disabilitare il tuo account"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Richiedi la cancellazione dell'account"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Hai perso il tuo ultimo token OTP?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Se hai perso il tuo ultimo token OTP, devi inviare un'email a "
 "%(admin_email)s. Se possibile, firma questa email con la chiave GPG "
 "associata al tuo account, così l'amministratore potrà verificare la tua "
 "identità."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Se avevi più token e ne hai perso uno, puoi usare un altro per accedere ed "
-"eliminare il token perso dal tuo account."
+"Se avevi più token e ne hai perso uno, puoi usare un altro per accedere "
+"ed eliminare il token perso dal tuo account."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
@@ -1168,37 +1949,56 @@ msgstr ""
 "Se non hai registrato un token OTP, non ne possiedi uno e questo non ti "
 "riguarda."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"Per far sapere agli amministratori che non sei uno spammer, invia un’email a "
-"%(email_link)s e spiega la situazione."
+"Per far sapere agli amministratori che non sei uno spammer, invia "
+"un’email a %(email_link)s e spiega la situazione."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Utilizzando un account Fedora, accetti di rispettare il <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-conduct/'>Codice di Condotta di "
-"Fedora</a>."
+"Utilizzando un account Fedora, accetti di rispettare il <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
+"conduct/'>Codice di Condotta di Fedora</a>."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Puoi anche usare il tuo account CentOS per accedere qui."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Il gruppo %(groupname)s non è stato trovato."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Annulla"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s su %(server)s"
@@ -1214,3 +2014,4 @@ msgstr "%(protocol)s su %(server)s"
 
 #~ msgid "Website"
 #~ msgstr "Sito web"
+

--- a/noggin/translations/ja/LC_MESSAGES/messages.po
+++ b/noggin/translations/ja/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Japanese translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: ja\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -886,13 +1071,12 @@ msgid_plural ""
 "Hello %(name)s. Please review the agreements below and then sign them if "
 "you agree with their content."
 msgstr[0] ""
-msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1177,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1189,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1201,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1310,145 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1478,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1491,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1800,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1830,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/ko/LC_MESSAGES/messages.po
+++ b/noggin/translations/ko/LC_MESSAGES/messages.po
@@ -4,1150 +4,1888 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 # simmon <simmon@nplob.com>, 2021.
 # 김인수 <simmon@nplob.com>, 2023, 2025, 2026.
-# Weblate Translation Memory <noreply-mt-weblate-translation-memory@weblate.org>, 2025.
+# Weblate Translation Memory
+# <noreply-mt-weblate-translation-memory@weblate.org>, 2025.
 # Weblate <noreply-mt-weblate@weblate.org>, 2025.
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2026-06-12 16:10+0000\n"
 "Last-Translator: 김인수 <simmon@nplob.com>\n"
-"Language-Team: Korean <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/ko/>\n"
 "Language: ko\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Korean <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/ko/>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 2026.6.1\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "비밀번호가 만료되었습니다 다시 재지정 해주세요."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "IPA 서버로 로그인 할 수 없습니다."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "환영합니다, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "토큰이 성공적으로 동기화 되었습니다"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "사용 가능한 IPA 서버가 없습니다"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "IPA 서버로 로그인 할 수 없습니다."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "비밀번호를 변경 할 수 없습니다, 다시 시도해주세요."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "검증 코드"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "사용자 %(username)s는 시스템에서 찾을 수 없습니다."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "사용자 %(username)s: %(errormessage)s를 추가 할 수 없습니다"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "맞아요! %(username)s 는 %(groupname)s에 추가되었습니다."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "맞아요! %(username)s는 %(groupname)s에서 제거되었습니다."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "맞아요! %(username)s는 %(groupname)s의 후원자가 더 이상 아닙니다."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "오래된 비밀번호 또는 사용자 이름이 정확하지 않습니다"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "비밀번호를 변경 할 수 없습니다."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "당신의 비밀번호가 변경되었습니다"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
-msgstr ""
-"요청한 비밀번호는 재설정은 요청 되었으며, 다른 요청 전에 %(wait_min)s 분과 "
-"%(wait_sec)s 초를 기다려야 합니다."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
+msgstr "요청한 비밀번호는 재설정은 요청 되었으며, 다른 요청 전에 %(wait_min)s 분과 %(wait_sec)s 초를 기다려야 합니다."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "사용자 %(username)s가 존재하지 않습니다"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "전자우편을 발송 할 수 없습니다, 다시 시도해주세요"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "전자우편 주소가 smtp 서버에 의해 거부되었습니다"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
-msgstr ""
-"전자우편은 비밀번호 재설정 방법에 따른 지시와 함께 주소를 보내야 합니다"
+msgstr "전자우편은 비밀번호 재설정 방법에 따른 지시와 함께 주소를 보내야 합니다"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "토큰이 유효하지 않습니다, 새로운 것으로 요청해 주세요."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "토큰이 만료되었습니다, 새로운 것으로 요청해주세요."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
-msgstr ""
-"요청한 이 토큰 이후에 비밀번호는 변경되었습니다, 새로운 것으로 요청해주세요."
+msgstr "요청한 이 토큰 이후에 비밀번호는 변경되었습니다, 새로운 것으로 요청해주세요."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"비밀번호가 변경되었으며, 정책(%(policy_error)s)을 준수하지 않고 따라서 만료"
-"된 것처럼 설정되었습니다. 로그인 후에 이를 변경할지 물어 볼 것입니다."
+"비밀번호가 변경되었으며, 정책(%(policy_error)s)을 준수하지 않고 따라서 만료된 것처럼 설정되었습니다. 로그인 후에 "
+"이를 변경할지 물어 볼 것입니다."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "잘못된 값."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "비밀번호를 변경 할 수 없습니다, 다시 시도해주세요."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "비밀번호가 변경되었습니다."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "전자우편 주소를 확인하세요"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr "주소 확인 전자우편을 발송 할 수 없습니다, 다시 시도해주세요"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
-msgstr ""
-"사용자이름 '%(username)s' 또는 전자우편 주소 '%(email)s은 이미 사용 중입니다."
+msgstr "사용자이름 '%(username)s' 또는 전자우편 주소 '%(email)s은 이미 사용 중입니다."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "계정 생성에 오류가 발생하였습니다, 다시 시도해 주세요."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "등록이 실패한 것으로 보이며, 다시 시도해주세요."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
-msgstr ""
-"주소 확인 전자우편은 다시 보냈습니다. 자신의 스팸 폴더에 위치하지 않았는지 확"
-"인하세요"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
+msgstr "주소 확인 전자우편은 다시 보냈습니다. 자신의 스팸 폴더에 위치하지 않았는지 확인하세요"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "제공된 토큰이 없으며, 자신의 전자우편 검증 연결을 점검해주세요."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "토큰이 유효하지 않으며, 다시 등록해주세요."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "이 토큰이 더 이상 유효하지 않으며, 다시 등록해주세요."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "이 사용자는 찾을 수 없으며, 다시 등록해주세요."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
-msgstr ""
-"사용자이름 및 전자우편 주소는 당신이 사용한 토큰과 일치하지 않으며, 다시 등록"
-"해주세요."
+"The username and the email address don't match the token you used, please"
+" register again."
+msgstr "사용자이름 및 전자우편 주소는 당신이 사용한 토큰과 일치하지 않으며, 다시 등록해주세요."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "자신의 계정을 생성 할 때에 문제가 발생했으며, 다시 시도해 주세요."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"계정이 생성되었습니다, 그러나 당신이 선택한 비밀번호는 정책(%(policy_error)s)"
-"과 함께 적용하지 않으며 만료된 것처럼 설정됩니다. 로그인 후에 이를 변경 할지"
-"에 대해 물어 볼 것입니다."
+"계정이 생성되었습니다, 그러나 당신이 선택한 비밀번호는 정책(%(policy_error)s)과 함께 적용하지 않으며 만료된 것처럼 "
+"설정됩니다. 로그인 후에 이를 변경 할지에 대해 물어 볼 것입니다."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"계정이 생성되었습니다, 오류가 비밀번호(%(message)s) 설정 할 때에 발생하였습니"
-"다. 로그인 후에 이를 변경이 필요 할 수 있습니다."
+"계정이 생성되었습니다, 오류가 비밀번호(%(message)s) 설정 할 때에 발생하였습니다. 로그인 후에 이를 변경이 필요 할 수 "
+"있습니다."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "축하합니다, 당신의 계정이 생성되었습니다! 환영합니다, %(name)s님."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
-msgstr ""
-"축하합니다, 당신의 계정이 생성되었습니다! 계속 진행하기 위하여 로그인 하세요."
+msgstr "축하합니다, 당신의 계정이 생성되었습니다! 계속 진행하기 위하여 로그인 하세요."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "모두"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "알 수 없음"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "스팸 아님"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "스팸"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "대기 중"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "등록은 현재 마감되었습니다."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"전자우편 주소 %(mail)s는 확인하기 위해 필요합니다. 자신의 우편함을 확인하고 "
-"진행하도록 연결에서 눌러주세요. 만약 몇 분 후에 전자우편을 찾을 수 없다면, 자"
-"신의 스팸 폴더를 확인하세요."
+"전자우편 주소 %(mail)s는 확인하기 위해 필요합니다. 자신의 우편함을 확인하고 진행하도록 연결에서 눌러주세요. 만약 몇 분 "
+"후에 전자우편을 찾을 수 없다면, 자신의 스팸 폴더를 확인하세요."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "수정 사항이 없습니다."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "토큰이 유효하지 않습니다, 다시 전자우편을 설정해 주세요."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
-msgstr ""
-"이와 같은 토큰이 더 이상 유효하지 않으며, 다시 전자우편을 설정해 주세요."
+msgstr "이와 같은 토큰이 더 이상 유효하지 않으며, 다시 전자우편을 설정해 주세요."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "이 토큰은 당신의 것이 아닙니다."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "잘못된 비밀번호"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "토큰을 생성 할 수 없습니다."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "토큰이 생성되었습니다."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "토큰 비밀을 찾을 수 없습니다"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "토큰의 이름을 변경 할 수 없습니다."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "죄송합니다, 최근 활동 토큰을 비활성 할 수 없습니다."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "토큰을 비활성화 할 수 없습니다."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "토큰을 활성화 할 수 없습니다. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "죄송합니다, 최근 동작 토큰을 제거 할 수 없습니다."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "토큰을 삭제 할 수 없습니다."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "토큰을 생성 할 수 없습니다."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "토큰의 이름을 변경 할 수 없습니다."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "잘못된 비밀번호"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "OTP 토큰 확인 및 활성화"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "%(username)s를 위해 비밀번호를 재지정합니다"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "합의에 서명 할 수 없습니다 \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "당신은 \"%(name)s\" 합의에 서명했습니다."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "토큰을 삭제 할 수 없습니다."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "토큰이 생성되었습니다."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "이는 유효한 별칭으로 보이지 않습니다."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "이는 유효한 서버 이름으로 보이지 않습니다."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "이름"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "이름은 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "성"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "성은 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "지역설정"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "지역설정은 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "지역설정은 유효한 단축-코드여야 합니다"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "대화 별칭"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "시간대"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "시간대는 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "시간대는 유효한 시간대여야 합니다"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "깃허브 사용자이름"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "깃랩 사용자이름"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "유효한 URL이 필요합니다"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "블로그 URL"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "RSS URL"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "비공개"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
-msgstr ""
-"다른 사용자에게 정보를 제한하고, 자세한 내용은 개인 정보 보호 정책을 참고하세"
-"요."
+msgstr "다른 사용자에게 정보를 제한하고, 자세한 내용은 개인 정보 보호 정책을 참고하세요."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "대명사"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "전자우편 주소"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "전자우편은 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "전자우편은 유효한 주소여야 합니다"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat 버그질라 전자우편"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH 키"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG 키"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "토큰 이름"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "이 토큰을 식별하는 데 도움이 되도록 선택적인 이름을 추가하세요"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "현재 비밀번호를 입력하세요"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "비밀번호를 제공하여야만 합니다"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "우리가 알고 있는 당신인지 재인증 해주세요"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "일회용 비밀번호"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "자신의 일회용 비밀번호를 입력하세요"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "OTP 토큰을 생성합니다"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "토큰 비밀을 찾을 수 없습니다"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "검증 코드"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "당신은 검증 코드를 제공해야 합니다"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "OTP 토큰 확인 및 활성화"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "코드는 잘못되었으며, 다시 시도해주세요."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "토큰은 비워 둘 수 없습니다"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "OTP 토큰을 생성합니다"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "OTP 토큰을 생성합니다"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "현재 비밀번호를 입력하세요"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "비밀번호는 비워 둘 수 없습니다"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "동의는 비워 둘 수 없습니다"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "새로운 사용자 이름은 비워 둘 수 없습니다"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "사용자이름"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "사용자 이름은 비워 둘 수 없습니다"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "사용자이름(또는 전자우편 주소)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "사용자 이름을 제공하여야만 합니다"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "비밀번호"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "로그인"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "새로운 비밀번호"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "비밀번호는 비워 둘 수 없습니다"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "비밀번호가 일치하지 않습니다"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "새로운 비밀번호를 확인합니다"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr "일회용 비밀번호 (만약 자신의 계정이 이-중 인증이 활성화되어 있으면)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "현재 비밀번호"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "현재 비밀번호는 비워 둘 수 없습니다"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "사용자이름 또는 전자우편"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "사용자 이름은 비워 둘 수 없습니다"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr "자신의 비밀번호를 초기화 하려면 사용자이름 또는 전자우편을 입력하세요"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "이들 문자만 허용됩니다: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "본인은 16세 이상입니다"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "당신은 계정을 생성하려면 16세 이상이어야 합니다"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "등록"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "전자우편 재전송"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "강력한 비밀번호를 입력해주세요"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "비밀번호를 확인합니다"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "활성화"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "첫 번째 OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "첫 번째 코드를 제공해야 합니다"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "두 번째 OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "두 번째 코드를 제공해야 합니다"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "토큰 ID"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "해당 도메인에서 전자우편 주소는 허용되지 않습니다"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "대소문자 혼합은 허용되지 않으며, 소문자로 시도하세요."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "입력란은 \"%(pattern)s\"과 일치하지 않아야 합니다."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "해당 페이지를 찾을 수 없습니다."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "동의 보기"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "다시보기"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "사용자 동의를 서명합니다"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "비밀번호를 잃어버렸나요?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "비밀번호 또는 OTP를 잃어버렸나요?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "토큰 동기화"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "이전"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "현재"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "다음"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "그룹"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "사용자"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "비밀번호 복구"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "비밀 번호를 잊어버렸나요?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
-msgstr ""
-"사용자이름 또는 전자우편을 입력하면 다른 지시와 함께 자신의 주소로 전자우편"
-"이 전송됩니다."
+msgstr "사용자이름 또는 전자우편을 입력하면 다른 지시와 함께 자신의 주소로 전자우편이 전송됩니다."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "전송"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "비밀번호 재설정"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "%(username)s를 위해 비밀번호를 재지정합니다"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s 그룹"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "그룹 떠나기"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
-msgstr ""
-"당신은 이 그룹의 후원자이지만, 구성원은 아닙니다. 만약 구성원이 되고자 하면 "
-"자신을 추가하세요."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
+msgstr "당신은 이 그룹의 후원자이지만, 구성원은 아닙니다. 만약 구성원이 되고자 하면 자신을 추가하세요."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "이 그룹에 참가하려면, 그룹 후원자와 접촉하세요."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "후원사"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "후원자가 없습니다"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "구성원"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "사용자 추가..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "아직 구성원이 없습니다."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "그룹 목록"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s 구성원"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "그룹이 없습니다."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "로그인"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA 오류"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "IPA 백엔드에 문제가 발생했으며, 다음에 다시 시도하세요."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
-msgstr ""
-"당신은 또한 <a href=\"%(url)s\">log out</a> 할 수 있고 만약 문제가 지속되면 "
-"다시 로그인하세요."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
+msgstr "당신은 또한 <a href=\"%(url)s\">log out</a> 할 수 있고 만약 문제가 지속되면 다시 로그인하세요."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "만료된 비밀번호를 재설정합니다"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "%(username)s를 위하여 만료된 비밀번호를 재설정합니다"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "비밀번호 변경"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "사용자 등록 중"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "이름:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "전자우편:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "등록됨:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "상태:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "스팸 확인을 위해 대기 중"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "스팸으로 표시되지 않음"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "스팸으로 표시됨"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "스팸 상태를 알 수 없음"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "허용"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "스팸 신고"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "삭제"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
-msgstr ""
-"허용에서 누르기는 해당 사용자에게 검증 전자우편을 보냅니다. 다른 누름단추는 "
-"어떤 것도 보내지 않습니다."
+msgstr "허용에서 누르기는 해당 사용자에게 검증 전자우편을 보냅니다. 다른 누름단추는 어떤 것도 보내지 않습니다."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "현재 이 상태에서 등록 중인 사용자가 없습니다."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "현재 등록 중인 사용자가 없습니다."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "자신의 계정을 활성화합니다"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "계정 생성, 단계 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
-msgstr ""
-"안녕하세요 %(name)s님. 자신의 계정을 활성화 하려면, 비밀번호를 선택해 주세요."
+msgstr "안녕하세요 %(name)s님. 자신의 계정을 활성화 하려면, 비밀번호를 선택해 주세요."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "동의에 서명하세요"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "선택적인 동의 서명하기"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
-msgstr[0] "안녕하세요 %(name)s. 만약 이들 내용에 동의하면 아래 동의를 검토하고 서명해주"
-"세요."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
+msgstr[0] "안녕하세요 %(name)s. 만약 이들 내용에 동의하면 아래 동의를 검토하고 서명해주세요."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "진행"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "건너뛰기"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "당신의 전자우편 주소를 검증합니다"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "계정 생성, 단계 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "%(name)s님 축하합니다, 당신의 계정이 생성되었습니다!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"로그인 하기 전에, 자신의 전자우편 주소: %(mail)s는 검증 할 때에 필요합니다. "
-"자신의 우편함을 확인하고 진행하려면 연결에서 눌러주세요."
+"로그인 하기 전에, 자신의 전자우편 주소: %(mail)s는 검증 할 때에 필요합니다. 자신의 우편함을 확인하고 진행하려면 연결에서"
+" 눌러주세요."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"만약 당신이 몇 분 안에 전자우편을 찾을 수 없으면, 자신의 스팸 폴더를 확인하세"
-"요. 만약 그곳에 있지 않으면, 당신은 아래 누름단추에서 눌러 다른 검증 전자우편"
-"을 요청 할 수 있습니다."
+"만약 당신이 몇 분 안에 전자우편을 찾을 수 없으면, 자신의 스팸 폴더를 확인하세요. 만약 그곳에 있지 않으면, 당신은 아래 "
+"누름단추에서 눌러 다른 검증 전자우편을 요청 할 수 있습니다."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "진행 중에 스팸 확인"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "당신의 계정이 확인 중입니다"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
-msgstr ""
-"로그인 전에, 자신의 계정은 스팸 가능성을 위해 점검이 필요합니다. 이는 몇 초 "
-"정도 밖에 걸리지 않으며, 잠시 기다려 주세요..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
+msgstr "로그인 전에, 자신의 계정은 스팸 가능성을 위해 점검이 필요합니다. 이는 몇 초 정도 밖에 걸리지 않으며, 잠시 기다려 주세요..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "당신의 계정은 관리자 승인이 필요합니다"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "당신의 계정은 관리자에 의해 승인이 필요합니다."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "당신은 결정이 내려 질 때에 전자우편을 받게 됩니다."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "당신의 인내에 감사드립니다."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "당신의 계정이 차단되었습니다"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "당신의 계정이 스팸으로 표시되었습니다."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "문제가 발생했습니다"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "미지원 스팸 상태: %s, 관리자에게 연락해주세요"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "OTP 토큰 동기화"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "OTP 토큰 동기화합니다"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "동기화"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "자신의 전자우편 확인"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
-msgstr ""
-"안녕하세요 %(user_name)s님. 당신의 %(attr_name)s를 %(mail)s로 설정할까요?"
+msgstr "안녕하세요 %(user_name)s님. 당신의 %(attr_name)s를 %(mail)s로 설정할까요?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "취소"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "실행"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "저장"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG 키 ID"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH 공개 키"
 
-msgid "Scan your new token"
-msgstr "새로운 토큰을 조사합니다"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "%(username)s 설정"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
-"새로운 토큰이 준비되었습니다. QR코드 공개를 위하여 아래 누름단추를 선택해주"
-"면 이를 조사합니다."
 
-msgid "Reveal"
-msgstr "공개"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "코드는 잘못되었으며, 다시 시도해주세요."
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
-"또는 QR 코드를 조사 할 수 없는 경우 다음 토큰 URL을 복사하여 붙여 넣기 할 수 "
-"있습니다:"
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
-msgstr ""
-"자신의 응용프로그램에서 토큰을 등록한 후에, 자신의 첫 번째 코드를 생성하고 아"
-"래에 이를 입력하여 확인하세요:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "OTP 토큰을 생성합니다"
 
-msgid "Add OTP Token"
-msgstr "OTP 토큰 추가"
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-"자신의 첫 번째 OTP 토큰 생성하기는 OTP를 사용하여 두 가지 인증을 사용 할 수 "
-"있습니다."
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr "일단 활성화되면, 두 가지 인증은 비활성화 할 수 없습니다."
-
-msgid "OTP Tokens"
-msgstr "OTP 토큰"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr "(이름 없음)"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "OTP 토큰을 갖고 있지 않습니다"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "대기 중"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "비밀번호"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "새로운 토큰을 조사합니다"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr "새로운 토큰이 준비되었습니다. QR코드 공개를 위하여 아래 누름단추를 선택해주면 이를 조사합니다."
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "공개"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr "또는 QR 코드를 조사 할 수 없는 경우 다음 토큰 URL을 복사하여 붙여 넣기 할 수 있습니다:"
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr "자신의 응용프로그램에서 토큰을 등록한 후에, 자신의 첫 번째 코드를 생성하고 아래에 이를 입력하여 확인하세요:"
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "OTP 토큰 추가"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr "자신의 첫 번째 OTP 토큰 생성하기는 OTP를 사용하여 두 가지 인증을 사용 할 수 있습니다."
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr "일단 활성화되면, 두 가지 인증은 비활성화 할 수 없습니다."
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "OTP 토큰"
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "이름변경"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "비활성화"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "활성화"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "OTP 토큰을 갖고 있지 않습니다"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr "자신의 계정에서 두 가지 인증을 활성화 하려면 OTP 토큰을 추가합니다."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "활성화"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "현재 비밀번호"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "스팸 아님"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH 키"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "OTP 토큰을 갖고 있지 않습니다"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr "자신의 계정에서 두 가지 인증을 활성화 하려면 OTP 토큰을 추가합니다."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "아바타 변경"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
-"만약 당신이 기본 서버를 사용하지 않는 경우에 형식은 <code>username</code> 또"
-"는 <code>username:server.name</code> 입니다:"
+"만약 당신이 기본 서버를 사용하지 않는 경우에 형식은 <code>username</code> 또는 "
+"<code>username:server.name</code> 입니다:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "%(title)s 용: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "%(username)s 설정"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "프로파일"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "전자우편"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG 키"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "동의"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "%(username)s를 위한 프로파일"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "프로파일 편집"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "첫 번째 OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "생성일"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "현재 시간"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "대화"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "블로그"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "Red Hat 버그질라"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s 그룹, %(agreementcount)s 동의"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "서명"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "후원사"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "구성원"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "사용자 %(username)s가 존재하지 않습니다"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "안녕하세요 %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
-msgstr ""
-"사용자 이름 %(username)s과 함께 자신의 계정을 활성화 하려면, 아래 연결을 눌러"
-"주세요:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
+msgstr "사용자 이름 %(username)s과 함께 자신의 계정을 활성화 하려면, 아래 연결을 눌러주세요:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
-msgstr ""
-"만약 당신이 사용자이름 %(username)s을 위해 계정을 생성하지 않으면, 이와 같은 "
-"전자우편을 무시 할 수 있습니다."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
+msgstr "만약 당신이 사용자이름 %(username)s을 위해 계정을 생성하지 않으면, 이와 같은 전자우편을 무시 할 수 있습니다."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "알마리눅스 팀"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "안녕,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"자신의 비밀번호를 재지정하려면 아래 연결을 눌러주세요. 만약 당신이 비밀번호 "
-"재지정을 요청하지 않았으면, 이와 같은 전자우편을 무시하세요."
+"자신의 비밀번호를 재지정하려면 아래 연결을 눌러주세요. 만약 당신이 비밀번호 재지정을 요청하지 않았으면, 이와 같은 전자우편을 "
+"무시하세요."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "알마리눅스 계정 서비스"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "검색..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "설정"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "도움말"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "로그 아웃"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "%(noggin_link)s 제공"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "알마리눅스 계정"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
-msgstr ""
-"알마리눅스 계정은 알마리눅스의 전체 기술기반을 통해 자신의 계정을 생성하고 관"
-"리 하도록 능력을 제공합니다."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
+msgstr "알마리눅스 계정은 알마리눅스의 전체 기술기반을 통해 자신의 계정을 생성하고 관리 하도록 능력을 제공합니다."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "전자우편 주소 %(address)s를 확인하려면, 아래 연결을 눌러주세요:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"만약 당신이 자신의 계정 %(username)s의 전자우편 주소%(address)s를 설정하지 않"
-"으면, 이 전자우편을 무시 할 수 있습니다."
+"만약 당신이 자신의 계정 %(username)s의 전자우편 주소%(address)s를 설정하지 않으면, 이 전자우편을 무시 할 수 "
+"있습니다."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin 팀"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "noggin 환영합니다!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"이는 FreeIPA를 위한 개방 자원, 커뮤니티 자체 서비스 포털입니다. 계정생성, 비"
-"밀번호 변경, 그룹 회원권 관리, 다른 것과 같이 할 수 있도록 허용합니다."
+"이는 FreeIPA를 위한 개방 자원, 커뮤니티 자체 서비스 포털입니다. 계정생성, 비밀번호 변경, 그룹 회원권 관리, 다른 것과 "
+"같이 할 수 있도록 허용합니다."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
-msgstr ""
-"추가적인 구성은 OTP가 활성화 되었을 때에 커버러스 티켓을 사용 할 때에 필요합"
-"니다"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
+msgstr "추가적인 구성은 OTP가 활성화 되었을 때에 커버러스 티켓을 사용 할 때에 필요합니다"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"자신의 시스템 구성에 대한 상세한 내용을 위해 <a href='https://"
-"docs.fedoraproject.org/en-US/fedora-accounts/user/#pkinit'>문서</a>를 "
-"읽으세요"
+"자신의 시스템 구성에 대한 상세한 내용을 위해 <a href='https://docs.fedoraproject.org/en-US"
+"/fedora-accounts/user/#pkinit'>문서</a>를 읽으세요"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "당신은 자신의 페도라 계정을 사용하여 이 곳에 로그인 할 수 있습니다."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
-msgstr ""
-"이와 같은 연결은 %(ttl)s 분 동안 유효합니다 (%(valid_until)s UTC 동안)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgstr "이와 같은 연결은 %(ttl)s 분 동안 유효합니다 (%(valid_until)s UTC 동안)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
-msgstr ""
-"만약 연결이 만료되면, 당신은 여기에 새로운 것을 요청을 할 수 있습니다: "
+msgstr "만약 연결이 만료되면, 당신은 여기에 새로운 것을 요청을 할 수 있습니다: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "페도라 계정 시스템"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "페도라 계정"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "위키"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "페도라 사람들"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
-msgstr ""
-"페도라 계정은 페도라 도구 및 인프라를 위한 계정 생성과 관리에 허용됩니다."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
+msgstr "페도라 계정은 페도라 도구 및 인프라를 위한 계정 생성과 관리에 허용됩니다."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "그룹 편집"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
-msgstr ""
-"그룹 상세를 변경하거나 후원을 추가하고자 하려면, 다음으로 티켓을 제출하세요"
+msgstr "그룹 상세를 변경하거나 후원을 추가하고자 하려면, 다음으로 티켓을 제출하세요"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "계정을 비활성화하기 위하여 PDR 요청을 생성합니다"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "계정 삭제를 요청합니다"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "최근 OTP 토큰을 잃어버렸나요?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"만약 최근 OTP 토큰을 잃어 버렸다면 %(admin_email)s로 전자우편을 보내야 합니"
-"다. 당신의 가능한 계정과 관계된 GPG 키를 사용하여 전자우편에 서명해주세요, 그"
-"러면 관리자는 당신의 신원을 증명 할 수 있습니다."
+"만약 최근 OTP 토큰을 잃어 버렸다면 %(admin_email)s로 전자우편을 보내야 합니다. 당신의 가능한 계정과 관계된 GPG"
+" 키를 사용하여 전자우편에 서명해주세요, 그러면 관리자는 당신의 신원을 증명 할 수 있습니다."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"만약 당신이 여러 토큰을 가지고 있고 이 중 하나를 잃어버렸으면, 로그인에 다른 "
-"것을 사용 할 수 있고 자신의 계정에서 분실된 토큰을 삭제해주세요."
+"만약 당신이 여러 토큰을 가지고 있고 이 중 하나를 잃어버렸으면, 로그인에 다른 것을 사용 할 수 있고 자신의 계정에서 분실된 "
+"토큰을 삭제해주세요."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
-msgstr ""
-"만약 당신이 OTP 토큰을 등록하지 않은 경우, 당신이 가지고 있지 않으면 적용하"
-"지 않습니다."
+msgstr "만약 당신이 OTP 토큰을 등록하지 않은 경우, 당신이 가지고 있지 않으면 적용하지 않습니다."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
-msgstr ""
-"당신이 스팸 사용자가 아닌 것으로 관리자에게 알리려면, %(email_link)s에게 전자"
-"우편을 보내고 상태를 설명해주세요."
+msgstr "당신이 스팸 사용자가 아닌 것으로 관리자에게 알리려면, %(email_link)s에게 전자우편을 보내고 상태를 설명해주세요."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"페도라 계정 사용에 의해, 당신은 <a href='https://docs.fedoraproject.org/en-"
-"US/project/code-of-conduct/'>페도라&nbsp;행동&nbsp;강령</a>를 따르는데 동의합"
-"니다."
+"페도라 계정 사용에 의해, 당신은 <a href='https://docs.fedoraproject.org/en-US/project"
+"/code-of-conduct/'>페도라&nbsp;행동&nbsp;강령</a>를 따르는데 동의합니다."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
-msgstr ""
-"당신은 또한 자신의 CentOS 계정을 사용하여 여기에 로그인 할 수 있습니다."
+msgstr "당신은 또한 자신의 CentOS 계정을 사용하여 여기에 로그인 할 수 있습니다."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "그룹 %(groupname)s를 찾을 수 없습니다."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "전자우편 %(username_or_email)s 인 사용자를 찾을 수 없습니다"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "실행 취소"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s (%(server)s의)"
@@ -1177,11 +1915,10 @@ msgstr "%(protocol)s (%(server)s의)"
 #~ msgstr "등록"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
-#~ msgstr ""
-#~ "이는 절대로 다시 보여주지 않을 것이며, 토큰이 저장될 때까지 이 창을 닫지 "
-#~ "않아야 합니다."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
+#~ msgstr "이는 절대로 다시 보여주지 않을 것이며, 토큰이 저장될 때까지 이 창을 닫지 않아야 합니다."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "비밀번호 또는 비밀번호 + 1회용 비밀번호"
@@ -1196,9 +1933,10 @@ msgstr "%(protocol)s (%(server)s의)"
 #~ msgstr "RHBZ 전자우편"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
-#~ msgstr ""
-#~ "이 그룹의 상세 또는 후원을 변경하는 경우 페도라 인프라 티켓을 제출해주세요"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
+#~ msgstr "이 그룹의 상세 또는 후원을 변경하는 경우 페도라 인프라 티켓을 제출해주세요"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "상세 변경을 요청합니다"
@@ -1211,3 +1949,4 @@ msgstr "%(protocol)s (%(server)s의)"
 
 #~ msgid "Website"
 #~ msgstr "웹사이트"
+

--- a/noggin/translations/messages.pot
+++ b/noggin/translations/messages.pot
@@ -1,43 +1,96 @@
 # Translations template for PROJECT.
-# Copyright (C) 2025 ORGANIZATION
+# Copyright (C) 2026 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -138,62 +191,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -201,49 +254,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -251,246 +309,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -499,22 +676,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -522,11 +699,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -550,7 +727,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -558,36 +735,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -628,15 +805,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -650,6 +827,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -872,7 +1057,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -887,11 +1072,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -992,6 +1177,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1002,7 +1189,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1014,8 +1201,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1038,60 +1310,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1121,7 +1479,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1134,45 +1492,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1434,12 +1801,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""

--- a/noggin/translations/my/LC_MESSAGES/messages.po
+++ b/noggin/translations/my/LC_MESSAGES/messages.po
@@ -7,1058 +7,1829 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: my\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: none\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr ""
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr ""
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr ""
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr ""
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr ""
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
+msgstr ""
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/nl/LC_MESSAGES/messages.po
+++ b/noggin/translations/nl/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Dutch translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: nl\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,11 +1073,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1178,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1190,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1202,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1311,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1480,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1493,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1802,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1832,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/pl/LC_MESSAGES/messages.po
+++ b/noggin/translations/pl/LC_MESSAGES/messages.po
@@ -10,682 +10,1089 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2024-05-08 18:36+0000\n"
-"Last-Translator: Weblate Translation Memory <noreply-mt-weblate-translation-"
-"memory@weblate.org>\n"
-"Language-Team: Polish <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/pl/>\n"
+"Last-Translator: Weblate Translation Memory <noreply-mt-weblate-"
+"translation-memory@weblate.org>\n"
 "Language: pl\n"
+"Language-Team: Polish <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/pl/>\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Hasło wygasło. Proszę zresetuj je."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Nie można zalogować do serwera IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Witaj, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token poprawnie zsynchronizowany"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Nie można zalogować do serwera IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Nie można zmienić hasła, spróbuj ponownie później."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Kod weryfikacyjny"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Użytkownik %(username)s nie został znaleziony w systemie."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Nie można dodać użytkownika %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Masz to! %(username)s został dodany do %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Masz to! %(username)s został usunięty z %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Masz to! %(username)s nie jest już sponsorem %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Stare hasło albo nazwa użytkownika jest niepoprawna"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Nie można zmienić hasła."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Twoje hasło zostało zmienione"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Już zażądałeś resetu hasła, musisz odczekać %(wait_min)s minut i "
 "%(wait_sec)s sekund przed następną zmianą."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Użytkownik %(username)s nie istnieje"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Nie możemy wysłać ci maila, spróbuj ponownie później"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Twój adres email został odrzucony przez serwer smtp"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Email z instrukcjami jak zresetować hasło został wysłany na twój adres email"
+"Email z instrukcjami jak zresetować hasło został wysłany na twój adres "
+"email"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Ten token jest niepoprawny, proszę zażądaj nowego."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Ten token wygasł, proszę zażądaj nowego."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Twoje hasło zostało zmienione od żądania tego tokenu, proszę zażądaj nowego."
+"Twoje hasło zostało zmienione od żądania tego tokenu, proszę zażądaj "
+"nowego."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Twoje hasło zostało zmienione, ale nie jest zgodne z polityką "
 "(%(policy_error)s) i przez to zostało ustawione jako wygasłe. Zostaniesz "
 "zapytany o jego zmianę po zalogowaniu."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Niepoprawna wartość."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Nie można zmienić hasła, spróbuj ponownie później."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Twoje hasło zostało zmienione."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Zweryfikuj swój adres email"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 "Nie możemy ci wysłać wiadomości weryfikacyjnej email, spróbuj ponownie "
 "później"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Nazwa użytkownika '%(username)s' albo adres email '%(email)s' zostały już "
-"zajęte."
+"Nazwa użytkownika '%(username)s' albo adres email '%(email)s' zostały już"
+" zajęte."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Wystąpił błąd podczas tworzenia konta, spróbuj ponownie później."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
-msgstr ""
-"Wygląda na to że rejestracja nie powiodła się, spróbuj ponownie później."
+msgstr "Wygląda na to że rejestracja nie powiodła się, spróbuj ponownie później."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"Email weryfikacyjny został ponownie wysłany, upewnij się że nie wylądował w "
-"spamie"
+"Email weryfikacyjny został ponownie wysłany, upewnij się że nie wylądował"
+" w spamie"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "Nie podano tokenu, sprawdź link do aktywacji w swoim emailu."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Ten token jest niepoprawny, proszę zarejestruj się ponownie."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Ten token nie jest już ważny, załóż konto ponownie."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Ten użytkownik nie może być znaleziony, spróbuj ponownie później."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Ta nazwa użytkownika i adres email nie pasują do tokenu który użyłeś, proszę "
-"zarejestruj się ponownie."
+"Ta nazwa użytkownika i adres email nie pasują do tokenu który użyłeś, "
+"proszę zarejestruj się ponownie."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 "Coś poszło nie tak przy tworzeniu twojego konta, proszę spróbuj ponownie "
 "później."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Twoje konto zostało utworzone, ale wybrane przez ciebie hasło nie pasuje do "
-"polityki (%(policy_error)s) i zostało ustawione jako wygasłe. Zostaniesz "
-"poproszony o jego zmianę po zalogowaniu."
+"Twoje konto zostało utworzone, ale wybrane przez ciebie hasło nie pasuje "
+"do polityki (%(policy_error)s) i zostało ustawione jako wygasłe. "
+"Zostaniesz poproszony o jego zmianę po zalogowaniu."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Twoje konto zostało utworzone, ale wystąpił problem przy ustawianiu twojego "
-"hasła (%(message)s). Może być wymagana jego zmiana po zalogowaniu."
+"Twoje konto zostało utworzone, ale wystąpił problem przy ustawianiu "
+"twojego hasła (%(message)s). Może być wymagana jego zmiana po "
+"zalogowaniu."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Gratulacje, twoje konto zostało utworzone! Witaj, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
-msgstr ""
-"Gratulacje, twoje konto zostało utworzone! Zaloguj się aby kontynuować."
+msgstr "Gratulacje, twoje konto zostało utworzone! Zaloguj się aby kontynuować."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Wszystko"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Nieznany"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Nie spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Oczekuje"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Rejestracja jest w tym momencie nieaktywna."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "Adres email %(mail)s musi zostać zweryfikowany. Proszę sprawdź swoją "
-"skrzynkę odbiorczą i kliknij link aby kontynuować. Jeśli nie znajdziesz go w "
-"kilka minut, sprawdź swój folder spam."
+"skrzynkę odbiorczą i kliknij link aby kontynuować. Jeśli nie znajdziesz "
+"go w kilka minut, sprawdź swój folder spam."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Bez zmian."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Ten token jest niepoprawny, proszę ustaw email ponownie."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Ten token nie jest już ważny, proszę ustaw email ponownie."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Ten token nie należy do ciebie."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Niepoprawne hasło"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Nie można utworzyć tego tokenu."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Token został utworzony."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Nie można znaleźć wartości prywatnej tokenu"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Nie można zmienić nazwy tokenu."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Przepraszamy, nie możesz wyłączyć swojego ostatniego aktywnego tokenu."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Nie można wyłączyć tokenu."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Nie można włączyć tokenu. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Przepraszamy, Nie możesz usunąć swojego ostatniego aktywnego tokenu."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Nie można usunąć tokenu."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Nie można utworzyć tego tokenu."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Nie można zmienić nazwy tokenu."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Niepoprawne hasło"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Zweryfikuj i Włącz ten token OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Zresetuj hasło dla %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Nie można podpisać zgody \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Podpisałeś zgodę \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Nie można usunąć tokenu."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Token został utworzony."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "To nie wygląda jak poprawny nick."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "To nie wygląda jak poprawna nazwa serwera."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Imie"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Imie nie może być puste"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Nazwisko"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Nazwisko nie może być puste"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Język"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Język nie może być pusty"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Język musi być poprawnym krótkim-kodem języka"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Nick chatu"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Strefa czasowa"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Strefa czasowa nie może być pusta"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Strefa czasowa musi być poprawną strefą czasową"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nazwa użytkownika GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nazwa Użytkownika GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Wymagany poprawny URL"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Wyloguj"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Prywatne"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Ukryj informacje przed innymi użytkownikami, zobacz naszą Politykę "
 "Prywatności po szczegóły."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Zaimek"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Adres e-mail"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "Email nie może być pusty"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "Email musi być poprawny"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Adres Email Red Hat Bugzilla"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Klucz SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Klucz GPG"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nazwa tokenu"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Dodaj opcjonalną nazwę która pomoże ci zidentyfikować ten token"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Wpisz swoje aktualne hasło"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Musisz podać hasło"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "Proszę zaloguj się ponownie byśmy wiedzieli że to ty"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Hasło jednorazowe"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Wprowadź swoje hasło jednorazowe"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Wygeneruj hasło jednorazowe"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Nie można znaleźć wartości prywatnej tokenu"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Kod weryfikacyjny"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Musisz podać kod weryfikacyjny"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Zweryfikuj i Włącz ten token OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Ten kod jest niepoprawny, spróbuj ponownie później."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Token nie może być pusty"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Wygeneruj hasło jednorazowe"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Wygeneruj hasło jednorazowe"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Wpisz swoje aktualne hasło"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Hasło nie może być puste"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Zgoda nie może być pusta"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Nazwa użytkownika nowego członka nie może być pusta"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Nazwa użytkownika nie może być pusta"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Zweryfikuj swój adres email"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Musisz podać nazwe użytkownika"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Hasło"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Zaloguj"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nowe hasło"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Hasło nie może być puste"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Hasła muszą się zgadzać"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Potwierdź nowe hasło"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 "Kod jednorazowy (jeśli twoje konto ma aktywne uwierzytelnianie "
 "dwuskładnikowe)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Aktualne hasło"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Aktualne hasło nie może być puste"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Nazwa użytkownika"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Nazwa użytkownika nie może być pusta"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Wpisz swoją nazwe użytkownika aby zresetować swoje hasło"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Tyle te znaki są dozwolone: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Mam ponad 16 lat"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Musisz mieć ponad 16 lat aby utworzyć konto"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Zarejestruj"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Ponownie wyślij email"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Proszę wybierz silne hasło"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Potwierdź hasło"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Aktywuj"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Pierwsze OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Musisz podać pierwszy kod"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Drugi kod"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Musisz podać drugi kod"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID Tokenu"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Adresy email z tej domeny nie są dozwolone"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 "Mieszane wielkie i małe litery nie są dozwolone, spróbuj samymi małymi "
 "literami."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Pole nie może być równe \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Ta strona nie została znaleziona."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Zobacz zgodę"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Podpisz zgodę użytkownika"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Zapomniałeś hasła?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Zapomniałeś hasła albo kodu OTP?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Zsynchronizuj token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Poprzednie"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "Aktualne"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Następne"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupy"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Użytkownicy"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Odzyskiwanie hasła"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Czy zapomniałeś hasła?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Wprowadź swoją nazwę użytkownika i email z dalszymi instrukcjami zostanie do "
-"ciebie wysłany."
+"Wprowadź swoją nazwę użytkownika i email z dalszymi instrukcjami zostanie"
+" do ciebie wysłany."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Wyślij"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Zresetuj hasło"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Zresetuj hasło dla %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Grupa %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Opuść grupę"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Jesteś sponsorem tej grupy ale nie jej członkiem. Dodaj siebie jeśli chcesz "
-"być członkiem."
+"Jesteś sponsorem tej grupy ale nie jej członkiem. Dodaj siebie jeśli "
+"chcesz być członkiem."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Aby dołączyć do tej grupy, skontaktuj się z jej sponsorem."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsorzy"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "Brak sponsorów"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Członkowie"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "Dodaj użytkownika..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Na razie nie ma członków."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista Grup"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s członków"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Bez grup."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Logowanie"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Błąd IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Wystąpił problem z backendem IPA, spróbuj ponownie później."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Możesz też <a href=\"%(url)s\">Wylogować się</a> i zalogować się ponownie "
-"jeśli problem dalej trwa."
+"Możesz też <a href=\"%(url)s\">Wylogować się</a> i zalogować się ponownie"
+" jeśli problem dalej trwa."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Wygaśnięte resetowanie hasła"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Wygaśnięte resetowanie hasła dla %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Zmień hasło"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Rejestracja użytkowników"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nazwa:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Email:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Zarejestrowany:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Status:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Oczekiwanie na sprawdzanie spamu"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Nie oznaczone jako spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Oznaczone jako spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Stan spam nieznany"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Akceptuj"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Oznacz jako spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Usuń"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
@@ -693,214 +1100,458 @@ msgstr ""
 "Kliknięcie akceptuj wyślę link weryfikacyjny do tego użytkownika. Inne "
 "przyciski nie wyślą nic."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "W tym momencie brak rejestrujących się użytkowników w tym stanie."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "W tym momencie brak rejestrujących się użytkowników."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Aktywuj swoje konto"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Tworzenie konta, krok 3 z 3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Witaj %(name)s. Aby aktywować konto, wybierz hasło."
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "Podpisz zgodę użytkownika"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Potwierdź swój adres email"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Tworzenie konta, krok 2 z 3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Gratulacje %(name)s, twoje konto zostało utworzone!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"Zanim się zalogujesz, twój adres email: %(mail)s musi zostać zweryfikowany. "
-"Proszę sprawdź swoją skrzynkę odbiorczą i kliknij w link aby kontynuować."
+"Zanim się zalogujesz, twój adres email: %(mail)s musi zostać "
+"zweryfikowany. Proszę sprawdź swoją skrzynkę odbiorczą i kliknij w link "
+"aby kontynuować."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Jeśli nie możesz znaleźć wiadomości email w ciągu kilku minut, sprawdź swój "
-"folder spam. Jeśli jej ta nie ma, możesz wnioskować o następnym email "
-"potwierdzający klikając przycisk poniżej."
+"Jeśli nie możesz znaleźć wiadomości email w ciągu kilku minut, sprawdź "
+"swój folder spam. Jeśli jej ta nie ma, możesz wnioskować o następnym "
+"email potwierdzający klikając przycisk poniżej."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Sprawdzanie spamu w trakcie"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Twoje konto jest sprawdzane"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Zanim się zalogujesz, twoje konto musi zostać sprawdzone na ryzyko spamu. To "
-"powinno zająć tylko kilka sekund, proszę czekać..."
+"Zanim się zalogujesz, twoje konto musi zostać sprawdzone na ryzyko spamu."
+" To powinno zająć tylko kilka sekund, proszę czekać..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Twoje konto wymaga potwierdzenia administratora"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Twoje konto musi zostać potwierdzone przez administratora."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Otrzymasz email zanim decyzja zostanie podjęta."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Dziękujemy za twoją cierpliwość."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Twoje konto jest zablokowane"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Twoje konto zostało oznaczone jako spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Coś poszło nie tak"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Niewspierany stan spamu: %s. proszę skontaktuj się z administratorami"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Zsynchronizuj token OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Synchronizuj token OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Synchronizuj"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Potwierdź swój email"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
-msgstr ""
-"Witaj %(user_name)s. Czy chcesz ustawić swój %(attr_name)s to %(mail)s?"
+msgstr "Witaj %(user_name)s. Czy chcesz ustawić swój %(attr_name)s to %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Anuluj"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Zrób to"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Zapisz"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID klucza GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Klucz publiczny SSH"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Ustawienia dla %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Ten kod jest niepoprawny, spróbuj ponownie później."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Wygeneruj hasło jednorazowe"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(bez nazwy)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Nie masz tokenów OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Oczekuje"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Hasło"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Zeskanuj swój nowy token"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Twój nowy token jest gotowy. Kliknij na przycisk poniżej by pokazać kod QR i "
-"zeskanuj go."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Twój nowy token jest gotowy. Kliknij na przycisk poniżej by pokazać kod "
+"QR i zeskanuj go."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Pokaż"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
-"albo skopiuj i wklej poniższy URL tokenu jeśli nie możesz zeskanować kodu QR:"
+"albo skopiuj i wklej poniższy URL tokenu jeśli nie możesz zeskanować kodu"
+" QR:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
 "Po dodaniu swojego tokenu do aplikacji, zweryfikuj go generując swój "
 "pierwszy kod i podając go poniżej:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Dodaj token OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
-"Tworzenie twojego pierwszego tokenu OTP włącza weryfikacje dwu-etapową przy "
-"użyciu kodu OTP."
+"Tworzenie twojego pierwszego tokenu OTP włącza weryfikacje dwu-etapową "
+"przy użyciu kodu OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr "Po aktywowaniu, weryfikacja dwuetapowa nie może zostać wyłączona."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Tokeny OTP"
 
-msgid "(no name)"
-msgstr "(bez nazwy)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Zmień nazwę"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Wyłącz"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Włącz"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Nie masz tokenów OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr "Dodaj token OTP aby włączyć weryfikacje dwuetapową na swoim koncie."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Aktywuj"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Aktualne hasło"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Nie spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Klucz SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Nie masz tokenów OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr "Dodaj token OTP aby włączyć weryfikacje dwuetapową na swoim koncie."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Zmień awatar"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
 "            Ten format to albo  <code>nazwaużytkownika</code> albo "
@@ -908,277 +1559,425 @@ msgstr ""
 "serwerów:\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              Dla %(title)s: <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Ustawienia dla %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Adresy email"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG Klucze"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Zgody"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil dla %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Edytuj profil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Pierwsze OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Aktualny czas"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chat"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Logowanie"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Grup, %(agreementcount)s Zgód"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "podpisane"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "członek"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Użytkownik %(username)s nie istnieje"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Witaj %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"Aby aktywować swoje konto z nazwą użytkownika %(username)s, kliknij poniższy "
-"link:"
+"Aby aktywować swoje konto z nazwą użytkownika %(username)s, kliknij "
+"poniższy link:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Jeśli nie tworzyłeś konta na nazwę użytkownika %(username)s, możesz "
 "zignorować ten email."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "Zespół AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Witaj,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Kliknij poniższy link aby zresetować swoje hasło. Jeśli nie żądałeś resetu "
-"hasła, proszę zignoruj ten email."
+"Kliknij poniższy link aby zresetować swoje hasło. Jeśli nie żądałeś "
+"resetu hasła, proszę zignoruj ten email."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "System kont AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "Wyszukaj..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Ustawienia"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Pomoc"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Wyloguj"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Zasilane przez %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Konta AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 "Konta AlmaLinux pozwalają ci tworzyć i zarządzać swoim kontem w całej "
 "infrastrukturze AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "Aby zweryfikować swój adres email %(address)s, kliknij poniższy link:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Jeśli nie ustawiałeś adresu email %(address)s w swoim koncie %(username)s, "
-"możesz zignorować tą wiadomość."
+"Jeśli nie ustawiałeś adresu email %(address)s w swoim koncie "
+"%(username)s, możesz zignorować tą wiadomość."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Zespół Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Witaj w noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"To jest otwarto źródłowy, portal społecznościowy self-service dla FreeIPA. "
-"Pozwala ci robić rzeczy jak tworzyć konto, zmieniać swoje hasło, zarządzać "
-"obecnością w grupach, i więcej."
+"To jest otwarto źródłowy, portal społecznościowy self-service dla "
+"FreeIPA. Pozwala ci robić rzeczy jak tworzyć konto, zmieniać swoje hasło,"
+" zarządzać obecnością w grupach, i więcej."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 "Dodatkowa konfiguracja jest wymagana jeśli używane są bilety Kerberos z "
 "włączonym OTP"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Przeczytaj <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/"
-"user/#pkinit'>dokumentacje</a> po szczegóły jak skonfigurować swój system"
+"Przeczytaj <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>dokumentacje</a> po szczegóły jak skonfigurować "
+"swój system"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Możesz też użyć swojego konta Fedora by się tu zalogować."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr "Ten link będzie ważny przez %(ttl)s minut (do %(valid_until)s UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Jeśli ten link wygasł, tutaj możesz wnioskować o nowy: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "System kont Fedora"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Konta Fedory"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Członkowie Fedora"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Konta Fedora pozwalają ci tworzyć i zarządzać kontem dla narzędzi Fedora i "
-"całej infrastruktury."
+"Konta Fedora pozwalają ci tworzyć i zarządzać kontem dla narzędzi Fedora "
+"i całej infrastruktury."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Edytuj grupę"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr "Aby zmienić szczegóły grupy albo dodać sposorów, zgłoś to"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Zrób wniosek PDR aby wyłączyć swoje konto"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Poproś o usunięcie konta"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Czy straciłeś swój ostatni token OTP?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Jeśli zgubiłeś swój ostatni token OTP musisz wysłać email do "
 "%(admin_email)s.\n"
-"Proszę jeśli to możliwe podpisz ten email używając klucz GPG przypisany do "
-"swojego konta aby administrator mógł potwierdzić twoją tożsamość."
+"Proszę jeśli to możliwe podpisz ten email używając klucz GPG przypisany "
+"do swojego konta aby administrator mógł potwierdzić twoją tożsamość."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"jeśli masz wiele tokenów i stracisz jeden, możesz użyć innego do zalogowania "
-"i usunięcia straconego tokenu ze swojego konta."
+"jeśli masz wiele tokenów i stracisz jeden, możesz użyć innego do "
+"zalogowania i usunięcia straconego tokenu ze swojego konta."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
-msgstr ""
-"Jeśli nie pobrałeś tokenu OTP, nie masz żadnego i to ciebie nie dotyczy."
+msgstr "Jeśli nie pobrałeś tokenu OTP, nie masz żadnego i to ciebie nie dotyczy."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"Aby dać znać administratorom że nie jesteś spamerem, proszę wyślij email to "
-"%(email_link)s i wyjaśnij tą sytuacje."
+"Aby dać znać administratorom że nie jesteś spamerem, proszę wyślij email "
+"to %(email_link)s i wyjaśnij tą sytuacje."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Przez używanie konta Fedora, zgadzasz się by przestrzegać <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"Przez używanie konta Fedora, zgadzasz się by przestrzegać <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>&nbsp;Kodeksu&nbsp;Postępowania&nbsp;Fedora</a>."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Możesz też użyć swojego konta CentOS aby się tu zalogować."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Grupa %(groupname)s nie może zostać znaleziona."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Cofnij"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s na %(server)s"
@@ -1194,3 +1993,4 @@ msgstr "%(protocol)s na %(server)s"
 
 #~ msgid "Website"
 #~ msgstr "Strona WWW"
+

--- a/noggin/translations/pt/LC_MESSAGES/messages.po
+++ b/noggin/translations/pt/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Portuguese translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: pt\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n > 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,11 +1073,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1178,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1190,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1202,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1311,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1480,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1493,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1802,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1832,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/noggin/translations/pt_BR/LC_MESSAGES/messages.po
@@ -3,90 +3,167 @@
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2020.
 # Rafael Fontenelle <rafaelff@gnome.org>, 2021, 2026.
-# Weblate Translation Memory <noreply-mt-weblate-translation-memory@weblate.org>, 2026.
+# Weblate Translation Memory
+# <noreply-mt-weblate-translation-memory@weblate.org>, 2026.
 # Weblate <noreply-mt-weblate@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2026-06-14 02:10+0000\n"
 "Last-Translator: Rafael Fontenelle <rafaelff@gnome.org>\n"
-"Language-Team: Portuguese (Brazil) <https://translate.fedoraproject.org/"
-"projects/fedora-infra/noggin/pt_BR/>\n"
 "Language: pt_BR\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Portuguese (Brazil) "
+"<https://translate.fedoraproject.org/projects/fedora-infra/noggin/pt_BR/>"
+"\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2026.6.1\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Senha expirada. Por favor, redefina-a."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Não foi possível se autenticar no servidor IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Bem-vindo, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token sincronizado com sucesso"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Nenhum servidor IPA disponível"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Não foi possível se autenticar no servidor IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Não foi possível alterar a senha, tente novamente."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Código de verificação"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "O usuário %(username)s não foi encontrado no sistema."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Não foi possível adicionar o usuário %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Você conseguiu! %(username)s foi adicionado a %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Você conseguiu! %(username)s foi removido de %(groupname)s."
 
 # | msgid "You got it! %(username)s has been removed from %(groupname)s."
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Você conseguiu! %(username)s não é mais patrocinador de %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "A senha antiga ou nome de usuário antigo não está correto"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Não foi possível alterar a senha."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Sua senha foi alterada"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 "Você já solicitou uma redefinição de senha, você precisa aguardar "
 "%(wait_min)s minuto(s) e %(wait_sec)s segundos antes de solicitar outra."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "O usuário %(username)s não existe"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
-msgstr ""
-"Não foi possível enviar um e-mail para você, tente novamente mais tarde"
+msgstr "Não foi possível enviar um e-mail para você, tente novamente mais tarde"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Seu endereço de e-mail é rejeitado pelo servidor smtp"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
@@ -94,104 +171,125 @@ msgstr ""
 "Um e-mail foi enviado para o seu endereço com instruções sobre como "
 "redefinir sua senha"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "O token é inválido, solicite um novo."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "O token expirou, solicite um novo."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Sua senha foi alterada desde que você solicitou este token, solicite um novo."
+"Sua senha foi alterada desde que você solicitou este token, solicite um "
+"novo."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Sua senha foi alterada, mas não está de acordo com a política "
 "(%(policy_error)s) e, portanto, foi definida como expirada. Você será "
 "solicitado a alterá-lo após a autenticação."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Valor incorreto."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Não foi possível alterar a senha, tente novamente."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Sua senha foi alterada."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifique seu endereço de e-mail"
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Não foi possível enviar um e-mail de validação de endereço para você, tente "
-"novamente mais tarde"
+"Não foi possível enviar um e-mail de validação de endereço para você, "
+"tente novamente mais tarde"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"O nome de usuário \"%(username)s\" ou o endereço de e-mail \"%(email)s\" já "
-"estão sendo usados."
+"O nome de usuário \"%(username)s\" ou o endereço de e-mail \"%(email)s\" "
+"já estão sendo usados."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Ocorreu um erro ao criar a conta, tente novamente."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "O cadastro parece ter falhado, tente novamente."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"O e-mail de validação de endereço foi enviado novamente. Certifique-se de "
-"que ele não está na sua pasta de spam"
+"O e-mail de validação de endereço foi enviado novamente. Certifique-se de"
+" que ele não está na sua pasta de spam"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "Nenhum token fornecido, verifique seu link de validação de e-mail."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "O token é inválido, cadastre novamente."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "O token não é mais válido, cadastre novamente."
 
 # | msgid "Could not change password, please try again."
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Este usuário não foi encontrado, cadastre novamente."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"O nome de usuário e o endereço de e-mail não correspondem ao token que você "
-"usou, cadastre novamente."
+"O nome de usuário e o endereço de e-mail não correspondem ao token que "
+"você usou, cadastre novamente."
 
 # | msgid "An error occurred while creating the account, please try again."
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Algo deu errado enquanto criava sua conta, tente novamente mais tarde."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Sua conta foi criada, mas a senha que você escolheu não está de acordo com a "
-"política (%(policy_error)s) e, portanto, foi definida como expirada. Você "
-"será solicitado a alterá-lo após se autenticar."
+"Sua conta foi criada, mas a senha que você escolheu não está de acordo "
+"com a política (%(policy_error)s) e, portanto, foi definida como "
+"expirada. Você será solicitado a alterá-lo após se autenticar."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
@@ -200,6 +298,7 @@ msgstr ""
 "Sua conta foi criada, mas ocorreu um erro ao definir sua senha "
 "(%(message)s). Pode ser necessário alterá-lo após se autenticar."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Parabéns, sua conta foi criada! Desejamos boas-vindas, %(name)s."
@@ -207,806 +306,1411 @@ msgstr "Parabéns, sua conta foi criada! Desejamos boas-vindas, %(name)s."
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
-"Parabéns, sua conta foi criada! Vá em frente e autentique-se para continuar."
+"Parabéns, sua conta foi criada! Vá em frente e autentique-se para "
+"continuar."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Todos"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Desconhecido"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Não spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Aguardando"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Cadastro está fechado no momento."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "O endereço de e-mail %(mail)s precisa ser validado. Confira sua caixa de "
-"entrada e clique no link para continuar. Se você não conseguir encontrar o e-"
-"mail após alguns minutos, verifique sua pasta de spam."
+"entrada e clique no link para continuar. Se você não conseguir encontrar "
+"o e-mail após alguns minutos, verifique sua pasta de spam."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Nenhuma modificação."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "O token é inválido, defina o e-mail novamente."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Este token é não é mais válido, defina o e-mail novamente."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Este token não pertence a você."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Senha incorreta"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Não foi possível criar o token."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "O token foi criado."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Não foi possível encontrar o segredo do token"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
 # | msgid "Cannot create the token."
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Não foi possível renomear o token."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Desculpe, você não pode desabilitar seu último token ativo."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Não foi possível desabilitar o token."
 
 # | msgid "Cannot disable the token."
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Não foi possível habilitar o token. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Desculpe, você não pode excluir seu último token ativo."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Não foi possível excluir o token."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Não foi possível criar o token."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+# | msgid "Cannot create the token."
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Não foi possível renomear o token."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Senha incorreta"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Verificar e habilitar token OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Redefinição de senha para %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Não foi possível assinar o acordo \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Você assinou o acordo \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Não foi possível excluir o token."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "O token foi criado."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Isso não parece ser um apelido válido."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Isso não parece ser um nome de servidor válido."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Primeiro nome"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "O primeiro nome não pode estar vazio"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Sobrenome"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "O sobrenome não pode estar vazio"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Localidade"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "A localidade não pode estar vazia"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "A localidade deve ser um código curto válido de localidade"
 
 # | msgid "IRC Nickname"
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Apelidos de bate-papo"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Fuso horário"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "O fuso horário não pode estar vazio"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "O fuso horário deve ser um fuso horário válido"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nome de usuário do GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nome de usuário do GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "URL válida necessária"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "URL de blog"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "URL de RSS"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privado"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
-"Oculta informação de outros usuários, veja a Política de Privacidade para "
-"detalhes."
+"Oculta informação de outros usuários, veja a Política de Privacidade para"
+" detalhes."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronomes"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Endereço de e-mail"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "O e-mail não pode estar vazio"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "O e-mail deve ser válido"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "E-mail do Bugzilla da Red Hat"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Chaves SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Chaves GPG"
 
 # | msgid "Token ID"
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Nome do token"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "Adicione um nome opcional para lhe ajudar a identificar este token"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Insira sua senha atual"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Você deve fornecer uma senha"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "autentique-se novamente para que saibamos que é você"
 
 # | msgid "Confirm Password"
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Senha de uso único"
 
 # | msgid "Enter your current password"
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Insira sua senha de uso único"
 
 # | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Gerar token OTP"
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Não foi possível encontrar o segredo do token"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Código de verificação"
 
 # | msgid "You must provide a second code"
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Você deve fornecer um código de verificação"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Verificar e habilitar token OTP"
 
 # | msgid "Could not change password, please try again."
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "O código está incorreto, tente novamente."
 
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "O token não pode estar vazio"
 
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Gerar token OTP"
+
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Gerar token OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Insira sua senha atual"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "A senha não pode estar vazia"
+
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "O acordo não pode estar vazio"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "O nome de usuário do novo membro não pode estar vazio"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nome de usuário"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "O nome de usuário não pode estar vazio"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Nome de usuário (ou endereço de e-mail)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Você deve fornecer um nome de usuário"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Senha"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Iniciar sessão"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nova senha"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "A senha não pode estar vazia"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "As senhas devem ser iguais"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Confirmar nova senha"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 "Senha de uso único (se sua conta tiver autenticação de dois faturas "
 "habilitada)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Senha atual"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "A senha atual não pode estar vazia"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Nome de usuário ou e-mail"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "O nome de usuário não pode estar vazio"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr "Insira seu nome de usuário ou e-mail para redefinir sua senha"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Apenas estes caracteres são permitidos: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Tenho mais de 16 anos"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Você precisa ter mais de 16 anos para criar uma conta"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Cadastrar"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Reenviar e-mail"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Escolha uma senha forte"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Confirmar senha"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Ativar"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Primeiro OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Você deve fornecer um primeiro código"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Segundo OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Você deve fornecer um segundo código"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "ID do token"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Endereços de e-mail deste domínio não são permitidos"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 "Misturar letras maiúsculas e minúsculas não é permitido, tente somente "
 "minúsculas."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "O campo não pode corresponder a \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Essa página não foi encontrada."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Ver o acordo"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "Revisar"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Assinar acordo de usuário"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Esqueceu a senha?"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Esqueceu a senha ou OTP?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sincronizar token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Anterior"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "atual"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Próximo"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupos"
 
 # | msgid "Username"
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Usuários"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Recuperação de senha"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Não se lembra da sua senha?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Insira seu nome de usuário ou endereço de e-mail, e um e-mail será enviado "
-"para seu endereço com mais instruções."
+"Insira seu nome de usuário ou endereço de e-mail, e um e-mail será "
+"enviado para seu endereço com mais instruções."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Enviar"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Redefinir senha"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Redefinição de senha para %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Grupo %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Abandonar grupo"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Você é um patrocinador deste grupo, mas não um membro. Adicione a si próprio "
-"se quiser ser um membro."
+"Você é um patrocinador deste grupo, mas não um membro. Adicione a si "
+"próprio se quiser ser um membro."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
-msgstr ""
-"Para ingressar neste grupo, entre em contato com um patrocinador do grupo."
+msgstr "Para ingressar neste grupo, entre em contato com um patrocinador do grupo."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "sem patrocinadores"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Membros"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "adicionar usuário..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Ainda sem membros."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista de grupos"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s membros"
 
 # | msgid "Groups"
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Nenhum grupo."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Iniciar sessão"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Erro no IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Houve um problema com o backend IPA, tente novamente mais tarde."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Você também pode <a href=\"%(url)s\">encerrar a sessão</a> e se autenticar "
-"novamente se o problema persistir."
+"Você também pode <a href=\"%(url)s\">encerrar a sessão</a> e se "
+"autenticar novamente se o problema persistir."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Redefinição de senha expirada"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Redefinição de senha expirada para %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Alterar senha"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Usuários cadastrados"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Nome:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "E-mail:"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Cadastrado:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Status:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Aguardando por verificação de spam"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Não sinalizado como spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Sinalizado como spam"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Status de spam desconhecido"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Aceitar"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Sinalizar como spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Excluir"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Clicar em Aceitar vai enviar o e-mail de validação a este usuário. Outros "
-"botões não enviarão nada."
+"Clicar em Aceitar vai enviar o e-mail de validação a este usuário. Outros"
+" botões não enviarão nada."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Não há usuário cadastrado neste estado no momento."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Não há usuário cadastrado no momento."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Ative sua conta"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Criação da conta, passo 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Olá, %(name)s. Para ativar sua conta, defina uma senha."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Assinar acordos"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "Assinatura de acordo opcional"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 "Olá, %(name)s. Revise o acordo abaixo e assine-o se você concordar seu "
 "conteúdo."
 msgstr[1] ""
-"Olá, %(name)s. Revise os acordos abaixo e assine-os se você concordar seu "
-"conteúdo."
+"Olá, %(name)s. Revise os acordos abaixo e assine-os se você concordar seu"
+" conteúdo."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Continuar"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Ignorar"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Valide seu endereço e-mail"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Criação da conta, passo 2/3"
 
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Parabéns, %(name)s! Sua conta foi criada!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 "Antes que você possa iniciar uma sessão, seu endereço de e-mail %(mail)s "
 "precisa ser validado. Confira sua caixa de entrada e clique no link para "
 "continuar."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Se você não conseguir encontrar o e-mail após alguns minutos, confira sua "
-"pasta de spam. Se não estiver lá, você pode pedir outro e-mail de validação "
-"clicando no botão abaixo."
+"Se você não conseguir encontrar o e-mail após alguns minutos, confira sua"
+" pasta de spam. Se não estiver lá, você pode pedir outro e-mail de "
+"validação clicando no botão abaixo."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Verificação de spam em progresso"
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Sua conta está sendo verificada"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Antes que você possa iniciar uma sessão, sua conta precisa ser verificada "
-"por probabilidade de spam. Isso só vai levar alguns minutos, por favor "
+"Antes que você possa iniciar uma sessão, sua conta precisa ser verificada"
+" por probabilidade de spam. Isso só vai levar alguns minutos, por favor "
 "aguarde..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Sua conta requer aprovação de admin"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Sua conta precisa ser aprovada por um administrador."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Você vai receber um e-mail quando a decisão tiver sido tomada."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Obrigado por sua paciência."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Sua conta está bloqueada"
 
 # | msgid "Your password has been changed."
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Sua conta foi sinalizada como spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Alguma coisa deu errado"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Status de spam sem suporte: %s, contate os administradores"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sincronizar token OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sincronizar token OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sincronizar"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Valide seu e-mail"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
-msgstr ""
-"Olá, %(user_name)s. Você deseja definir seu %(attr_name)s para %(mail)s?"
+msgstr "Olá, %(user_name)s. Você deseja definir seu %(attr_name)s para %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Faça isso"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Salvar"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "ID da chave GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Chave pública SSH"
 
-msgid "Scan your new token"
-msgstr "Ler seu novo token"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Configurações para %(username)s"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
-"Seu novo token está pronto. Clique no botão abaixo para revelar o código QR "
-"e lê-lo."
 
-msgid "Reveal"
-msgstr "Revelar"
+# | msgid "Could not change password, please try again."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "O código está incorreto, tente novamente."
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
-"ou copie e cole a seguinte URL de token se você não consegue ler o código QR:"
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
-msgstr ""
-"Após cadastrar o token em seu aplicativo, verifique-o gerando seu primeiro "
-"código e inserindo-o abaixo:"
+# | msgid "Sync OTP Token"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Gerar token OTP"
 
-msgid "Add OTP Token"
-msgstr "Adicionar token OTP"
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-"Criar seu primeiro token OTP habilita autenticação de dois fatores usando "
-"OTP."
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-"Uma vez habilitada, a autenticação de dois fatores não pode ser desabilitada."
-
-msgid "OTP Tokens"
-msgstr "Token OTP"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr "(sem nome)"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Você tem nenhum token OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Aguardando"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Senha"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "Ler seu novo token"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Seu novo token está pronto. Clique no botão abaixo para revelar o código "
+"QR e lê-lo."
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "Revelar"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+"ou copie e cole a seguinte URL de token se você não consegue ler o código"
+" QR:"
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+"Após cadastrar o token em seu aplicativo, verifique-o gerando seu "
+"primeiro código e inserindo-o abaixo:"
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "Adicionar token OTP"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+"Criar seu primeiro token OTP habilita autenticação de dois fatores usando"
+" OTP."
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+"Uma vez habilitada, a autenticação de dois fatores não pode ser "
+"desabilitada."
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "Token OTP"
+
 # | msgid "Username"
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Renomear"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Desabilitar"
 
 # | msgid "Disable"
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Habilitar"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Você tem nenhum token OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 "Adicione um token OTP para habilitar autenticação de dois faturas em sua "
 "conta."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Ativar"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Senha atual"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Não spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Chaves SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Você tem nenhum token OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Adicione um token OTP para habilitar autenticação de dois faturas em sua "
+"conta."
+
 # | msgid "Change Password"
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Alterar avatar"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "O formato é <code>nome-do-usuário</code> ou <code>nome-do-"
-"usuário:nome.do.servidor</code>, se você não estiver usando os servidores "
-"padrões:"
+"usuário:nome.do.servidor</code>, se você não estiver usando os servidores"
+" padrões:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "Para %(title)s: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Configurações para %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Perfil"
 
 # | msgid "E-mail Address"
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "E-mails"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Chaves SSH &amp; GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Acordos"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Perfil para %(username)s"
 
 # | msgid "Profile"
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Editar perfil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Primeiro OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Criado em"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Hora atual"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Bate-papo"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blog"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s grupo(s), %(agreementcount)s acordo(s)"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "assinado"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "patrocionador"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "membro"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "O usuário %(username)s não existe"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Bem-vindo %(name)s,"
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 "Para ativar sua conta com o nome de usuário %(username)s, clique no link "
 "abaixo:"
@@ -1014,65 +1718,106 @@ msgstr ""
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "Se você não criou uma conta para o nome de usuário %(username)s, pode "
 "ignorar este e-mail."
 
 # | msgid "The Noggin team"
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "A equipe do AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Olá,"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Clique no link abaixo para redefinir sua senha. Se você não solicitou uma "
-"redefinição de senha, pode ignorar este e-mail."
+"Clique no link abaixo para redefinir sua senha. Se você não solicitou uma"
+" redefinição de senha, pode ignorar este e-mail."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Serviços de conta do AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "procurar..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Configurações"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Ajuda"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Encerrar sessão"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Desenvolvido com %(noggin_link)s"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Contas AlmaLinux"
 
 # | msgid ""
 # | "Fedora Accounts allows you to create and manage an account for Fedora "
 # | "Tools and Infrastructure."
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Contas AlmaLinux oferece a possibilidade de criar e gerenciar sua conta em "
-"toda a infraestrutura do AlmaLinux."
+"Contas AlmaLinux oferece a possibilidade de criar e gerenciar sua conta "
+"em toda a infraestrutura do AlmaLinux."
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "Para validar o endereço de e-mail %(address)s, clique no link abaixo:"
@@ -1080,91 +1825,130 @@ msgstr "Para validar o endereço de e-mail %(address)s, clique no link abaixo:"
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Se você não solicitou o endereço de e-mail %(address)s em sua conta %"
-"(username)s, pode ignorar este e-mail."
+"Se você não solicitou o endereço de e-mail %(address)s em sua conta "
+"%(username)s, pode ignorar este e-mail."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "A equipe do Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Bem-vindo ao noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 "Este é o portal de código aberto de autoatendimento da comunidade para "
-"FreeIPA. Ele permite que você crie uma conta, altere sua senha, gerencie a "
-"associação ao grupo e muito mais."
+"FreeIPA. Ele permite que você crie uma conta, altere sua senha, gerencie "
+"a associação ao grupo e muito mais."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"Configuração adicional é exigida ao usar tickets do Kerberos quando senha de "
-"uso única (OTP) está habilitada"
+"Configuração adicional é exigida ao usar tickets do Kerberos quando senha"
+" de uso única (OTP) está habilitada"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Leia a <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentação</a> para detalhes sobre a configuração do seu sistema"
+"Leia a <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentação</a> para detalhes sobre a "
+"configuração do seu sistema"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Você também pode usar sua conta Fedora para iniciar sessão aqui."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr "Este link será válido por %(ttl)s minutos (até %(valid_until)s UTC)."
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Se o link tiver expirado, você pode solicitar um novo aqui: "
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Sistema de Contas do Fedora"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Contas Fedora"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora People"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Contas Fedora oferece a possibilidade de criar e gerenciar sua conta para "
-"Ferramenta e Infraestrutura do Fedora."
+"Contas Fedora oferece a possibilidade de criar e gerenciar sua conta para"
+" Ferramenta e Infraestrutura do Fedora."
 
 # | msgid "Groups"
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Editar grupo"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
-"Para alterar os detalhes de grupo ou adicionar patrocinadores, registre um "
-"ticket com"
+"Para alterar os detalhes de grupo ou adicionar patrocinadores, registre "
+"um ticket com"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Criar uma solicitação de PDR para desativar sua conta"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Solicitar exclusão de conta"
 
 # | msgid "Did you lose your OTP token?"
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Você perdeu seu último token OTP?"
 
@@ -1174,23 +1958,28 @@ msgstr "Você perdeu seu último token OTP?"
 # "
 # | "your account if possible, so that the administrator can verify your "
 # | "identity."
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"Se você perdeu seu último token OTP, você precisa enviar um e-mail para %"
-"(admin_email)s. Assine este e-mail usando a chave GPG associada à sua conta, "
-"se possível, para que o administrador possa verificar sua identidade."
+"Se você perdeu seu último token OTP, você precisa enviar um e-mail para "
+"%(admin_email)s. Assine este e-mail usando a chave GPG associada à sua "
+"conta, se possível, para que o administrador possa verificar sua "
+"identidade."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Se você tinha vários tokens e perdeu um, você pode usar outro para iniciar "
-"uma sessão e excluir o token perdido de sua conta."
+"Se você tinha vários tokens e perdeu um, você pode usar outro para "
+"iniciar uma sessão e excluir o token perdido de sua conta."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
@@ -1198,37 +1987,56 @@ msgstr ""
 "Se você não cadastrou um token OTP, então você não tem um e isso não se "
 "aplica a você."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"Para deixar os administradores saberem que você não é um spammer, envie um e-"
-"mail para %(email_link)s e explique a situação."
+"Para deixar os administradores saberem que você não é um spammer, envie "
+"um e-mail para %(email_link)s e explique a situação."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Ao usar uma conta Fedora, você concorda em seguir o <a href='https://"
-"docs.fedoraproject.org/pt_BR/project/code-of-conduct/'>"
-"Código&nbsp;de&nbsp;Conduta&nbsp;do&nbsp;Fedora</a>."
+"Ao usar uma conta Fedora, você concorda em seguir o <a "
+"href='https://docs.fedoraproject.org/pt_BR/project/code-of-"
+"conduct/'>Código&nbsp;de&nbsp;Conduta&nbsp;do&nbsp;Fedora</a>."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Você também pode user sua conta CentOS para iniciar sessão aqui."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "O grupo %(groupname)s não foi encontrado."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "Não foi encontrado um usuário com o e-mail %(username_or_email)s"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Desfazer"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s em %(server)s"
@@ -1255,11 +2063,13 @@ msgstr "%(protocol)s em %(server)s"
 #~ msgstr "Registro"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Isso nunca será mostrado a você novamente, não feche esta janela até que "
-#~ "seu token seja salvo."
+#~ "Isso nunca será mostrado a você "
+#~ "novamente, não feche esta janela até "
+#~ "que seu token seja salvo."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Senha ou Senha + Senha de uso único (OTP)"
@@ -1274,10 +2084,14 @@ msgstr "%(protocol)s em %(server)s"
 #~ msgstr "E-Mail RHBZ"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "preencha um tíquete no Fedora Infra para alterar os detalhes ou "
+#~ "preencha um tíquete no Fedora Infra "
+#~ "para alterar os detalhes ou "
 #~ "patrocinadores deste grupo"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Solicitar alteração de detalhes"
+

--- a/noggin/translations/pt_PT/LC_MESSAGES/messages.po
+++ b/noggin/translations/pt_PT/LC_MESSAGES/messages.po
@@ -8,198 +8,298 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2024-05-25 17:36+0000\n"
 "Last-Translator: Hugo Costa <hugo.a.costa@outlook.pt>\n"
-"Language-Team: Portuguese (Portugal) <https://translate.fedoraproject.org/"
-"projects/fedora-infra/noggin/pt_PT/>\n"
 "Language: pt_PT\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Portuguese (Portugal) "
+"<https://translate.fedoraproject.org/projects/fedora-infra/noggin/pt_PT/>"
+"\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Palavra-passe expirada. Por favor, reinicie-a."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Não foi possível iniciar a sessão no servidor IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Bem-vindo %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Código sincronizado com sucesso"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Não foi possível iniciar a sessão no servidor IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Não foi possível alterara a palavra-passe. Por favor, tente novamente."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "O utilizador %(username)s não foi encontrado no sistema."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Não é possível adicionar o utilizador %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Você entendeu! %(username)s foi adicionado a %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Você entendeu! %(username)s foi removido de %(groupname)s."
 
 # | msgid "You got it! %(username)s has been removed from %(groupname)s."
+#: noggin/controller/group.py:194
 #, fuzzy, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Você entendeu! %(username)s foi removido de %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "A palavra-passe antiga ou o nome de utilizador não está correto"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Não foi possível alterar a palavra-passe."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "A sua palavra-passe foi alterada"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Já solicitou uma redefinição da palavra-passe, tem de aguardar %(wait_min)s "
-"minuto(s) e %(wait_sec)s segundo(s) antes de poder solicitar outra."
+"Já solicitou uma redefinição da palavra-passe, tem de aguardar "
+"%(wait_min)s minuto(s) e %(wait_sec)s segundo(s) antes de poder solicitar"
+" outra."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "O utilizador %(username)s não existe"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
-"Não nos foi possível enviar um ''e-mail''. Por favor, tente novamente mais "
-"tarde"
+"Não nos foi possível enviar um ''e-mail''. Por favor, tente novamente "
+"mais tarde"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Foi enviado um ''e-mail'' para o seu endereço com as instruções sobre como "
-"redefinir a sua palavra-passe"
+"Foi enviado um ''e-mail'' para o seu endereço com as instruções sobre "
+"como redefinir a sua palavra-passe"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "O código era inválido. Por favor, solicite um novo."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "O código expirou. Por favor, solicite um novo."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"A sua palavra-passe foi alterada desde que solicitou este código. Por favor, "
-"solicite um novo."
+"A sua palavra-passe foi alterada desde que solicitou este código. Por "
+"favor, solicite um novo."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"A sua palavra-passe foi alterada, mas esta não está de acordo com a política "
-"(%(policy_error)s) e, por isso, foi definida como expirada. Ser-lhe-rá "
-"solicitado para a alterar depois de iniciar a sessão."
+"A sua palavra-passe foi alterada, mas esta não está de acordo com a "
+"política (%(policy_error)s) e, por isso, foi definida como expirada. Ser-"
+"lhe-rá solicitado para a alterar depois de iniciar a sessão."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Valor incorreto."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Não foi possível alterara a palavra-passe. Por favor, tente novamente."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "A sua palavra-passe foi alterada."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 #, fuzzy
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Não nos foi possível enviar um ''e-mail''. Por favor, tente novamente mais "
-"tarde"
+"Não nos foi possível enviar um ''e-mail''. Por favor, tente novamente "
+"mais tarde"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Ocorreu um erro enquanto criava a conta. Por favor, tente novamente."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 #, fuzzy
 msgid "The token is invalid, please register again."
 msgstr "O código era inválido. Por favor, solicite um novo."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 #, fuzzy
 msgid "This token is no longer valid, please register again."
 msgstr "O código era inválido. Por favor, solicite um novo."
 
 # | msgid "Could not change password, please try again."
+#: noggin/controller/registration.py:228
 #, fuzzy
 msgid "This user cannot be found, please register again."
 msgstr "Não foi possível alterara a palavra-passe. Por favor, tente novamente."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
 # | msgid "An error occurred while creating the account, please try again."
+#: noggin/controller/registration.py:262
 #, fuzzy
-msgid ""
-"Something went wrong while creating your account, please try again later."
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Ocorreu um erro enquanto criava a conta. Por favor, tente novamente."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "A sua conta foi criada, mas a palavra-passe que escolheu não está em "
-"conformidade com a política %(policy_error)s, e por isso, foi definida como "
-"expirada. Ser-lhe-á solicitado para a alterar depois de iniciar a sessão."
+"conformidade com a política %(policy_error)s, e por isso, foi definida "
+"como expirada. Ser-lhe-á solicitado para a alterar depois de iniciar a "
+"sessão."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"A sua conta foi criada, mas ocorreu um erro enquanto definia a sua palavras-"
-"passe (%(message)s). Poderá ser necessário alterá-la depois de iniciar a "
-"sessão."
+"A sua conta foi criada, mas ocorreu um erro enquanto definia a sua "
+"palavras-passe (%(message)s). Poderá ser necessário alterá-la depois de "
+"iniciar a sessão."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
@@ -207,843 +307,1478 @@ msgstr ""
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/controller/registration.py:330
 #, fuzzy
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "Parabéns, agora tem conta! Continue e inicie a sessão para prosseguir."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 #, fuzzy
 msgid "The token is invalid, please set the email again."
 msgstr "O código era inválido. Por favor, solicite um novo."
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 #, fuzzy
 msgid "This token is no longer valid, please set the email again."
 msgstr "O código era inválido. Por favor, solicite um novo."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Palavra-passe incorreta"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Não pode criar o código."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Não foi possível encontrar o segredo do código"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
 # | msgid "Cannot create the token."
+#: noggin/controller/user.py:606
 #, fuzzy
 msgid "Cannot rename the token."
 msgstr "Não pode criar o código."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Desculpe, não pode desativar o seu último código ativo."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Não pode desativar o código."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Não pode ativar o código.%(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Desculpe, não pode eliminar o seu último código ativo."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Não pode eliminar o código."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Não pode criar o código."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+# | msgid "Cannot create the token."
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Não pode criar o código."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Palavra-passe incorreta"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Não pode eliminar o código."
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "redefinição de Palavra-passe para %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Não pode eliminar o código."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "A sua palavra-passe foi alterada."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Primeiro Nome"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "O primeiro nome não deve estar em branco"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Último Nome"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "O último nome não deve estar em branco"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Idioma"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "O idioma não deve estar em branco"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "O idioma deve ser um código curto válido do idioma"
 
 # | msgid "IRC Nickname"
+#: noggin/form/edit_user.py:111
 #, fuzzy
 msgid "Chat Nicknames"
 msgstr "Apelido de IRC"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Zona Horária"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "A zona horária não deve estar em branco"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "A zona horária deve ser uma válida"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Nome de Utilizador do GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Nome de Utilizador do GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Terminar Sessão"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronomes"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Endereço de E-mail"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "O ''e-mail'' não deve estar em branco"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "O ''e-mail'' deve ser válido"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "E-mail de Bugzilla Red Hat"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Chaves SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Chaves GPG"
 
 # | msgid "Token ID"
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 #, fuzzy
 msgid "Token name"
 msgstr "Id. do Código"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Insira a sua palavra-passe atual"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Deve fornecer uma palavra-passe"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
 # | msgid "Confirm Password"
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 #, fuzzy
 msgid "One-Time Password"
 msgstr "Confirmar Palavra-passe"
 
 # | msgid "Enter your current password"
+#: noggin/form/edit_user.py:206
 #, fuzzy
 msgid "Enter your One-Time Password"
 msgstr "Insira a sua palavra-passe atual"
 
 # | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:209
 #, fuzzy
 msgid "Generate OTP Token"
 msgstr "Sincronizar Código OTP"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Não foi possível encontrar o segredo do código"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
 # | msgid "You must provide a second code"
+#: noggin/form/edit_user.py:223
 #, fuzzy
 msgid "You must provide a verification code"
 msgstr "Deve fornecer um segundo código"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
 # | msgid "Could not change password, please try again."
+#: noggin/form/edit_user.py:230
 #, fuzzy
 msgid "The code is wrong, please try again."
 msgstr "Não foi possível alterara a palavra-passe. Por favor, tente novamente."
 
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 #, fuzzy
 msgid "Token must not be empty"
 msgstr "o código não deve estar em branco"
 
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Sincronizar Código OTP"
+
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Sincronizar Código OTP"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Insira a sua palavra-passe atual"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "A palavra-passe não deve estar em branco"
+
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:285
 #, fuzzy
 msgid "Agreement must not be empty"
 msgstr "o código não deve estar em branco"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "O nome de utilizador do novo membro não deve estar em branco"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Nome de utilizador"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "O nome de utilizador não deve estar em branco"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Endereço de E-mail"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Deve fornecer um nome de utilizador"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Palavra-passe"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Iniciar Sessão"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nova Palavra-passe"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "A palavra-passe não deve estar em branco"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "As palavras-passe devem coincidir"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Confirmar Nova Palavra-passe"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Palavra-passe Atual"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "A palavra-passe atual não deve estar em branco"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Nome de utilizador"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "O nome de utilizador não deve estar em branco"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Insira o seu nome de utilizador para redefinir a sua palavra-passe"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registar"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Por favor, escolha uma palavra-passe forte"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Confirmar Palavra-passe"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Primeiro OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Deve fornecer um primeiro código"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Segundo OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Deve fornecer um segundo código"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Id. do Código"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Essa página não foi encontrada."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:21
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "Não se lembra da palavra-passe?"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:23
 #, fuzzy
 msgid "Forgot Password or OTP?"
 msgstr "Não se lembra da palavra-passe?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Sincronizar Código"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupos"
 
 # | msgid "Username"
+#: noggin/templates/base.html:29
 #, fuzzy
 msgid "Users"
 msgstr "Nome de utilizador"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Recuperação de Palavra-passe"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Não se lembra da sua palavra-passe?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Insira o seu nome de utilizador e ser-lhe-á enviado um ''e-mail'' para o seu "
-"endereço com mais instruções."
+"Insira o seu nome de utilizador e ser-lhe-á enviado um ''e-mail'' para o "
+"seu endereço com mais instruções."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Enviar"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Redefinir Palavra-passe"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "redefinição de Palavra-passe para %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Grupo %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Para se juntar a este grupo, contacte o patrocinador do grupo."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Patrocinadores"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "sem partocinadores"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Membros"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "adicionar utilizador..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Ainda sem membros."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Lista de Grupos"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s membro(s)"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Sem grupos."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Iniciar sessão"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Redefinição de Palavra-passe Expirada"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Redefinição de Palavra-passe Expirada para %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Alterar Palavra-passe"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 #, fuzzy
 msgid "Registering Users"
 msgstr "Registar"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Registados:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/templates/registration-confirmation.html:16
 #, fuzzy, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Parabéns, agora tem conta! Continue e inicie a sessão para prosseguir."
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 #, fuzzy
 msgid "Your account is being checked"
 msgstr "A sua palavra-passe foi alterada"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
 # | msgid "Your password has been changed."
+#: noggin/templates/registration-spamcheck-wait.html:32
 #, fuzzy
 msgid "Your account has been flagged as spam."
 msgstr "A sua palavra-passe foi alterada."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Sincronizar Código OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Sincronizar Código OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Sincronizar"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Guardar"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "Id. da Chave PGP"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Chave Pública SSH"
 
-msgid "Scan your new token"
-msgstr "Digitalize o seu novo código"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Definições para %(username)s"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
-"O seu novo código está pronto. Clique no botão abaixo para revelar o código "
-"QR e digitalize-o."
 
-msgid "Reveal"
-msgstr "Revelar"
+# | msgid "Could not change password, please try again."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Não foi possível alterara a palavra-passe. Por favor, tente novamente."
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr ""
-"ou copie e cole o seguinte URL do código se não pode digitalizar o código QR:"
-
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr "Adicionar Código OTP"
+# | msgid "Sync OTP Token"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Sincronizar Código OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr "Códigos OTP"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Não tem códigos OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Palavra-passe"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "Digitalize o seu novo código"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"O seu novo código está pronto. Clique no botão abaixo para revelar o "
+"código QR e digitalize-o."
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "Revelar"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+"ou copie e cole o seguinte URL do código se não pode digitalizar o código"
+" QR:"
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "Adicionar Código OTP"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "Códigos OTP"
+
 # | msgid "Username"
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 #, fuzzy
 msgid "Rename"
 msgstr "Nome de utilizador"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Desativar"
 
 # | msgid "Disable"
+#: noggin/templates/user-settings-otp.html:157
 #, fuzzy
 msgid "Enable"
 msgstr "Desativar"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Não tem códigos OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Guardar"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Palavra-passe Atual"
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Chaves SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Não tem códigos OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
 # | msgid "Change Password"
+#: noggin/templates/user-settings-profile.html:12
 #, fuzzy
 msgid "Change Avatar"
 msgstr "Alterar Palavra-passe"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Definições para %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Perfil"
 
 # | msgid "E-mail Address"
+#: noggin/templates/user-settings.html:22
 #, fuzzy
 msgid "Emails"
 msgstr "Endereço de E-mail"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Chaves GPG e SSH"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Perfil para %(username)s"
 
 # | msgid "Profile"
+#: noggin/templates/user.html:17
 #, fuzzy
 msgid "Edit Profile"
 msgstr "Perfil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Primeiro OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Iniciar sessão"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "patrocinador"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "membro"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "O utilizador %(username)s não existe"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Bem-vindo %(name)s,"
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, fuzzy, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr "Para redefinir a sua palavra-passe, clique na hiperligação abaixo:"
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, fuzzy, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este ''e-"
-"mail''."
+"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este "
+"''e-mail''."
 
 # | msgid "The Noggin team"
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "The AlmaLinux Team"
 msgstr "A equipa Noggin"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 #, fuzzy
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este ''e-"
-"mail''."
+"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este "
+"''e-mail''."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "procurar..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Definições"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Terminar Sessão"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Desenvolvido por %(noggin_link)s"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/almalinux/templates/main.html:88
 #, fuzzy
 msgid "AlmaLinux Accounts"
 msgstr "Contas Fedora"
@@ -1051,15 +1786,20 @@ msgstr "Contas Fedora"
 # | msgid ""
 # | "Fedora Accounts allows you to create and manage an account for Fedora "
 # | "Tools and Infrastructure."
+#: noggin/themes/almalinux/templates/main.html:90
 #, fuzzy
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Contas Fedora permite-lhe criar e gerir uma conta para a «Infraestrutura» e "
-"«Ferramentas» do Fedora."
+"Contas Fedora permite-lhe criar e gerir uma conta para a «Infraestrutura»"
+" e «Ferramentas» do Fedora."
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, fuzzy, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "Para redefinir a sua palavra-passe, clique na hiperligação abaixo:"
@@ -1067,88 +1807,126 @@ msgstr "Para redefinir a sua palavra-passe, clique na hiperligação abaixo:"
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, fuzzy, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este ''e-"
-"mail''."
+"Se não solicitou para redefinir a sua palavra-passe, pode ignorar este "
+"''e-mail''."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "A equipa Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Bem-vindo a noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 "Este é o portal de atendimento comunitário automático e de código aberto "
 "para FreeIPA. Este permite-lhe fazer coisas, tais como criar uma conta, "
 "alterar a sua palavra-passe, gerir a associação ao grupo, e muito mais."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 #, fuzzy
 msgid "If the link has expired, you can request a new one here: "
 msgstr "O código expirou. Por favor, solicite um novo."
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "Fedora Accounts System"
 msgstr "Contas Fedora"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Contas Fedora"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Contas Fedora permite-lhe criar e gerir uma conta para a «Infraestrutura» e "
-"«Ferramentas» do Fedora."
+"Contas Fedora permite-lhe criar e gerir uma conta para a «Infraestrutura»"
+" e «Ferramentas» do Fedora."
 
 # | msgid "Groups"
+#: noggin/themes/fas/templates/main.html:167
 #, fuzzy
 msgid "Edit Group"
 msgstr "Grupos"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Criar um pedido PDR para desativar a sua conta"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Solicitar eliminação da conta"
 
 # | msgid "Did you lose your OTP token?"
+#: noggin/themes/fas/templates/main.html:190
 #, fuzzy
 msgid "Did you lose your last OTP token?"
 msgstr "Perdeu o seu código OTP?"
@@ -1159,53 +1937,76 @@ msgstr "Perdeu o seu código OTP?"
 # "
 # | "your account if possible, so that the administrator can verify your "
 # | "identity."
+#: noggin/themes/fas/templates/main.html:194
 #, fuzzy, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Se perdeu o seu código OTP, tem de enviar um ''e-mail'' para "
-"%(admin_email)s. Por favor, assine este ''e-mail'' utilizando a chave GPG "
-"associada com a sua conta, se possível, e assim, o administrador pdoe "
+"%(admin_email)s. Por favor, assine este ''e-mail'' utilizando a chave GPG"
+" associada com a sua conta, se possível, e assim, o administrador pdoe "
 "verificar a sua identidade."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Não foi possível encontrar o grupo %(groupname)s."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
@@ -1232,11 +2033,13 @@ msgstr ""
 #~ msgstr "Registo"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Não voltará a ver isto , não feche esta janela até que o seu código "
-#~ "esteja guardado."
+#~ "Não voltará a ver isto , não "
+#~ "feche esta janela até que o seu"
+#~ " código esteja guardado."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Palavra-passe ou Palavra-passe + Palavra-passe Única"
@@ -1251,10 +2054,14 @@ msgstr ""
 #~ msgstr "E-mail RHBZ"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "preencha um 'pedido' do Fedora Infra para alterar os detalhes ou os "
+#~ "preencha um 'pedido' do Fedora Infra "
+#~ "para alterar os detalhes ou os "
 #~ "patrocinadores deste grupo"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Solicitar Alteração dos Detalhes"
+

--- a/noggin/translations/ru/LC_MESSAGES/messages.po
+++ b/noggin/translations/ru/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Russian translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,39 +7,92 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: ru\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -140,62 +193,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -203,49 +256,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -253,246 +311,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -501,22 +678,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -524,11 +701,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -552,7 +729,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -560,36 +737,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -630,15 +807,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -652,6 +829,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -874,7 +1059,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,12 +1073,13 @@ msgid_plural ""
 "you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
+msgstr[2] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -994,6 +1180,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1004,7 +1192,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1016,8 +1204,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1040,60 +1313,147 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1123,7 +1483,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1136,45 +1496,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1436,12 +1805,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1454,3 +1835,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/si/LC_MESSAGES/messages.po
+++ b/noggin/translations/si/LC_MESSAGES/messages.po
@@ -7,1059 +7,1831 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2021-08-19 06:05+0000\n"
 "Last-Translator: Hela Basa <r45xveza@pm.me>\n"
-"Language-Team: Sinhala <https://translate.fedoraproject.org/projects/fedora-"
-"infra/noggin/si/>\n"
 "Language: si\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Sinhala <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/si/>\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "මුරපදය කල් ඉකත් වී ඇත. එය නැවත සකසන්න."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "මුරපදය කල් ඉකත් වී ඇත. එය නැවත සකසන්න."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr ""
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr ""
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr ""
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr ""
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr ""
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr ""
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr ""
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr ""
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr ""
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr ""
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr ""
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr ""
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr ""
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr ""
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr ""
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr ""
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr ""
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr ""
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr ""
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr ""
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr ""
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr ""
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr ""
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr ""
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr ""
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr ""
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr ""
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr ""
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr ""
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr ""
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr ""
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr ""
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr ""
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr ""
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr ""
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr ""
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr ""
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr ""
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr ""
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr ""
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr ""
 
-msgid "Scan your new token"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Reveal"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr ""
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
-
-msgid "OTP Tokens"
-msgstr ""
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr ""
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr ""
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr ""
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr ""
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr ""
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr ""
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr ""
 
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr ""
 
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
+msgstr ""
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr ""
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/sq/LC_MESSAGES/messages.po
+++ b/noggin/translations/sq/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Albanian translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: sq\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -888,11 +1073,11 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1178,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1190,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1202,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1311,146 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1480,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1493,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1802,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1832,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/sv/LC_MESSAGES/messages.po
+++ b/noggin/translations/sv/LC_MESSAGES/messages.po
@@ -9,127 +9,214 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-12-14 17:58+0000\n"
 "Last-Translator: Luna Jernberg <droidbittin@gmail.com>\n"
-"Language-Team: Swedish <https://translate.fedoraproject.org/projects/"
-"fedora-infra/noggin/sv/>\n"
 "Language: sv\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Swedish <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/sv/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.14.3\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Lösenordet har löpt ut. Vänligen återställ det."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Kunde inte logga in till IPA-servern."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Välkommen, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Token har synkroniserats framgångsrikt"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Ingen IPA-server tillgänglig"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Kunde inte logga in till IPA-servern."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Det gick inte att ändra lösenordet, försök igen."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Verifierings kod"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "Användare %(username)s hittades inte i systemet."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Det gick inte att lägga till användare %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Du har det! %(username)s har lagts till %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Du har det! %(username)s har tagits bort från %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Du har det! %(username)s är inte längre en sponsor av %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Det gamla lösenordet eller användarnamnet är inte korrekt"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Kunde inte ändra lösenord."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Ditt lösenord har ändrats"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Du har redan begärt en lösenordsåterställning, du måste vänta %(wait_min)s "
-"minut(er) och %(wait_sec)s sekunder innan du kan begära ett annat."
+"Du har redan begärt en lösenordsåterställning, du måste vänta "
+"%(wait_min)s minut(er) och %(wait_sec)s sekunder innan du kan begära ett "
+"annat."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Användare %(username)s existerar inte"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Vi kunde inte skicka ett e-postmeddelande till dig, försök igen senare"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Din e-postadress avvisas av smtp-servern"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Ett e-postmeddelande har skickats till din adress med instruktioner om hur "
-"du återställer ditt lösenord"
+"Ett e-postmeddelande har skickats till din adress med instruktioner om "
+"hur du återställer ditt lösenord"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Token är ogiltig, begär en ny."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Tokenen har gått ut, begär en ny."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Ditt lösenord har ändrats sedan du begärde denna token, vänligen begär en ny."
+"Ditt lösenord har ändrats sedan du begärde denna token, vänligen begär en"
+" ny."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
 "Ditt lösenord har ändrats, men det överensstämmer inte med policyn "
-"(%(policy_error)s) och har därför ställts in som utgånget. Du kommer att bli "
-"ombedd att ändra det efter att du har loggat in."
+"(%(policy_error)s) och har därför ställts in som utgånget. Du kommer att "
+"bli ombedd att ändra det efter att du har loggat in."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Felaktigt värde."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Det gick inte att ändra lösenordet, försök igen."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Ditt lösenord har ändrats."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Verifiera din e-postadress"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
-msgstr ""
-"Vi kunde inte skicka adressvalideringsmailet till dig, försök igen senare"
+msgstr "Vi kunde inte skicka adressvalideringsmailet till dig, försök igen senare"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
@@ -138,883 +225,1534 @@ msgstr ""
 "Användarnamnet '%(username)s' eller e-postadressen '%(email)s' är redan "
 "upptagen."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Ett fel uppstod när kontot skapades, försök igen."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "Registreringen verkar ha misslyckats, försök igen."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"Adressvalideringsmailet har skickats igen. Se till att det inte har hamnat i "
-"din skräppostmapp"
+"Adressvalideringsmailet har skickats igen. Se till att det inte har "
+"hamnat i din skräppostmapp"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
-msgstr ""
-"Ingen token har tillhandahållits, kontrollera din e-postvalideringslänk."
+msgstr "Ingen token har tillhandahållits, kontrollera din e-postvalideringslänk."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Token är ogiltig, registrera dig igen."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Denna token är inte längre giltig, registrera dig igen."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Denna användare kan inte hittas, registrera dig igen."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 "Användarnamnet och e-postadressen stämmer inte överens med den token du "
 "använde, vänligen registrera dig igen."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "Något gick fel när du skapade ditt konto. Försök igen senare."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Ditt konto har skapats, men lösenordet du valde överensstämmer inte med "
-"policyn (%(policy_error)s) och har därför ställts in som utgånget. Du kommer "
-"att bli ombedd att ändra det efter att du har loggat in."
+"policyn (%(policy_error)s) och har därför ställts in som utgånget. Du "
+"kommer att bli ombedd att ändra det efter att du har loggat in."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Ditt konto har skapats, men ett fel uppstod när du ställde in ditt lösenord "
-"(%(message)s). Du kan behöva ändra det efter att du har loggat in."
+"Ditt konto har skapats, men ett fel uppstod när du ställde in ditt "
+"lösenord (%(message)s). Du kan behöva ändra det efter att du har loggat "
+"in."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Grattis, ditt konto har skapats! Välkommen, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
-msgstr ""
-"Grattis, ditt konto har skapats! Gå vidare och logga in för att fortsätta."
+msgstr "Grattis, ditt konto har skapats! Gå vidare och logga in för att fortsätta."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Alla"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Okänd"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Inte spam"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Avvaktar"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Registreringen är stängd för tillfället."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
-"E-postadressen %(mail)s måste valideras. Kontrollera din inkorg och klicka "
-"på länken för att fortsätta. Om du inte kan hitta e-postmeddelandet inom ett "
-"par minuter, kolla din skräppostmapp."
+"E-postadressen %(mail)s måste valideras. Kontrollera din inkorg och "
+"klicka på länken för att fortsätta. Om du inte kan hitta "
+"e-postmeddelandet inom ett par minuter, kolla din skräppostmapp."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Inga modifikationer."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Token är ogiltig, vänligen ställ in din e-postadress igen."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
-"Denna token är inte längre giltig, vänligen ställ in din e-postadress igen."
+"Denna token är inte längre giltig, vänligen ställ in din e-postadress "
+"igen."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Denna token tillhör inte dig."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Fel lösenord"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Kunde inte skapa token."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Denna token har skapats."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Kunde inte hitta tokenhemlighet"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Kunde inte byta namn på token."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Tyvärr, du kan inte inaktivera din senast aktiva token."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Kan inte inaktivera token."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Kunde inte aktivera token. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Tyvärr, du kan inte ta bort din senast aktiva token."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Kunde inte ta bort token."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Kunde inte skapa token."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Kunde inte byta namn på token."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Fel lösenord"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Verifiera och aktivera OTP-token"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Lösenordsåterställning för %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Kunde inte signera avtalet \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Du har signerat \"%(name)s\". avtalet."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Kunde inte ta bort token."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Denna token har skapats."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Detta ser inte ut som ett giltigt smeknamn."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Detta ser inte ut som ett giltigt servernamn."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Förnamn"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Förnamn får inte vara tomt"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Efternamn"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Efternamn får inte vara tomt"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Lokal"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Lokal får inte vara tomt"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Lokal måste vara en giltig kortkod för lokal"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Chatt smeknamn"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Tidszon"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Tidszon får inte vara tom"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Tidszon måste vara en giltig tidszon"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Github användarnamn"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Gitlab användarnamn"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Giltig URL krävs"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "Blogg URL"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "RSS URL"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Privat"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
-msgstr ""
-"Dölj information från andra användare, se sekretesspolicyn för detaljer."
+msgstr "Dölj information från andra användare, se sekretesspolicyn för detaljer."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Pronomen"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "E-postadress"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "E-post får inte vara tomt"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "E-post måste vara giltigt"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla E-post"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH-nycklar"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG-nycklar"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Token namn"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
-msgstr ""
-"Lägg till ett valfritt namn för att hjälpa dig att identifiera denna token"
+msgstr "Lägg till ett valfritt namn för att hjälpa dig att identifiera denna token"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Ange ditt nuvarande lösenord"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Du måste ange ett lösenord"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "vänligen autentisera dig på nytt så att vi vet att det är du"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Engångslösenord"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Ange ditt engångslösenord"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Generera OTP token"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Kunde inte hitta tokenhemlighet"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Verifierings kod"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Du måste ange en verifieringskod"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Verifiera och aktivera OTP-token"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Detta är fel kod, försök igen."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Token får inte vara tom"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Generera OTP token"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Generera OTP token"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Ange ditt nuvarande lösenord"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Lösenord får inte vara tomt"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Avtal får inte vara tomt"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Nytt användarnamn får inte vara tomt"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Användarnamn"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Användarnamn får inte vara tomt"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Användarnamn (eller e-postadress)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Du måste ange ett användarnamn"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Lösenord"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Logga in"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Nytt lösenord"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Lösenord får inte vara tomt"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Lösenorden måste matcha"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Bekräfta nytt lösenord"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr "Engångslösenord (om ditt konto har tvåfaktorsautentisering aktiverat)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Nuvarande lösenord"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Nuvarande lösenord får inte vara tomt"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Användarnamn eller e-post"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Användarnamn får inte vara tomt"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
 msgstr "Ange ditt användarnamn eller e-post för att återställa ditt lösenord"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Endast dessa tecken är tillåtna: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Jag är över 16 år"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Du måste vara över 16 år för att skapa ett konto"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Registrera"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Skicka om e-postmeddelande"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Snälla välj ett starkt lösenord"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Bekräfta lösenord"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Aktivera"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Första OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Du måste ange en första kod"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Andra OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Du måste ange en andra kod"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Token ID"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "E-postadresser från den här domänen är inte tillåtna"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "Blandade bokstäver är inte tillåtna, försök med små bokstäver."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Fält får inte matcha \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Den sidan hittades inte."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Visa avtal"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "Granska"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Signera användaravtal"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Glömt Lösenord?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Glömt Lösenord eller OTP?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Synkronisera token"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Föregående"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "aktuell"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Nästa"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Grupper"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Användare"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Återställning av lösenord"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Har du glömt ditt lösenord?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr ""
-"Ange ditt användarnamn eller e-post så skickas ett e-postmeddelande till din "
-"adress med ytterligare instruktioner."
+"Ange ditt användarnamn eller e-post så skickas ett e-postmeddelande till "
+"din adress med ytterligare instruktioner."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Skicka"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Återställ lösenord"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Lösenordsåterställning för %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s Grupp"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Lämna grupp"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Du är sponsor till denna grupp, men inte medlem. Lägg till dig själv om du "
-"vill bli medlem."
+"Du är sponsor till denna grupp, men inte medlem. Lägg till dig själv om "
+"du vill bli medlem."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "För att gå med i den här gruppen, kontakta en gruppsponsor."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsorer"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "inga sponsorer"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Medlemmar"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "lägg till användare..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Inga medlemmar än."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Grupplista"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s medlemmar"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Inga grupper."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Inloggning"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA fel"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Det uppstod ett problem med IPA-bakände, försök igen senare."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Du kan också <a href=\"%(url)s\">logga ut</a> och logga in igen om problemet "
-"kvarstår."
+"Du kan också <a href=\"%(url)s\">logga ut</a> och logga in igen om "
+"problemet kvarstår."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Lösenordsåterställning har löpt ut"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Lösenordsåterställning har löpt ut för %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Ändra lösenord"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Registrera användare"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Namn:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "E-post:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Registrerad:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Status:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Väntar på spamkontroll"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Inte flaggad som spam"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Flaggad som skräppost"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Spamstatus okänd"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Acceptera"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Flagga som spam"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Ta bort"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Om du klickar på Acceptera skickas valideringsmailet till denna användare. "
-"Andra knappar skickar inget."
+"Om du klickar på Acceptera skickas valideringsmailet till denna "
+"användare. Andra knappar skickar inget."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Inga registrerande användare i detta tillstånd för tillfället."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Inga registrerande användare för tillfället."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Aktivera ditt konto"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Skapande av konto, steg 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Hej %(name)s. För att aktivera ditt konto, vänligen välj ett lösenord."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Skriv under avtal"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "Valfri avtalsignering"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
-"Hallå %(name)s. Vänligen granska avtalet nedan och signera det sedan om du "
-"godkänner innehållet."
-msgstr[1] ""
-"Hallå %(name)s. Vänligen granska avtalen nedan och underteckna dem sedan om "
+"Hallå %(name)s. Vänligen granska avtalet nedan och signera det sedan om "
 "du godkänner innehållet."
+msgstr[1] ""
+"Hallå %(name)s. Vänligen granska avtalen nedan och underteckna dem sedan "
+"om du godkänner innehållet."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Fortsätt"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Hoppa över"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Verifiera din e-postadress"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Skapande av konto, steg 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Grattis %(name)s, ditt konto har skapats!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 "Innan du kan logga in måste din e-postadress: %(mail)s valideras. "
 "Kontrollera din inkorg och klicka på länken för att fortsätta."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 "Om du inte kan hitta e-postmeddelandet inom ett par minuter, kolla din "
 "skräppostmapp. Om det inte finns där kan du be om ytterligare ett "
 "valideringsmail genom att klicka på knappen nedan."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Spamkontroll pågår"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Ditt konto kontrolleras"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Innan du kan logga in måste ditt konto kontrolleras med avseende på spam. "
-"Det bör bara ta några sekunder, vänta..."
+"Innan du kan logga in måste ditt konto kontrolleras med avseende på spam."
+" Det bör bara ta några sekunder, vänta..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Ditt konto kräver administratörsgodkännande"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Ditt konto måste godkännas av en administratör."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Du får ett e-post när beslutet är taget."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Tack för ditt tålamod."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Ditt konto har blockerats"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Ditt konto har flaggats som spam."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Något gick fel"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Spamstatus som inte stöds: %s, kontakta administratörerna"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Synkronisera OTP token"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Synkronisera OTP token"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Synkronisera"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Validera din e-postadress"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr "Hej %(user_name)s Vill du ställa in ditt %(attr_name)s till %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Avbryt"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Gör det"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Spara"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG nyckel-ID"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH publik nyckel"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Inställningar för %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Detta är fel kod, försök igen."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Generera OTP token"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(inget namn)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "Du har inga OTP tokens"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Avvaktar"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Lösenord"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Skanna din nya token"
 
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
 msgstr ""
 "Din nya token är redo. Klicka på knappen nedan för att visa QR-koden och "
 "skanna den."
 
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Avslöja"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
 "eller kopiera och klistra in följande token-URL om du inte kan skanna QR-"
 "koden:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"När du har registrerat en token i din app, verifiera den genom att generera "
-"din första kod och ange den nedan:"
+"När du har registrerat en token i din app, verifiera den genom att "
+"generera din första kod och ange den nedan:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Lägg till OTP token"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr ""
-"Att skapa din första OTP-token möjliggör tvåfaktorsautentisering med OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr "Att skapa din första OTP-token möjliggör tvåfaktorsautentisering med OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr "När det har aktiverats kan tvåfaktorsautentisering inte inaktiveras."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "OTP Tokens"
 
-msgid "(no name)"
-msgstr "(inget namn)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Byt namn"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Avaktivera"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Aktivera"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "Du har inga OTP tokens"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 "Lägg till en OTP-token för att aktivera tvåfaktorsautentisering på ditt "
 "konto."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Aktivera"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Nuvarande lösenord"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Inte spam"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH-nycklar"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "Du har inga OTP tokens"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Lägg till en OTP-token för att aktivera tvåfaktorsautentisering på ditt "
+"konto."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Byt Avatar"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
-"Formatet är antingen <code>username</code> eller <code>username:server.name</"
-"code> om du inte använder standardservrarna:"
+"Formatet är antingen <code>username</code> eller "
+"<code>username:server.name</code> om du inte använder standardservrarna:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "För %(title)s: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Inställningar för %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "E-postadresser"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG-nycklar"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Avtal"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Profil för %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Redigera Profil"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Första OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Skapad den"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Nuvarande tid"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Chatt"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blogg"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Grupp(er), %(agreementcount)s Avtal"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "signerat"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "medlem"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Användare %(username)s existerar inte"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Hallå, %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
-"För att aktivera ditt konto med användarnamn %(username)s, klicka på länken "
-"nedan:"
+"För att aktivera ditt konto med användarnamn %(username)s, klicka på "
+"länken nedan:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Om du inte skapade ett konto för användarnamn %(username)s kan du ignorera "
-"detta e-postmeddelande."
+"Om du inte skapade ett konto för användarnamn %(username)s kan du "
+"ignorera detta e-postmeddelande."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "AlmaLinux teamet"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Hej,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Klicka på länken nedan för att återställa ditt lösenord. Om du inte begärde "
-"en lösenordsåterställning, ignorera detta e-postmeddelande."
+"Klicka på länken nedan för att återställa ditt lösenord. Om du inte "
+"begärde en lösenordsåterställning, ignorera detta e-postmeddelande."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "AlmaLinux kontotjänster"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "sök..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Inställningar"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Hjälp"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Logga ut"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "Drivs av %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux konton"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"AlmaLinux konton ger möjligheten att skapa och hantera ditt konto över hela "
-"AlmaLinux infrastruktur."
+"AlmaLinux konton ger möjligheten att skapa och hantera ditt konto över "
+"hela AlmaLinux infrastruktur."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "För att validera e-postadressen %(address)s, klicka på länken nedan:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
@@ -1023,140 +1761,198 @@ msgstr ""
 "Om du inte har angett e-postadressen %(address)s på ditt konto med "
 "%(username)s kan du ignorera detta e-postmeddelande."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin teamet"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Välkommen till noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Detta är öppen källkod, gemenskaps självbetjäningsportal för FreeIPA. Den "
-"låter dig göra saker som att skapa ett konto, ändra ditt lösenord, hantera "
-"gruppmedlemskap och mer."
+"Detta är öppen källkod, gemenskaps självbetjäningsportal för FreeIPA. Den"
+" låter dig göra saker som att skapa ett konto, ändra ditt lösenord, "
+"hantera gruppmedlemskap och mer."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"Ytterligare konfiguration krävs när du använder Kerberos-biljetter när OTP "
-"är aktiverat"
+"Ytterligare konfiguration krävs när du använder Kerberos-biljetter när "
+"OTP är aktiverat"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Läs <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>dokumentationen</a> för detaljer om hur du konfigurerar ditt system"
+"Läs <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>dokumentationen</a> för detaljer om hur du "
+"konfigurerar ditt system"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Du kan också använda ditt Fedora konto för att logga in här."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
-"Denna länk kommer att vara giltig i %(ttl)s minuter (tills %(valid_until)s "
-"UTC)."
+"Denna länk kommer att vara giltig i %(ttl)s minuter (tills "
+"%(valid_until)s UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Om länken har gått ut kan du begära en ny här: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora Kontosystem"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora konton"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora folk"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Fedora Konton låter dig skapa och hantera ett konto för Fedora Verktyg och "
-"Infrastruktur."
+"Fedora Konton låter dig skapa och hantera ett konto för Fedora Verktyg "
+"och Infrastruktur."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Redigera Grupp"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 "För att ändra gruppinformation eller lägga till sponsorer, lämna in ett "
 "ärende med"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Skapa en PDR-begäran för att inaktivera ditt konto"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Begär radering av konto"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Har du tappat bort din senaste OTP token?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"Om du har tappat bort din senaste OTP token måste du skicka ett e-"
-"postmeddelande till %(admin_email)s. Vänligen signera detta e-postmeddelande "
-"med GPG-nyckeln som är kopplad till ditt konto om möjligt, så att "
-"administratören kan verifiera din identitet."
+"Om du har tappat bort din senaste OTP token måste du skicka ett "
+"e-postmeddelande till %(admin_email)s. Vänligen signera detta "
+"e-postmeddelande med GPG-nyckeln som är kopplad till ditt konto om "
+"möjligt, så att administratören kan verifiera din identitet."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 "Om du hade flera tokens och förlorat en, kan du använda en annan för att "
 "logga in och ta bort den förlorade token från ditt konto."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
-"Om du inte har registrerat en OTP-token har du ingen och detta gäller inte "
-"dig."
+"Om du inte har registrerat en OTP-token har du ingen och detta gäller "
+"inte dig."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"För att meddela administratörer att du inte är en spammare, skicka ett e-"
-"postmeddelande till %(email_link)s och förklara situationen."
+"För att meddela administratörer att du inte är en spammare, skicka ett "
+"e-postmeddelande till %(email_link)s och förklara situationen."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 "Genom att använda ett Fedora-konto samtycker du till att följa <a "
 "href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedoras&nbsp;kod&nbsp;för uppförande</a >."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Du kan också använda ditt CentOS konto för att logga in här."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Grupp %(groupname)s kunde inte hittas."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "Inga användare med e-post %(username_or_email)s hittades"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Ångra"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s på %(server)s"
@@ -1165,9 +1961,10 @@ msgstr "%(protocol)s på %(server)s"
 #~ msgstr "Signera"
 
 #~ msgid ""
-#~ "Congratulations, you now have an account! Go ahead and sign in to proceed."
-#~ msgstr ""
-#~ "Grattis, du har nu ett konto! Gå vidare och logga in för att fortsätta."
+#~ "Congratulations, you now have an "
+#~ "account! Go ahead and sign in to"
+#~ " proceed."
+#~ msgstr "Grattis, du har nu ett konto! Gå vidare och logga in för att fortsätta."
 
 #~ msgid "IRC Nickname"
 #~ msgstr "IRC smeknamn"
@@ -1200,11 +1997,13 @@ msgstr "%(protocol)s på %(server)s"
 #~ msgstr "Registrering"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Detta kommer aldrig att visas för dig igen, stäng inte det här fönstret "
-#~ "förrän din token har sparats."
+#~ "Detta kommer aldrig att visas för "
+#~ "dig igen, stäng inte det här "
+#~ "fönstret förrän din token har sparats."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Lösenord eller lösenord + engångslösenord"
@@ -1222,16 +2021,21 @@ msgstr "%(protocol)s på %(server)s"
 #~ msgstr "För att återställa ditt lösenord, klicka på länken nedan:"
 
 #~ msgid ""
-#~ "If you did not request your password to be reset, you can ignore this "
-#~ "email."
+#~ "If you did not request your "
+#~ "password to be reset, you can "
+#~ "ignore this email."
 #~ msgstr ""
-#~ "Om du inte har begärt att ditt lösenord ska återställas kan du ignorera "
-#~ "detta e-postmeddelande."
+#~ "Om du inte har begärt att ditt "
+#~ "lösenord ska återställas kan du ignorera"
+#~ " detta e-postmeddelande."
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "Skicka in ett Fedora Infra ärende för att ändra detaljerna eller "
+#~ "Skicka in ett Fedora Infra ärende "
+#~ "för att ändra detaljerna eller "
 #~ "sponsorerna för denna grupp"
 
 #~ msgid "Request Change of Details"
@@ -1241,15 +2045,21 @@ msgstr "%(protocol)s på %(server)s"
 #~ msgstr "Har du tappat bort din OTP token?"
 
 #~ msgid ""
-#~ "If you have lost your OTP token you need to send an email to %"
-#~ "(admin_email)s. Please sign this email using the GPG key associated with "
-#~ "your account if possible, so that the administrator can verify your "
+#~ "If you have lost your OTP token"
+#~ " you need to send an email to"
+#~ " %(admin_email)s. Please sign this email"
+#~ " using the GPG key associated with"
+#~ " your account if possible, so that"
+#~ " the administrator can verify your "
 #~ "identity."
 #~ msgstr ""
-#~ "Om du har tappat bort din OTP token måste du skicka ett e-postmeddelande "
-#~ "till %(admin_email)s. Vänligen signera detta e-postmeddelande med GPG-"
-#~ "nyckeln som är kopplad till ditt konto om möjligt, så att administratören "
-#~ "kan verifiera din identitet."
+#~ "Om du har tappat bort din OTP "
+#~ "token måste du skicka ett "
+#~ "e-postmeddelande till %(admin_email)s. Vänligen "
+#~ "signera detta e-postmeddelande med GPG-"
+#~ "nyckeln som är kopplad till ditt "
+#~ "konto om möjligt, så att administratören"
+#~ " kan verifiera din identitet."
 
 #~ msgid "Unknown agreement: %(name)s."
 #~ msgstr "Okänt avtal: %(name)s."
@@ -1259,3 +2069,4 @@ msgstr "%(protocol)s på %(server)s"
 
 #~ msgid "Website"
 #~ msgstr "Webbplats"
+

--- a/noggin/translations/tr/LC_MESSAGES/messages.po
+++ b/noggin/translations/tr/LC_MESSAGES/messages.po
@@ -8,184 +8,280 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-12-14 17:58+0000\n"
 "Last-Translator: Oğuz Ersen <oguz@ersen.moe>\n"
-"Language-Team: Turkish <https://translate.fedoraproject.org/projects/"
-"fedora-infra/noggin/tr/>\n"
 "Language: tr\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Turkish <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/tr/>\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.14.3\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "Parolanın süresi doldu. Lütfen sıfırlayın."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "IPA sunucusunda oturum açılamadı."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Hoş geldin, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Belirteç başarıyla eşzamanlandı"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr "Kullanılabilir IPA sunucusu yok"
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "IPA sunucusunda oturum açılamadı."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Parola değiştirilemedi, lütfen tekrar deneyin."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Doğrulama Kodu"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "%(username)s kullanıcısı sistemde bulunamadı."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "%(username)s kullanıcısı eklenemedi: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "İşe yaradı! %(username)s, %(groupname)s grubuna eklendi."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "İşe yaradı! %(username)s, %(groupname)s grubundan kaldırıldı."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "İşe yaradı! %(username)s, artık %(groupname)s grubunun sponsoru değil."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Eski parola veya kullanıcı adı doğru değil"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Parola değiştirilemedi."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Parolanız değiştirildi"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Zaten bir parola sıfırlama isteğinde bulundunuz, tekrar istekte bulunabilmek "
-"için %(wait_min)s dakika ve %(wait_sec)s saniye beklemeniz gerekmektedir."
+"Zaten bir parola sıfırlama isteğinde bulundunuz, tekrar istekte "
+"bulunabilmek için %(wait_min)s dakika ve %(wait_sec)s saniye beklemeniz "
+"gerekmektedir."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "%(username)s kullanıcısı mevcut değil"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "Size e-posta gönderemedik, lütfen daha sonra tekrar deneyin"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "E-posta adresiniz smtp sunucusu tarafından reddedildi"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"Adresinize parolanızı nasıl sıfırlayacağınızla ilgili talimatları içeren bir "
-"e-posta gönderildi"
+"Adresinize parolanızı nasıl sıfırlayacağınızla ilgili talimatları içeren "
+"bir e-posta gönderildi"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Belirteç geçersiz, lütfen yeni bir tane isteyin."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "Belirtecin süresi doldu, lütfen yeni bir tane isteyin."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr ""
-"Bu belirteç için istekte bulunduktan sonra parolanız değiştirildi, lütfen "
-"yeni bir tane isteyin."
+"Bu belirteç için istekte bulunduktan sonra parolanız değiştirildi, lütfen"
+" yeni bir tane isteyin."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"Parolanız değiştirildi, ancak kurallara uygun değil (%(policy_error)s) ve bu "
-"nedenle süresi dolmuş olarak ayarlandı. Oturum açtıktan sonra sizden "
+"Parolanız değiştirildi, ancak kurallara uygun değil (%(policy_error)s) ve"
+" bu nedenle süresi dolmuş olarak ayarlandı. Oturum açtıktan sonra sizden "
 "değiştirmeniz istenecektir."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Yanlış değer."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Parola değiştirilemedi, lütfen tekrar deneyin."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Parolanız değiştirildi."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "E-posta adresinizi doğrulayın"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
-"Size adres doğrulama e-postası gönderemedik, lütfen daha sonra tekrar deneyin"
+"Size adres doğrulama e-postası gönderemedik, lütfen daha sonra tekrar "
+"deneyin"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
-msgstr ""
-"'%(username)s' kullanıcı adı veya '%(email)s' e-posta adresi zaten alındı."
+msgstr "'%(username)s' kullanıcı adı veya '%(email)s' e-posta adresi zaten alındı."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "Hesap oluşturulurken bir hata oluştu, lütfen tekrar deneyin."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "Kayıt başarısız oldu gibi görünüyor, lütfen tekrar deneyin."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"Adres doğrulama e-postası tekrar gönderildi. İstenmeyen e-posta klasörünüze "
-"düşmediğinden emin olun"
+"Adres doğrulama e-postası tekrar gönderildi. İstenmeyen e-posta "
+"klasörünüze düşmediğinden emin olun"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
-msgstr ""
-"Belirteç girilmedi, lütfen e-posta doğrulama bağlantınızı gözden geçirin."
+msgstr "Belirteç girilmedi, lütfen e-posta doğrulama bağlantınızı gözden geçirin."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Belirteç geçersiz, lütfen tekrar kaydolun."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Bu belirteç artık geçerli değil, lütfen tekrar kaydolun."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Bu kullanıcı bulunamıyor, lütfen tekrar kaydolun."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Kullanıcı adı ve e-posta adresi kullandığınız belirteçle eşleşmiyor, lütfen "
-"tekrar kaydolun."
+"Kullanıcı adı ve e-posta adresi kullandığınız belirteçle eşleşmiyor, "
+"lütfen tekrar kaydolun."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 "Hesabınız oluşturulurken bir şeyler ters gitti, lütfen daha sonra tekrar "
 "deneyin."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
 "Hesabınız oluşturuldu, ancak seçtiğiniz parola kurallara uygun değil "
 "(%(policy_error)s) ve bu nedenle süresi dolmuş olarak ayarlandı. Oturum "
 "açtıktan sonra sizden değiştirmeniz istenecektir."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
@@ -194,368 +290,636 @@ msgstr ""
 "Hesabınız oluşturuldu, ancak parolanız belirlenirken bir hata oluştu "
 "(%(message)s). Oturum açtıktan sonra değiştirmeniz gerekebilir."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Tebrikler, hesabınız oluşturuldu! Hoş geldin, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "Tebrikler, hesabınız oluşturuldu! Devam etmek için oturum açın."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Tümü"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Spam Değil"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Spam"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Bekliyor"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "Kayıtlar şu anda kapalı."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "%(mail)s e-posta adresinin doğrulanması gerekiyor. Lütfen gelen kutunuza "
 "bakın ve devam etmek için bağlantıya tıklayın. E-postayı birkaç dakika "
 "içinde bulamazsanız, istenmeyen e-posta klasörünüze bakın."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Değişiklik yok."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Belirteç geçersiz, lütfen e- posta adresini yeniden ayarlayın."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
-"Bu belirteç artık geçerli değil, lütfen e- posta adresini yeniden ayarlayın."
+"Bu belirteç artık geçerli değil, lütfen e- posta adresini yeniden "
+"ayarlayın."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Bu belirteç size ait değil."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Yanlış parola"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Belirteç oluşturulamıyor."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Belirteç oluşturuldu."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Belirteç şifresi bulunamadı"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Belirteç yeniden adlandırılamıyor."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Maalesef, son etkin belirtecinizi devre dışı bırakamazsınız."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Belirteç devre dışı bırakılamıyor."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Belirteç etkinleştirilemiyor. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Maalesef, son etkin belirtecinizi silemezsiniz."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Belirteç silinemiyor."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Belirteç oluşturulamıyor."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Belirteç yeniden adlandırılamıyor."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Yanlış parola"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "OTP Belirtecini Doğrula ve Etkinleştir"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "%(username)s için Parola Sıfırlama"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "\"%(name)s\" sözleşmesi imzalanamıyor: %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "\"%(name)s\" sözleşmesini imzaladınız."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Belirteç silinemiyor."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Belirteç oluşturuldu."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Bu geçerli bir takma ad gibi görünmüyor."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Bu geçerli bir sunucu adı gibi görünmüyor."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Ad"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Ad boş bırakılamaz"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Soyadı"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Soyadı boş bırakılamaz"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Yerel Ayarı"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Yerel ayarı boş bırakılamaz"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Yerel ayarı, geçerli bir yerel ayar kısa kodu olmalıdır"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Sohbet Takma Adları"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Zaman Dilimi"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Zaman dilimi boş bırakılamaz"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Zaman dilimi, geçerli bir zaman dilimi olmalıdır"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub Kullanıcı Adı"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab Kullanıcı Adı"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Geçerli URL gerekli"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr "Blog URL'si"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr "RSS URL'si"
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Özel"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 "Bilgilerinizi diğer kullanıcılardan gizleyin, ayrıntılar için Gizlilik "
 "İlkesine bakın."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Zamirler"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "E-posta Adresi"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "E-posta adresi boş bırakılamaz"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "E-posta adresi, geçerli bir adres olmalıdır"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla E-posta Adresi"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH Anahtarları"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG Anahtarları"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Belirteç adı"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
-"Bu belirteci tanımlamanıza yardımcı olması için isteğe bağlı bir ad ekleyin"
+"Bu belirteci tanımlamanıza yardımcı olması için isteğe bağlı bir ad "
+"ekleyin"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Geçerli parolanızı girin"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Bir parola girmelisiniz"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "lütfen siz olduğunuzu bilmemiz için yeniden kimlik doğrulaması yapın"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Tek Seferlik Parola"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Tek Seferlik Parolanızı girin"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "OTP Belirteci Oluştur"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Belirteç şifresi bulunamadı"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Doğrulama Kodu"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Doğrulama kodu girmelisiniz"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "OTP Belirtecini Doğrula ve Etkinleştir"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Kod yanlış, lütfen tekrar deneyin."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Belirteç boş bırakılamaz"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "OTP Belirteci Oluştur"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "OTP Belirteci Oluştur"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Geçerli parolanızı girin"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Parola boş bırakılamaz"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Sözleşme boş bırakılamaz"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Yeni üye kullanıcı adı boş bırakılamaz"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Kullanıcı Adı"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Kullanıcı adı boş bırakılamaz"
 
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr "Kullanıcı adı (veya e-posta adresi)"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Bir kullanıcı adı girmelisiniz"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Parola"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Oturum Aç"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Yeni Parola"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Parola boş bırakılamaz"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Parolalar eşleşmelidir"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Yeni Parolayı Onayla"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 "Tek Seferlik Parola (hesabınızda iki adımlı kimlik doğrulama "
 "etkinleştirildiyse)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Geçerli Parola"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Geçerli parola boş bırakılamaz"
 
+#: noggin/form/password_reset.py:36
 msgid "Username or Email"
 msgstr "Kullanıcı Adı veya E-posta Adresi"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Kullanıcı adı boş bırakılamaz"
 
+#: noggin/form/password_reset.py:38
 msgid "Enter your username or email to reset your password"
-msgstr ""
-"Parolanızı sıfırlamak için kullanıcı adınızı veya e-posta adresinizi girin"
+msgstr "Parolanızı sıfırlamak için kullanıcı adınızı veya e-posta adresinizi girin"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Yalnızca şu karakterlere izin verilir: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "16 yaşından büyüğüm"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Hesap oluşturmak için 16 yaşından büyük olmalısınız"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Kaydol"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "E-postayı yeniden gönder"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Lütfen sağlam bir parola seçin"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Parolayı Onayla"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Etkinleştir"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "İlk OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "İlk kodu girmelisiniz"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "İkinci OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "İkinci bir kod girmelisiniz"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Belirteç Kimliği"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Bu etki alanından e-posta adreslerine izin verilmiyor"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "Büyük/küçük harf karışımına izin verilmiyor, küçük harf deneyin."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Alan \"%(pattern)s\" ile eşleşmemelidir."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Bu sayfa bulunamadı."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Sözleşmeyi görüntüle"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr "Gözden Geçir"
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Kullanıcı Sözleşmesini İmzala"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Parolanızı mı unuttunuz?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Parolanızı veya OTP'yi mi unuttunuz?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Belirteci Eşzamanla"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Önceki"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "şu anki"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Sonraki"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Gruplar"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Kullanıcılar"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Parola Kurtarma"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Parolanızı mı unuttunuz?"
 
+#: noggin/templates/forgot-password-ask.html:17
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
@@ -563,122 +927,165 @@ msgstr ""
 "Kullanıcı adınızı veya e-posta adresinizi girin, adresinize sonraki "
 "talimatları içeren bir e-posta gönderilecektir."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Gönder"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Parolayı Sıfırla"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "%(username)s için Parola Sıfırlama"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s Grubu"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Gruptan ayrıl"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 "Bu grubun sponsorusunuz, ancak üyesi değilsiniz. Üye olmak istiyorsanız "
 "kendinizi ekleyin."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Bu gruba katılmak için bir grup sponsoruyla irtibata geçin."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Sponsorlar"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "sponsor yok"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Üyeler"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "kullanıcı ekle..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Henüz üye yok."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Grup Listesi"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s üye"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Grup yok."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Oturum Aç"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA Hatası"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
-"IPA arka yüzüyle ilgili bir sorun oluştu, lütfen daha sonra tekrar deneyin."
+"IPA arka yüzüyle ilgili bir sorun oluştu, lütfen daha sonra tekrar "
+"deneyin."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 "Ayrıca sorun devam ederse <a href=\"%(url)s\">oturumu kapatıp</a> tekrar "
 "oturum açabilirsiniz."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Süresi Dolmuş Parola Sıfırlama"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "%(username)s için Süresi Dolmuş Parola Sıfırlama"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Parola Değiştir"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Kullanıcı Kaydı"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Ad:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "E-posta adresi:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Kayıtlı:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Durum:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Spam denetimi bekleniyor"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Spam olarak işaretlenmedi"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Spam olarak işaretlendi"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Spam durumu bilinmiyor"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Kabul et"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Spam olarak işaretle"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Sil"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
@@ -686,458 +1093,835 @@ msgstr ""
 "Kabul et düğmesine tıklandığında bu kullanıcıya doğrulama e-postası "
 "gönderilecektir. Diğer düğmeler hiçbir şey göndermeyecektir."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "Şu anda bu durumda kullanıcı kaydı yok."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "Şu anda kullanıcı kaydı yok."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Hesabınızı etkinleştirin"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Hesap oluşturma, adım 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
-msgstr ""
-"Merhaba %(name)s. Hesabınızı etkinleştirmek için lütfen bir parola seçin."
+msgstr "Merhaba %(name)s. Hesabınızı etkinleştirmek için lütfen bir parola seçin."
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr "Sözleşmeleri imzala"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr "İsteğe bağlı sözleşme imzalanması"
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
-"Merhaba %(name)s. Lütfen aşağıdaki sözleşmeyi inceleyin ve içeriğini kabul "
-"ediyorsanız imzalayın."
+"Merhaba %(name)s. Lütfen aşağıdaki sözleşmeyi inceleyin ve içeriğini "
+"kabul ediyorsanız imzalayın."
 msgstr[1] ""
-"Merhaba %(name)s. Lütfen aşağıdaki sözleşmeleri inceleyin ve içeriğini kabul "
-"ediyorsanız imzalayın."
+"Merhaba %(name)s. Lütfen aşağıdaki sözleşmeleri inceleyin ve içeriğini "
+"kabul ediyorsanız imzalayın."
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr "Devam Et"
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr "Atla"
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "E-posta adresinizi doğrulayın"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Hesap oluşturma, adım 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Tebrikler %(name)s, hesabınız oluşturuldu!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
-"Oturum açmadan önce e-posta adresinizin: %(mail)s doğrulanması gerekiyor. "
-"Lütfen gelen kutunuza bakın ve devam etmek için bağlantıya tıklayın."
+"Oturum açmadan önce e-posta adresinizin: %(mail)s doğrulanması gerekiyor."
+" Lütfen gelen kutunuza bakın ve devam etmek için bağlantıya tıklayın."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"E-postayı birkaç dakika içinde bulamazsanız, istenmeyen e-posta klasörünüze "
-"bakın. Orada değilse, aşağıdaki düğmeye tıklayarak başka bir doğrulama e-"
-"postası isteyebilirsiniz."
+"E-postayı birkaç dakika içinde bulamazsanız, istenmeyen e-posta "
+"klasörünüze bakın. Orada değilse, aşağıdaki düğmeye tıklayarak başka bir "
+"doğrulama e-postası isteyebilirsiniz."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Spam denetimi devam ediyor"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Hesabınız denetleniyor"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
-"Oturum açabilmeniz için önce hesabınızın spam olasılığına karşı denetlenmesi "
-"gerekiyor. Bu işlem yalnızca birkaç saniye sürecektir, lütfen bekleyin..."
+"Oturum açabilmeniz için önce hesabınızın spam olasılığına karşı "
+"denetlenmesi gerekiyor. Bu işlem yalnızca birkaç saniye sürecektir, "
+"lütfen bekleyin..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Hesabınız için yönetici onayı gerekiyor"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Hesabınızın bir yönetici tarafından onaylanması gerekiyor."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Karar alındığında size bir e-posta gönderilecektir."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Beklediğiniz için teşekkür ederiz."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Hesabınız engellendi"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Hesabınız spam olarak işaretlendi."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Bir şeyler ters gitti"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Desteklenmeyen spam durumu: %s, lütfen yöneticilerle iletişime geçin"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "OTP Belirtecini Eşzamanla"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "OTP Belirtecini Eşzamanla"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Eşzamanla"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "E-posta adresinizi doğrulayın"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
-"Merhaba %(user_name)s. %(attr_name)s için %(mail)s olarak ayarlamak ister "
-"misiniz?"
+"Merhaba %(user_name)s. %(attr_name)s için %(mail)s olarak ayarlamak ister"
+" misiniz?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "İptal"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Yap"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Kaydet"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG Anahtarı Kimliği"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH Genel Anahtarı"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "%(username)s için Ayarlar"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Kod yanlış, lütfen tekrar deneyin."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "OTP Belirteci Oluştur"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(ad yok)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "OTP belirteciniz yok"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Bekliyor"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Parola"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Yeni belirtecinizi tarayın"
 
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
 msgstr ""
 "Yeni belirteciniz hazır. QR kodunu görüntülemek için aşağıdaki düğmeye "
 "tıklayın ve tarayın."
 
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Görüntüle"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
 "veya QR kodunu tarayamıyorsanız aşağıdaki belirteç URL'sini kopyalayıp "
 "yapıştırın:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"Belirteci uygulamanıza kaydettikten sonra, ilk kodunuzu oluşturup aşağıya "
-"girerek doğrulayın:"
+"Belirteci uygulamanıza kaydettikten sonra, ilk kodunuzu oluşturup aşağıya"
+" girerek doğrulayın:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "OTP Belirteci Ekle"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
 "İlk OTP belirtecinizi oluşturmak, OTP kullanarak iki adımlı kimlik "
 "doğrulamayı etkinleştirir."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
-"İki adımlı kimlik doğrulama etkinleştirildikten sonra devre dışı bırakılamaz."
+"İki adımlı kimlik doğrulama etkinleştirildikten sonra devre dışı "
+"bırakılamaz."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "OTP Belirteçleri"
 
-msgid "(no name)"
-msgstr "(ad yok)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Yeniden adlandır"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Devre Dışı Bırak"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Etkinleştir"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "OTP belirteciniz yok"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 "Hesabınızda iki adımlı kimlik doğrulamayı etkinleştirmek için bir OTP "
 "belirteci ekleyin."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Etkinleştir"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Geçerli Parola"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Spam Değil"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH Anahtarları"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "OTP belirteciniz yok"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Hesabınızda iki adımlı kimlik doğrulamayı etkinleştirmek için bir OTP "
+"belirteci ekleyin."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Avatar Değiştir"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
-"Öntanımlı sunucuları kullanmıyorsanız biçim ya <code>kullanıcı.adı</code> ya "
-"da <code>kullanıcı.adı:sunucu.adı</code> şeklindedir:"
+"Öntanımlı sunucuları kullanmıyorsanız biçim ya <code>kullanıcı.adı</code>"
+" ya da <code>kullanıcı.adı:sunucu.adı</code> şeklindedir:"
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr "%(title)s için: <code>%(server)s</code>"
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "%(username)s için Ayarlar"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Profil"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "E-postalar"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG Anahtarları"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Sözleşmeler"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "%(username)s Profili"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Profili Düzenle"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "İlk OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr "Oluşturuldu"
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Şu Anki Saat"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Sohbet"
 
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr "Blog"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr "RSS"
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s Grup, %(agreementcount)s Sözleşme"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "imzalandı"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "sponsor"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "üye"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "%(username)s kullanıcısı mevcut değil"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Merhaba %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 "%(username)s kullanıcı adıyla hesabınızı etkinleştirmek için aşağıdaki "
 "bağlantıya tıklayın:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
 "%(username)s kullanıcı adı için bir hesap oluşturmadıysanız bu e-postayı "
 "görmezden gelebilirsiniz."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "AlmaLinux Takımı"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Merhaba,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Parolanızı sıfırlamak için aşağıdaki bağlantıya tıklayın. Parola sıfırlama "
-"isteğinde bulunmadıysanız lütfen bu e-postayı dikkate almayın."
+"Parolanızı sıfırlamak için aşağıdaki bağlantıya tıklayın. Parola "
+"sıfırlama isteğinde bulunmadıysanız lütfen bu e-postayı dikkate almayın."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "AlmaLinux Hesap Hizmetleri"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "ara..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Ayarlar"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Yardım"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Oturumu Kapat"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "%(noggin_link)s ile geliştirildi"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux Hesapları"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"AlmaLinux Hesapları, tüm AlmaLinux altyapısında hesabınızı oluşturmanıza ve "
-"yönetmenize olanak tanır."
+"AlmaLinux Hesapları, tüm AlmaLinux altyapısında hesabınızı oluşturmanıza "
+"ve yönetmenize olanak tanır."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
-"%(address)s e-posta adresini doğrulamak için aşağıdaki bağlantıya tıklayın:"
+"%(address)s e-posta adresini doğrulamak için aşağıdaki bağlantıya "
+"tıklayın:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"%(username)s hesabınızda %(address)s e-posta adresini ayarlamadıysanız bu e-"
-"postayı görmezden gelebilirsiniz."
+"%(username)s hesabınızda %(address)s e-posta adresini ayarlamadıysanız bu"
+" e-postayı görmezden gelebilirsiniz."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin takımı"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Noggin'e hoş geldiniz!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
 "Bu, FreeIPA için açık kaynaklı bir topluluk hizmet kapısıdır. Hesap "
-"oluşturmak, şifrenizi değiştirmek, grup üyeliklerini yönetmek ve daha pek "
-"çok şey için kullanılabilir."
+"oluşturmak, şifrenizi değiştirmek, grup üyeliklerini yönetmek ve daha pek"
+" çok şey için kullanılabilir."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
-"OTP etkinleştirildiğinde Kerberos biletleri kullanılırken ek yapılandırma "
-"gerekir"
+"OTP etkinleştirildiğinde Kerberos biletleri kullanılırken ek yapılandırma"
+" gerekir"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Sisteminizi yapılandırmayla ilgili ayrıntılar için <a href='https://"
-"docs.fedoraproject.org/en-US/fedora-accounts/user/#pkinit'>belgeleri</a> "
-"okuyun"
+"Sisteminizi yapılandırmayla ilgili ayrıntılar için <a "
+"href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>belgeleri</a> okuyun"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "Burada oturum açmak için Fedora hesabınızı da kullanabilirsiniz."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
-"Bu bağlantı %(ttl)s dakika boyunca geçerli olacaktır (%(valid_until)s UTC'ye "
-"kadar)."
+"Bu bağlantı %(ttl)s dakika boyunca geçerli olacaktır (%(valid_until)s "
+"UTC'ye kadar)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "Bağlantının süresi dolduysa, buradan yeni bir tane isteyebilirsiniz: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora Hesapları Sistemi"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora Hesapları"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora Kişileri"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"Fedora Hesapları, Fedora Araçları ve Altyapısı için bir hesap oluşturmanıza "
-"ve yönetmenize olanak tanır."
+"Fedora Hesapları, Fedora Araçları ve Altyapısı için bir hesap "
+"oluşturmanıza ve yönetmenize olanak tanır."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Grubu Düzenle"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
-"Grup ayrıntılarını değiştirmek veya sponsor eklemek için bir bilet oluşturun"
+"Grup ayrıntılarını değiştirmek veya sponsor eklemek için bir bilet "
+"oluşturun"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Hesabınızı devre dışı bırakmak için bir PDR isteği oluşturun"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Hesabın silinmesini iste"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Son OTP belirtecinizi mi kaybettiniz?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"Son OTP belirtecinizi kaybettiyseniz, %(admin_email)s adresine bir e-posta "
-"göndermeniz gerekmektedir. Yöneticinin kimliğinizi doğrulayabilmesi için "
-"lütfen bu e-postayı mümkünse hesabınızla ilişkili GPG anahtarını kullanarak "
-"imzalayın."
+"Son OTP belirtecinizi kaybettiyseniz, %(admin_email)s adresine bir "
+"e-posta göndermeniz gerekmektedir. Yöneticinin kimliğinizi "
+"doğrulayabilmesi için lütfen bu e-postayı mümkünse hesabınızla ilişkili "
+"GPG anahtarını kullanarak imzalayın."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Birden fazla belirteciniz varsa ve birini kaybettiyseniz, oturum açmak için "
-"başka bir belirteç kullanabilir ve kayıp belirteci hesabınızdan "
+"Birden fazla belirteciniz varsa ve birini kaybettiyseniz, oturum açmak "
+"için başka bir belirteç kullanabilir ve kayıp belirteci hesabınızdan "
 "silebilirsiniz."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
-"Bir OTP belirteci kaydetmediyseniz, bir belirteciniz yoktur ve bu sizin için "
-"geçerli değildir."
+"Bir OTP belirteci kaydetmediyseniz, bir belirteciniz yoktur ve bu sizin "
+"için geçerli değildir."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
@@ -1146,29 +1930,47 @@ msgstr ""
 "Yöneticilere spam gönderici olmadığınızı göstermek için lütfen "
 "%(email_link)s adresine bir e-posta gönderin ve durumu açıklayın."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"Bir Fedora hesabı kullanarak, <a href='https://docs.fedoraproject.org/en-US/"
-"project/code-of-conduct/'>Fedora&nbsp;Davranış&nbsp;Kurallarına</a> uymayı "
-"kabul etmiş olursunuz."
+"Bir Fedora hesabı kullanarak, <a href='https://docs.fedoraproject.org/en-"
+"US/project/code-of-conduct/'>Fedora&nbsp;Davranış&nbsp;Kurallarına</a> "
+"uymayı kabul etmiş olursunuz."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "Burada oturum açmak için CentOS hesabınızı da kullanabilirsiniz."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "%(groupname)s grubu bulunamadı."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr "%(username_or_email)s e-posta adresine sahip kullanıcı bulunamadı"
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Geri al"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(server)s üzerinde %(protocol)s"
@@ -1198,10 +2000,12 @@ msgstr "%(server)s üzerinde %(protocol)s"
 #~ msgstr "Kayıt"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Bu size bir daha asla gösterilmeyecek, belirteciniz kaydedilene kadar bu "
+#~ "Bu size bir daha asla gösterilmeyecek,"
+#~ " belirteciniz kaydedilene kadar bu "
 #~ "pencereyi kapatmayın."
 
 #~ msgid "Password or Password + One-Time-Password"
@@ -1217,10 +2021,13 @@ msgstr "%(server)s üzerinde %(protocol)s"
 #~ msgstr "RHBZ E-posta Adresi"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "bu grubun ayrıntılarını veya sponsorlarını değiştirmek için bir Fedora "
-#~ "Infra bileti oluşturun"
+#~ "bu grubun ayrıntılarını veya sponsorlarını "
+#~ "değiştirmek için bir Fedora Infra bileti"
+#~ " oluşturun"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Ayrıntı Değişikliği İste"
@@ -1233,3 +2040,4 @@ msgstr "%(server)s üzerinde %(protocol)s"
 
 #~ msgid "Website"
 #~ msgstr "Web Sitesi"
+

--- a/noggin/translations/uk/LC_MESSAGES/messages.po
+++ b/noggin/translations/uk/LC_MESSAGES/messages.po
@@ -9,99 +9,182 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2024-11-21 19:38+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
-"Language-Team: Ukrainian <https://translate.fedoraproject.org/projects/"
-"fedora-infra/noggin/uk/>\n"
 "Language: uk\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Ukrainian <https://translate.fedoraproject.org/projects"
+"/fedora-infra/noggin/uk/>\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
-"Строк дії пароля вичерпано. Будь ласка, виконайте процедуру скидання пароля."
+"Строк дії пароля вичерпано. Будь ласка, виконайте процедуру скидання "
+"пароля."
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "Не вдалося увійти до сервера IPA."
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "Вітаємо, %(username)s!"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "Жетон успішно синхронізовано"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "Не вдалося увійти до сервера IPA."
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "Не вдалося змінити пароль. Будь ласка, повторіть спробу."
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "Код підтвердження"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "У системі не виявлено користувача %(username)s."
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "Не вдалося додати користувача %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "Вийшло! %(username)s було додано до %(groupname)s."
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "Вийшло! %(username)s було вилучено з %(groupname)s."
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "Вийшло! %(username)s більше не є спонсором %(groupname)s."
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "Старий пароль або ім'я користувача є неправильними"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "Не вдалося змінити пароль."
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "Ваш пароль змінено"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
 msgstr ""
-"Ви вже надіслали запит щодо скидання пароля. Вам слід зачекати %(wait_min)s "
-"хвилин і %(wait_sec)s секунд, перш ніж ви зможете надіслати ще один запит."
+"Ви вже надіслали запит щодо скидання пароля. Вам слід зачекати "
+"%(wait_min)s хвилин і %(wait_sec)s секунд, перш ніж ви зможете надіслати "
+"ще один запит."
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "Запису користувача %(username)s не існує"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr ""
 "Нам не вдалося надіслати вам повідомлення електронної пошти. Будь ласка, "
 "повторіть спробу пізніше."
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "Вашу адресу електронної пошти відхилено smtp-сервером"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr ""
-"На вашу адресу електронної пошти було надіслано повідомлення із настановами "
-"щодо того, які скинути ваш пароль"
+"На вашу адресу електронної пошти було надіслано повідомлення із "
+"настановами щодо того, які скинути ваш пароль"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "Жетон є некоректним. Будь ласка, надішліть запит щодо нового."
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr ""
-"Строк дії жетона вичерпано. Будь ласка, надішліть запит щодо нового жетона."
+"Строк дії жетона вичерпано. Будь ласка, надішліть запит щодо нового "
+"жетона."
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
@@ -109,466 +192,749 @@ msgstr ""
 "Ваш пароль було змінено з часу запиту щодо цього жетона. Будь ласка, "
 "надішліть новий запит."
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
 msgstr ""
-"Ваш пароль було змінено, але він не відповідає правилам (%(policy_error)s), "
-"тому вважається застарілим. Система попросить вас змінити його після входу "
-"до неї."
+"Ваш пароль було змінено, але він не відповідає правилам "
+"(%(policy_error)s), тому вважається застарілим. Система попросить вас "
+"змінити його після входу до неї."
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "Помилкове значення."
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "Не вдалося змінити пароль. Будь ласка, повторіть спробу."
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "Ваш пароль змінено."
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "Перевірте вашу адресу електронної пошти"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 "Нам не вдалося надіслати вам електронний лист для перевірки адреси, будь "
 "ласка, спробуйте пізніше."
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
-"Ім'я користувача '%(username)s' або адреса електронної пошти '%(email)s' вже "
-"використовується."
+"Ім'я користувача '%(username)s' або адреса електронної пошти '%(email)s' "
+"вже використовується."
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 "Під час спроби створити обліковий запис сталася помилка. Будь ласка, "
 "повторіть спробу."
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "Здається, реєстрація не вдалася, будь ласка, спробуйте ще раз."
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
-"Електронний лист для перевірки адреси надіслано знову. Переконайтеся, що він "
-"не потрапив у папку спаму"
+"Електронний лист для перевірки адреси надіслано знову. Переконайтеся, що "
+"він не потрапив у папку спаму"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 "Маркер не надано, будь ласка, перевірте посилання для підтвердження "
 "електронної пошти."
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "Маркер недійсний, зареєструйтеся ще раз."
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "Цей маркер більше не дійсний, зареєструйтеся ще раз."
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "Цей користувач не знайдений, зареєструйтеся ще раз."
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
-"Ім'я користувача та адреса електронної пошти не збігаються з маркером, який "
-"ви використали, зареєструйтеся ще раз."
+"Ім'я користувача та адреса електронної пошти не збігаються з маркером, "
+"який ви використали, зареєструйтеся ще раз."
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 "Під час створення облікового запису сталася помилка. Повторіть спробу "
 "пізніше."
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
 msgstr ""
-"Ваш обліковий запис було створено, але вибраний вами пароль не відповідає "
-"правилам (%(policy_error)s), тому вважається застарілим. Система попросить "
-"вас змінити його після входу до неї."
+"Ваш обліковий запис було створено, але вибраний вами пароль не відповідає"
+" правилам (%(policy_error)s), тому вважається застарілим. Система "
+"попросить вас змінити його після входу до неї."
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
-"Ваш обліковий запис було створено, але під час встановлення вашого пароля "
-"сталася помилка (%(message)s). Можливо, вам доведеться змінити пароль після "
-"входу до системи."
+"Ваш обліковий запис було створено, але під час встановлення вашого пароля"
+" сталася помилка (%(message)s). Можливо, вам доведеться змінити пароль "
+"після входу до системи."
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "Вітаємо, ваш обліковий запис створено! Ласкаво просимо, %(name)s."
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "Вітаємо, ваш обліковий запис створено! Увійдіть, щоб продовжити."
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "Все"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "Невідомий"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "Не спам"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "Спам"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "Очікування"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "На даний момент реєстрація закрита."
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
 msgstr ""
 "Адреса електронної пошти %(mail)s має бути перевірена. Перевірте свою "
-"поштову скриньку та натисніть посилання, щоб продовжити. Якщо ви не можете "
-"знайти електронний лист за пару хвилин, перевірте папку зі спамом."
+"поштову скриньку та натисніть посилання, щоб продовжити. Якщо ви не "
+"можете знайти електронний лист за пару хвилин, перевірте папку зі спамом."
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "Жодних модифікацій."
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "Маркер недійсний, установіть адресу електронної пошти ще раз."
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "Цей маркер більше не дійсний, установіть електронну адресу знову."
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "Цей маркер не належить вам."
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "Помилковий пароль"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "Не вдалося створити жетон."
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "Маркер створено."
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "Не вдалося знайти секрет маркера"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "Неможливо перейменувати маркер."
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "Вибачте, ви не можете вимкнути ваш останній активний жетон."
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "Не вдалося вимкнути жетон."
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "Не вдається ввімкнути маркер. %(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "Вибачте, ви не можете вилучити ваш останній активний жетон."
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "Не вдалося вилучити жетон."
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "Не вдалося створити жетон."
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "Неможливо перейменувати маркер."
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "Помилковий пароль"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "Перевірте та ввімкніть маркер OTP"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "Скидання пароля для %(username)s"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "Неможливо підписати угоду \"%(name)s\": %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "Ви підписали угоду \"%(name)s\"."
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "Не вдалося вилучити жетон."
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "Маркер створено."
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "Це не схоже на дійсний псевдонім."
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "Це не виглядає як дійсне ім'я сервера."
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "Ім’я"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "Ім'я має бути непорожнім"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "Прізвище"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "Прізвище має бути непорожнім"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "Локаль"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "Локаль має бути непорожньою"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "Локаль має бути вказано у коректному форматі скороченого коду"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "Псевдоніми чату"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "Часовий пояс"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "Часовий пояс має бути непорожнім"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "Часовий пояс має бути коректним записом часового поясу"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "Користувач GitHub"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "Користувач GitLab"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "Потрібна дійсна URL-адреса"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "Вийти"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "Приватний"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
-"Приховати інформацію від інших користувачів, подробиці дивіться в Політиці "
-"конфіденційності."
+"Приховати інформацію від інших користувачів, подробиці дивіться в "
+"Політиці конфіденційності."
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "Займенники"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "Адреса електронної пошти"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "Адреса електронної пошти має бути непорожньою"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "Адреса електронної пошти має бути коректною"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Адреса ел. пошти у Bugzilla Red Hat"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "Ключі SSH"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "Ключі GPG"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "Назва маркера"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
-msgstr ""
-"Додайте необов’язкову назву, щоб допомогти вам ідентифікувати цей маркер"
+msgstr "Додайте необов’язкову назву, щоб допомогти вам ідентифікувати цей маркер"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "Введіть ваш поточний пароль"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "Вам слід вказати пароль"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "пройдіть повторну автентифікацію, щоб ми знали, що це ви"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "Одноразовий пароль"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "Введіть свій одноразовий пароль"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "Згенеруйте OTP маркер"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "Не вдалося знайти секрет маркера"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "Код підтвердження"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "Ви повинні надати код підтвердження"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "Перевірте та ввімкніть маркер OTP"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "Код неправильний, спробуйте ще раз."
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "Маркер не повинен бути порожнім"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "Згенеруйте OTP маркер"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "Згенеруйте OTP маркер"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "Введіть ваш поточний пароль"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "Пароль має бути непорожнім"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "Угода не повинна бути порожньою"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "Нове ім'я користувача-учасника має бути непорожнім"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "Користувач"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "Ім'я користувача має бути непорожнім"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "Перевірте вашу адресу електронної пошти"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "Вам слід вказати ім'я користувача"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "Пароль"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "Увійти"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "Новий Пароль"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "Пароль має бути непорожнім"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "Паролі мають збігатися"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "Підтвердження нового пароля"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
-"Одноразовий пароль (якщо у вашому обліковому записі ввімкнено двофакторну "
-"автентифікацію)"
+"Одноразовий пароль (якщо у вашому обліковому записі ввімкнено двофакторну"
+" автентифікацію)"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "Поточний пароль"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "Поточний пароль має бути непорожнім"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "Користувач"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "Ім'я користувача має бути непорожнім"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "Введіть ваше ім'я користувача, щоб скинути ваш пароль"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "Дозволені лише такі символи: \"%(chars)s\"."
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "Мені більше 16 років"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "Вам має бути більше 16 років, щоб створити обліковий запис"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "Зареєструватися"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "Повторно надіслати електронний лист"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "Будь ласка, виберіть міцніший пароль"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "Підтвердьте пароль"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "Задіяти"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "Перший OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "Вам слід вказати перший код"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "Другий OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "Вам слід вказати другий код"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "Ід. жетона"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "Адреси електронної пошти з цього домену заборонені"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "Змішаний регістр не допускається, спробуйте малий регістр."
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "Поле не має відповідати \"%(pattern)s\"."
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "Ця сторінка не знайдена."
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "Переглянути угоду"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "Підписати угоду користувача"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "Забули пароль?"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "Забули пароль чи ОТП?"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "Синхронізувати жетон"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "Назад"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "поточний"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "Далі"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "Групи"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "Користувачі"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "Відновлення пароля"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "Забули ваш пароль?"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
@@ -577,586 +943,1002 @@ msgstr ""
 "Введіть ваше ім'я користувача, і ми надішлемо повідомлення із подальшими "
 "настановами на вашу адресу електронної пошти."
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "Надіслати"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "Скинути пароль"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "Скидання пароля для %(username)s"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "Група %(groupname)s"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "Покинути групу"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
-"Ви є спонсором цієї групи, але не учасником. Додайте себе, якщо хочете стати "
-"учасником."
+"Ви є спонсором цієї групи, але не учасником. Додайте себе, якщо хочете "
+"стати учасником."
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "Щоб долучитися до цієї групи, зв'яжіться зі спонсором групи."
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "Спонсори"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "немає спонсорів"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "Учасники"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "додати користувача…"
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "Ще немає учасників."
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "Список груп"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s учасників"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "Немає груп."
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "Увійти"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "Помилка IPA"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "Виникла проблема з серверною частиною IPA. Повторіть спробу пізніше."
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
-"Ви також можете <a href=\"%(url)s\">вийти</a> та увійти знову, якщо проблема "
-"не зникне."
+"Ви також можете <a href=\"%(url)s\">вийти</a> та увійти знову, якщо "
+"проблема не зникне."
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "Вичерпано строк дії скидання пароля"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "Вичерпано строк дії скидання пароля для %(username)s"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "Змінити пароль"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "Реєстрація користувачів"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "Назва:"
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "Ел. пошта:"
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "Зареєстровано:"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "Стан:"
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "Очікування перевірки на спам"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "Не позначено як спам"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "Позначено як спам"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "Статус спаму невідомий"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "Прийняти"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "Позначити як спам"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "Вилучити"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
-"Якщо натиснути «Прийняти», користувачеві буде надіслано електронний лист для "
-"підтвердження. Інші кнопки нічого не надсилатимуть."
+"Якщо натиснути «Прийняти», користувачеві буде надіслано електронний лист "
+"для підтвердження. Інші кнопки нічого не надсилатимуть."
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "На даний момент немає зареєстрованих користувачів у цьому стані."
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "На даний момент немає реєстрації користувачів."
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "Активуйте свій акаунт"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "Створення облікового запису, крок 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "Привіт, %(name)s. Щоб активувати обліковий запис, виберіть пароль."
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "Підписати угоду користувача"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "Перевірте свою електронну адресу"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "Створення облікового запису, крок 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "Вітаємо, %(name)s, ваш обліковий запис створено!"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 "Перш ніж ви зможете увійти, ваша електронна адреса: %(mail)s має бути "
-"підтверджена. Перевірте свою поштову скриньку та натисніть посилання, щоб "
-"продовжити."
+"підтверджена. Перевірте свою поштову скриньку та натисніть посилання, щоб"
+" продовжити."
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
-"Якщо ви не можете знайти електронний лист за пару хвилин, перевірте папку зі "
-"спамом. Якщо його немає, ви можете попросити інший електронний лист для "
-"перевірки, натиснувши кнопку нижче."
+"Якщо ви не можете знайти електронний лист за пару хвилин, перевірте папку"
+" зі спамом. Якщо його немає, ви можете попросити інший електронний лист "
+"для перевірки, натиснувши кнопку нижче."
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "Триває перевірка спаму"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "Ваш обліковий запис перевіряється"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 "Перш ніж ви зможете увійти, ваш обліковий запис потрібно перевірити на "
 "ймовірність спаму. Це займе лише кілька секунд, зачекайте..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "Ваш обліковий запис вимагає схвалення адміністратора"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "Ваш обліковий запис має бути затверджений адміністратором."
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "Ви отримаєте електронний лист, коли рішення буде прийнято."
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "Дякую тобі за терпіння."
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "Ваш обліковий запис заблоковано"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "Ваш обліковий запис позначено як спам."
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "Щось пішло не так"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "Непідтримуваний статус спаму: %s, зверніться до адміністраторів"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "Синхронізувати жетон OTP"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "Синхронізувати жетон OTP"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "Синхронізація"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "Підтвердьте свою електронну адресу"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
-msgstr ""
-"Привіт, %(user_name)s. Ви бажаєте встановити %(attr_name)s на %(mail)s?"
+msgstr "Привіт, %(user_name)s. Ви бажаєте встановити %(attr_name)s на %(mail)s?"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "Скасувати"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "Зроби це"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "Зберегти"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "Ід. ключа GPG"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "Відкритий ключ SSH"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "Параметри для %(username)s"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "Код неправильний, спробуйте ще раз."
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "Згенеруйте OTP маркер"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr "(без назви)"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "У вас немає жетонів OTP"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "Очікування"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "Пароль"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
 msgstr "Сканування вашого нового жетона"
 
-msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
-"Ваш новий жетон готовий. Натисніть розташовану нижче кнопку, щоб відкрити "
-"код QR і сканувати його."
 
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr ""
+"Ваш новий жетон готовий. Натисніть розташовану нижче кнопку, щоб відкрити"
+" код QR і сканувати його."
+
+#: noggin/templates/user-settings-otp.html:17
 msgid "Reveal"
 msgstr "Показати"
 
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
 msgstr ""
 "або скопіюйте і вставте наведену нижче адресу жетона, якщо ви не можете "
 "сканувати код QR:"
 
+#: noggin/templates/user-settings-otp.html:26
 msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
 msgstr ""
-"Після реєстрації токена у вашій програмі перевірте його, згенерувавши свій "
-"перший код і ввівши його нижче:"
+"Після реєстрації токена у вашій програмі перевірте його, згенерувавши "
+"свій перший код і ввівши його нижче:"
 
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
 msgid "Add OTP Token"
 msgstr "Додати жетон OTP"
 
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
 msgstr ""
-"Створення вашого першого токена OTP увімкне двофакторну автентифікацію за "
-"допомогою OTP."
+"Створення вашого першого токена OTP увімкне двофакторну автентифікацію за"
+" допомогою OTP."
 
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr "Після ввімкнення двофакторну автентифікацію неможливо вимкнути."
 
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr "Жетони OTP"
 
-msgid "(no name)"
-msgstr "(без назви)"
-
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "Перейменувати"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "Вимкнути"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "Увімкнути"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "У вас немає жетонів OTP"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 "Додайте токен OTP, щоб увімкнути двофакторну автентифікацію у своєму "
 "обліковому записі."
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "Задіяти"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "Поточний пароль"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "Не спам"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "Ключі SSH"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "У вас немає жетонів OTP"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+"Додайте токен OTP, щоб увімкнути двофакторну автентифікацію у своєму "
+"обліковому записі."
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "Змінити аватар"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
-"            Формат <code>username</code> або <code>username:server.name</"
-"code>, якщо ви не використовуєте сервери за замовчуванням:\n"
+"            Формат <code>username</code> або "
+"<code>username:server.name</code>, якщо ви не використовуєте сервери за "
+"замовчуванням:\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              Для %(title)s: <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "Параметри для %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "Профіль"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "Електронні листи"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "Ключі SSH і GPG"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "Угоди"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "Профіль %(username)s"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "Редагувати профіль"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "Перший OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "Поточний час"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "Спілкування"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "Увійти"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s групи, %(agreementcount)s угоди"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "підписаний"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "спонсор"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "учасник"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "Запису користувача %(username)s не існує"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "Привіт %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr ""
 "Щоб активувати свій обліковий запис з іменем користувача %(username)s, "
 "натисніть посилання нижче:"
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr ""
-"Якщо ви не створювали обліковий запис для імені користувача %(username)s, ви "
-"можете ігнорувати цей електронний лист."
+"Якщо ви не створювали обліковий запис для імені користувача %(username)s,"
+" ви можете ігнорувати цей електронний лист."
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "Команда AlmaLinux"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "Привіт,"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr ""
-"Натисніть посилання нижче, щоб скинути пароль. Якщо ви не надсилали запит на "
-"скидання пароля, проігноруйте цей електронний лист."
+"Натисніть посилання нижче, щоб скинути пароль. Якщо ви не надсилали запит"
+" на скидання пароля, проігноруйте цей електронний лист."
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "Служби облікових записів AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "шукати…"
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "Параметри"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "Довідка"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "Вийти"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "На основі %(noggin_link)s"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "Облікові записи AlmaLinux"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr ""
-"Облікові записи AlmaLinux надають можливість створювати ваш обліковий запис "
-"і керувати ним у всій інфраструктурі AlmaLinux."
+"Облікові записи AlmaLinux надають можливість створювати ваш обліковий "
+"запис і керувати ним у всій інфраструктурі AlmaLinux."
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr ""
-"Щоб підтвердити адресу електронної пошти %(address)s, натисніть посилання "
-"нижче:"
+"Щоб підтвердити адресу електронної пошти %(address)s, натисніть посилання"
+" нижче:"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr ""
-"Якщо ви не вказали адресу електронної пошти %(address)s у своєму обліковому "
-"записі %(username)s, ви можете ігнорувати цей електронний лист."
+"Якщо ви не вказали адресу електронної пошти %(address)s у своєму "
+"обліковому записі %(username)s, ви можете ігнорувати цей електронний "
+"лист."
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Команда Noggin"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "Вітаємо у noggin!"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
 msgstr ""
-"Це самостійно обслуговуваний спільнотою портал до FreeIPA з відкритим кодом. "
-"За його допомогою ви можете створювати облікові записи, змінювати ваш "
-"пароль, керувати членством у групах тощо."
+"Це самостійно обслуговуваний спільнотою портал до FreeIPA з відкритим "
+"кодом. За його допомогою ви можете створювати облікові записи, змінювати "
+"ваш пароль, керувати членством у групах тощо."
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 "Під час використання квитків Kerberos, коли ввімкнено OTP, потрібна "
 "додаткова конфігурація"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"Прочитайте <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/"
-"user/#pkinit'>документацію</a>, щоб дізнатися більше про налаштування вашої "
-"системи"
+"Прочитайте <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>документацію</a>, щоб дізнатися більше про "
+"налаштування вашої системи"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
-msgstr ""
-"Ви також можете використовувати свій обліковий запис Fedora для входу тут."
+msgstr "Ви також можете використовувати свій обліковий запис Fedora для входу тут."
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
-"Це посилання буде дійсним протягом %(ttl)s хвилин (до %(valid_until)s UTC)."
+"Це посилання буде дійсним протягом %(ttl)s хвилин (до %(valid_until)s "
+"UTC)."
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
-msgstr ""
-"Якщо термін дії посилання закінчився, ви можете подати запит на нове тут: "
+msgstr "Якщо термін дії посилання закінчився, ви можете подати запит на нове тут: "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Облікові записи Fedora"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Облікові записи Fedora"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Вікі"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Люди Fedora"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr ""
-"За допомогою «Облікових записів Fedora» ви можете створювати облікові записи "
-"інструментів та інфраструктури Fedora та керувати ними."
+"За допомогою «Облікових записів Fedora» ви можете створювати облікові "
+"записи інструментів та інфраструктури Fedora та керувати ними."
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "Редагувати групу"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr "Щоб змінити деталі групи або додати спонсорів, надішліть заявку в"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "Створити запит PDR для вилучення вашого облікового запису"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "Запит щодо вилучення облікового запису"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "Втратили токен OTP?"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
 "Якщо ви втратили свій останній маркер OTP, вам потрібно надіслати "
 "електронний лист на адресу %(admin_email)s. Будь ласка, підпишіть цей "
 "електронний лист за допомогою ключа GPG, пов’язаного з вашим обліковим "
 "записом, якщо це можливо, щоб адміністратор міг підтвердити вашу особу."
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
-"Якщо у вас було кілька маркерів і ви втратили один, ви можете використати "
-"інший для входу та видалити втрачений маркер зі свого облікового запису."
+"Якщо у вас було кілька маркерів і ви втратили один, ви можете використати"
+" інший для входу та видалити втрачений маркер зі свого облікового запису."
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
@@ -1164,38 +1946,56 @@ msgstr ""
 "Якщо ви не зареєстрували маркер OTP, у вас його немає, і це вас не "
 "стосується."
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
-"Щоб повідомити адміністраторам, що ви не спамер, надішліть електронний лист "
-"на адресу %(email_link)s і поясніть ситуацію."
+"Щоб повідомити адміністраторам, що ви не спамер, надішліть електронний "
+"лист на адресу %(email_link)s і поясніть ситуацію."
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 "Використовуючи обліковий запис Fedora, ви погоджуєтеся дотримуватися <a "
 "href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Кодекс&nbsp;&nbsp;поведінки&nbsp;Fedora</a >."
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
-msgstr ""
-"Ви також можете використовувати свій обліковий запис CentOS для входу тут."
+msgstr "Ви також можете використовувати свій обліковий запис CentOS для входу тут."
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "Не вдалося знайти групи %(groupname)s."
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "Відмінити"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(protocol)s на %(server)s"
@@ -1225,11 +2025,13 @@ msgstr "%(protocol)s на %(server)s"
 #~ msgstr "Реєстрація"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr ""
-#~ "Ці дані більше ніколи не буде показано — не закривайте це вікно, аж доки "
-#~ "жетон не буде збережено."
+#~ "Ці дані більше ніколи не буде "
+#~ "показано — не закривайте це вікно, "
+#~ "аж доки жетон не буде збережено."
 
 #~ msgid "Password or Password + One-Time-Password"
 #~ msgstr "Пароль або Пароль+Одноразовий-пароль"
@@ -1244,9 +2046,12 @@ msgstr "%(protocol)s на %(server)s"
 #~ msgstr "Адреса ел. пошти RHBZ"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr ""
-#~ "створіть квиток Fedora Infra для зміни подробиць або спонсорів цієї групи"
+#~ "створіть квиток Fedora Infra для зміни"
+#~ " подробиць або спонсорів цієї групи"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "Створити запит щодо зміни подробиць"
@@ -1259,3 +2064,4 @@ msgstr "%(protocol)s на %(server)s"
 
 #~ msgid "Website"
 #~ msgstr "Веб-сайт"
+

--- a/noggin/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/noggin/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Chinese (Simplified, China) translations for PROJECT.
 # Copyright (C) 2025 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
@@ -7,38 +7,91 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
 "Language: zh_CN\n"
+"Language-Team: none\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.17.0\n"
+"Generated-By: Babel 2.18.0\n"
 
-#: noggin/controller/authentication.py:36
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr ""
 
-#: noggin/controller/authentication.py:47
-#: noggin/controller/authentication.py:54
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr ""
 
-#: noggin/controller/authentication.py:56
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr ""
 
-#: noggin/controller/authentication.py:81
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr ""
 
-#: noggin/controller/authentication.py:91 noggin/controller/password.py:49
-#: noggin/controller/password.py:300 noggin/controller/registration.py:307
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
+msgstr ""
+
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+msgid "Could not look up user."
+msgstr ""
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+msgid "Challenge expired. Please try again."
+msgstr ""
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
 msgstr ""
 
 #: noggin/controller/group.py:65
@@ -139,62 +192,62 @@ msgstr ""
 msgid "Your password has been changed."
 msgstr ""
 
-#: noggin/controller/registration.py:72 noggin/controller/user.py:178
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
-#: noggin/controller/registration.py:81 noggin/controller/user.py:225
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr ""
 
-#: noggin/controller/registration.py:129
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
-#: noggin/controller/registration.py:144
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:165 noggin/controller/registration.py:182
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
-#: noggin/controller/registration.py:193
+#: noggin/controller/registration.py:196
 msgid ""
 "The address validation email has be sent again. Make sure it did not land"
 " in your spam folder"
 msgstr ""
 
-#: noggin/controller/registration.py:209 noggin/controller/user.py:262
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
-#: noggin/controller/registration.py:216
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:219
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:225
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr ""
 
-#: noggin/controller/registration.py:236
+#: noggin/controller/registration.py:239
 msgid ""
 "The username and the email address don't match the token you used, please"
 " register again."
 msgstr ""
 
-#: noggin/controller/registration.py:259
+#: noggin/controller/registration.py:262
 msgid "Something went wrong while creating your account, please try again later."
 msgstr ""
 
-#: noggin/controller/registration.py:279
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
 "Your account has been created, but the password you chose does not comply"
@@ -202,49 +255,54 @@ msgid ""
 " will be asked to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:299
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
 msgstr ""
 
-#: noggin/controller/registration.py:317
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
 
-#: noggin/controller/registration.py:327
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr ""
 
-#: noggin/controller/registration.py:405
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
-#: noggin/controller/registration.py:406
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
-#: noggin/controller/registration.py:407
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:408
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
-#: noggin/controller/registration.py:409
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
-#: noggin/controller/root.py:49 noggin/templates/_register_form.html:27
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
-#: noggin/controller/user.py:231
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
 "The email address %(mail)s needs to be validated. Please check your inbox"
@@ -252,246 +310,365 @@ msgid ""
 "couple minutes, check your spam folder."
 msgstr ""
 
-#: noggin/controller/user.py:244
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
-#: noggin/controller/user.py:269
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:273
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr ""
 
-#: noggin/controller/user.py:277
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
-#: noggin/controller/user.py:354
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr ""
 
-#: noggin/controller/user.py:374
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr ""
 
-#: noggin/controller/user.py:376
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
-#: noggin/controller/user.py:426
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+msgid "Could not load OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr ""
 
-#: noggin/controller/user.py:453
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:455 noggin/controller/user.py:460
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr ""
 
-#: noggin/controller/user.py:486
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr ""
 
-#: noggin/controller/user.py:514
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr ""
 
-#: noggin/controller/user.py:516 noggin/controller/user.py:521
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr ""
 
-#: noggin/controller/user.py:540
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+msgid "Cannot create recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+msgid "Cannot regenerate recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+msgid "Incorrect password."
+msgstr ""
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+msgid "Error deleting OTP tokens."
+msgstr ""
+
+#: noggin/controller/user.py:922
+#, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr ""
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
-#: noggin/controller/user.py:548
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
-#: noggin/form/edit_user.py:78
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+msgid "Cannot delete the passkey."
+msgstr ""
+
+#: noggin/controller/user.py:1187
+msgid "The passkey has been removed."
+msgstr ""
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
-#: noggin/form/edit_user.py:80
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
-#: noggin/form/edit_user.py:90 noggin/form/register_user.py:26
-msgid "First Name"
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
 msgstr ""
 
 #: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
+msgid "First Name"
+msgstr ""
+
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:95 noggin/form/register_user.py:32
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr ""
 
-#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:100
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr ""
 
-#: noggin/form/edit_user.py:103
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:104
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr ""
 
-#: noggin/form/edit_user.py:110
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr ""
 
-#: noggin/form/edit_user.py:114 noggin/templates/user.html:42
-#: noggin/templates/user.html:44
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:117
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:118
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr ""
 
-#: noggin/form/edit_user.py:123
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:127
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr ""
 
-#: noggin/form/edit_user.py:134 noggin/form/edit_user.py:146
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
-#: noggin/form/edit_user.py:139 noggin/templates/user.html:94
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 msgid "Blog URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:151 noggin/templates/user.html:106
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
-#: noggin/form/edit_user.py:155
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
-#: noggin/form/edit_user.py:157
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
-#: noggin/form/edit_user.py:162 noggin/templates/user.html:29
-#: noggin/templates/user.html:31
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
-#: noggin/form/edit_user.py:167 noggin/form/register_user.py:67
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr ""
 
-#: noggin/form/edit_user.py:169 noggin/form/register_user.py:69
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr ""
 
-#: noggin/form/edit_user.py:174
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr ""
 
-#: noggin/form/edit_user.py:180 noggin/templates/user.html:84
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:185 noggin/templates/user.html:74
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr ""
 
-#: noggin/form/edit_user.py:191 noggin/templates/user-settings-otp.html:59
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr ""
 
-#: noggin/form/edit_user.py:193
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
-#: noggin/form/edit_user.py:197
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr ""
 
-#: noggin/form/edit_user.py:198 noggin/form/login_user.py:20
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
 #: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr ""
 
-#: noggin/form/edit_user.py:199
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
-#: noggin/form/edit_user.py:203 noggin/form/login_user.py:23
-#: noggin/templates/user-settings-otp.html:62
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:205
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr ""
 
-#: noggin/form/edit_user.py:208
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:214
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr ""
 
-#: noggin/form/edit_user.py:221 noggin/templates/user-settings-otp.html:27
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
-#: noggin/form/edit_user.py:222
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr ""
 
-#: noggin/form/edit_user.py:224
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
-#: noggin/form/edit_user.py:229
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr ""
 
-#: noggin/form/edit_user.py:234 noggin/form/edit_user.py:240
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr ""
 
-#: noggin/form/edit_user.py:249
+#: noggin/form/edit_user.py:257
+msgid "Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:261
+msgid "Regenerate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:266
+msgid "Enter your password to confirm"
+msgstr ""
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+msgid "Passkey must not be empty"
+msgstr ""
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
+msgstr ""
+
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
 msgstr ""
 
 #: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr ""
 
-#: noggin/form/group.py:17 noggin/form/register_user.py:38
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
 #: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr ""
@@ -500,22 +677,22 @@ msgstr ""
 msgid "Username must not be empty"
 msgstr ""
 
-#: noggin/form/login_user.py:11
+#: noggin/form/login_user.py:12
 msgid "Username (or email address)"
 msgstr ""
 
-#: noggin/form/login_user.py:13 noggin/form/sync_token.py:11
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr ""
 
-#: noggin/form/login_user.py:19 noggin/form/register_user.py:93
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
 #: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
-#: noggin/templates/user-settings-otp.html:60
-#: noggin/templates/user-settings.html:31
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr ""
 
-#: noggin/form/login_user.py:25
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr ""
 
@@ -523,11 +700,11 @@ msgstr ""
 msgid "New Password"
 msgstr ""
 
-#: noggin/form/password_reset.py:13 noggin/form/register_user.py:95
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr ""
 
-#: noggin/form/password_reset.py:15 noggin/form/register_user.py:97
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr ""
 
@@ -551,7 +728,7 @@ msgstr ""
 msgid "Username or Email"
 msgstr ""
 
-#: noggin/form/password_reset.py:37 noggin/form/register_user.py:40
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr ""
 
@@ -559,36 +736,36 @@ msgstr ""
 msgid "Enter your username or email to reset your password"
 msgstr ""
 
-#: noggin/form/register_user.py:54
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
-#: noggin/form/register_user.py:76
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
-#: noggin/form/register_user.py:79
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
-#: noggin/form/register_user.py:84 noggin/templates/index.html:21
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr ""
 
-#: noggin/form/register_user.py:88
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
-#: noggin/form/register_user.py:100
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr ""
 
-#: noggin/form/register_user.py:103
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr ""
 
-#: noggin/form/register_user.py:105
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
@@ -629,15 +806,15 @@ msgstr ""
 msgid "That page wasn't found."
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:10
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:12
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
-#: noggin/templates/_agreements_form.html:32
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
@@ -651,6 +828,14 @@ msgstr ""
 
 #: noggin/templates/_login_form.html:26
 msgid "Sync Token"
+msgstr ""
+
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
 msgstr ""
 
 #: noggin/templates/_pagination.html:8
@@ -873,7 +1058,7 @@ msgstr ""
 msgid "Sign agreements"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:15
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
@@ -886,13 +1071,12 @@ msgid_plural ""
 "Hello %(name)s. Please review the agreements below and then sign them if "
 "you agree with their content."
 msgstr[0] ""
-msgstr[1] ""
 
-#: noggin/templates/registration-agreements.html:28
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
-#: noggin/templates/registration-agreements.html:31
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
@@ -993,6 +1177,8 @@ msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
 #: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
 #: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
@@ -1003,7 +1189,7 @@ msgstr ""
 
 #: noggin/templates/user-settings-email.html:14
 #: noggin/templates/user-settings-keys.html:13
-#: noggin/templates/user-settings-profile.html:59
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr ""
 
@@ -1015,8 +1201,93 @@ msgstr ""
 msgid "SSH Public Key"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, python-format
+msgid "Reset OTP for %(username)s"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:21
+msgid ""
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+msgid "These codes will not be shown again."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
+msgid ""
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+msgid "Current OTP tokens:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
+msgid "(no name)"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+msgid "This user has no OTP tokens."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+msgid "Your password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
 #: noggin/templates/user-settings-otp.html:11
 msgid "Scan your new token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:16
@@ -1039,60 +1310,145 @@ msgid ""
 "your first code and entering it below:"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:47
-#: noggin/templates/user-settings-otp.html:75
-msgid "Add OTP Token"
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:53
-msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgid "Save these codes in a safe place."
 msgstr ""
 
 #: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
 msgid "Once enabled, two-factor authentication cannot be disabled."
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:74
+#: noggin/templates/user-settings-otp.html:125
 msgid "OTP Tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:85
-msgid "(no name)"
-msgstr ""
-
-#: noggin/templates/user-settings-otp.html:86
-#: noggin/templates/user-settings-otp.html:92
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:101
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:106
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:118
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr ""
 
-#: noggin/templates/user-settings-otp.html:119
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+msgid "Active"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+msgid "Current password"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+msgid "Passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+msgid "You have no passkeys"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
 msgstr ""
 
 #: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:38
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
 "The format is either <code>username</code> or "
 "<code>username:server.name</code> if you're not using the default "
 "servers:"
 msgstr ""
 
-#: noggin/templates/user-settings-profile.html:45
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
@@ -1122,7 +1478,7 @@ msgstr ""
 msgid "OTP"
 msgstr ""
 
-#: noggin/templates/user-settings.html:34
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
@@ -1135,45 +1491,54 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-#: noggin/templates/user.html:23
+#: noggin/templates/user.html:21
+msgid "Reset OTP"
+msgstr ""
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
-#: noggin/templates/user.html:51 noggin/templates/user.html:53
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
-#: noggin/templates/user.html:62 noggin/templates/user.html:63
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
-#: noggin/templates/user.html:94
+#: noggin/templates/user.html:98
 msgid "Blog"
 msgstr ""
 
-#: noggin/templates/user.html:106
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
-#: noggin/templates/user.html:118
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
-#: noggin/templates/user.html:140
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
-#: noggin/templates/user.html:157
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
-#: noggin/templates/user.html:175
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr ""
 
-#: noggin/templates/user.html:176
+#: noggin/templates/user.html:180
 msgid "member"
+msgstr ""
+
+#: noggin/templates/user.html:184
+#, python-format
+msgid "%(username)s has no group memberships"
 msgstr ""
 
 #: noggin/themes/almalinux/templates/email-validation.html:2
@@ -1435,12 +1800,24 @@ msgstr ""
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
-#: noggin/utility/controllers.py:56
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr ""
 
-#: noggin/utility/controllers.py:78
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
@@ -1453,3 +1830,4 @@ msgstr ""
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
+

--- a/noggin/translations/zh_Hans/LC_MESSAGES/messages.po
+++ b/noggin/translations/zh_Hans/LC_MESSAGES/messages.po
@@ -7,186 +7,276 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2024-04-29 14:36+0000\n"
 "Last-Translator: Charles Lee <lchopn@gmail.com>\n"
-"Language-Team: Chinese (Simplified) <https://translate.fedoraproject.org/"
-"projects/fedora-infra/noggin/zh_Hans/>\n"
 "Language: zh_Hans\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Chinese (Simplified) "
+"<https://translate.fedoraproject.org/projects/fedora-"
+"infra/noggin/zh_Hans/>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "密码已经过期。请重置。"
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "无法登录至 IPA 服务器。"
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "欢迎，%(username)s！"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "令牌已成功地同步"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "无法登录至 IPA 服务器。"
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "无法修改密码，请重试。"
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+msgid "Passkey verification failed."
+msgstr ""
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "没有在系统中找到用户 %(username)s。"
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "无法添加用户 %(username)s：%(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "成功了！%(username)s 已经被添加到 %(groupname)s。"
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "成功了！%(username)s 已经从 %(groupname)s 中移除。"
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "成功了！%(username)s 已不再是 %(groupname)s 的赞助者。"
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "旧密码和用户名不正确"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "无法修改密码。"
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "您的密码已被修改"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
-msgstr ""
-"您已经请求过了密码重置，您需要等待 %(wait_min)s 分 %(wait_sec)s 秒才能重新请"
-"求。"
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
+msgstr "您已经请求过了密码重置，您需要等待 %(wait_min)s 分 %(wait_sec)s 秒才能重新请求。"
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "用户 %(username)s 不存在"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "我们无法向您发送邮件，请稍后再试"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "您的电子邮件地址已被 smtp 服务器拒绝"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr "一封带有如何重置密码指引的邮件已被发送至您的邮箱"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "此令牌无效，请请求一个新的。"
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "此令牌已过期，请请求一个新的。"
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr "您的密码已在请求此令牌之后修改，请请求一个新的令牌。"
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
-msgstr ""
-"您的密码已被修改，但是因其并不符合策略（%(policy_error)s）而已被设置为过期。"
-"您将需要在登录后修改密码。"
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
+msgstr "您的密码已被修改，但是因其并不符合策略（%(policy_error)s）而已被设置为过期。您将需要在登录后修改密码。"
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "不正确的值。"
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "无法修改密码，请重试。"
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "您的密码已被修改。"
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr ""
 
 # | msgid "We could not send you an email, please retry later"
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 #, fuzzy
 msgid "We could not send you the address validation email, please retry later"
 msgstr "我们无法向您发送邮件，请稍后再试"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr ""
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "创建账户时出现错误，请重试。"
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr ""
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr ""
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:219
 #, fuzzy
 msgid "The token is invalid, please register again."
 msgstr "此令牌无效，请请求一个新的。"
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/registration.py:222
 #, fuzzy
 msgid "This token is no longer valid, please register again."
 msgstr "此令牌无效，请请求一个新的。"
 
 # | msgid "Could not change password, please try again."
+#: noggin/controller/registration.py:228
 #, fuzzy
 msgid "This user cannot be found, please register again."
 msgstr "无法修改密码，请重试。"
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr ""
 
 # | msgid "An error occurred while creating the account, please try again."
+#: noggin/controller/registration.py:262
 #, fuzzy
-msgid ""
-"Something went wrong while creating your account, please try again later."
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "创建账户时出现错误，请重试。"
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
-msgstr ""
-"您的账户已被创建，但是您选择的密码因不符合策略（%(policy_error)s）而被设置为"
-"过期。您将需要在登录后修改密码。"
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
+msgstr "您的账户已被创建，但是您选择的密码因不符合策略（%(policy_error)s）而被设置为过期。您将需要在登录后修改密码。"
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
-msgstr ""
-"您的账户已被创建，但是在设置您的密码时出现了错误（%(message)s）。您将需要在登"
-"录后修改密码。"
+msgstr "您的账户已被创建，但是在设置您的密码时出现了错误（%(message)s）。您将需要在登录后修改密码。"
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr ""
@@ -194,840 +284,1474 @@ msgstr ""
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/controller/registration.py:330
 #, fuzzy
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "恭喜，您已经拥有了一个账户！登录以继续。"
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr ""
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr ""
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr ""
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr ""
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr ""
 
+#: noggin/controller/user.py:153
 #, python-format
-msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
 msgstr ""
 
+#: noggin/controller/user.py:274
+#, python-format
+msgid ""
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr ""
+
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr ""
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:312
 #, fuzzy
 msgid "The token is invalid, please set the email again."
 msgstr "此令牌无效，请请求一个新的。"
 
 # | msgid "The token is invalid, please request a new one."
+#: noggin/controller/user.py:316
 #, fuzzy
 msgid "This token is no longer valid, please set the email again."
 msgstr "此令牌无效，请请求一个新的。"
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr ""
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "不正确的密码"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "无法创建令牌。"
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr ""
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+# | msgid "Could not log in to the IPA server."
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "无法登录至 IPA 服务器。"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
 # | msgid "Cannot create the token."
+#: noggin/controller/user.py:606
 #, fuzzy
 msgid "Cannot rename the token."
 msgstr "无法创建令牌。"
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "抱歉，您无法停用您的最后一个活动的令牌。"
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "无法停用此令牌。"
 
 # | msgid "Cannot disable the token."
+#: noggin/controller/user.py:666
 #, fuzzy, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "无法停用此令牌。"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "抱歉，您无法删除您的最后一个活动的令牌。"
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "无法删除此令牌。"
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "无法创建令牌。"
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+# | msgid "Cannot create the token."
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "无法创建令牌。"
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "不正确的密码"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "无法删除此令牌。"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "%(username)s 的密码重置"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr ""
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr ""
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "无法删除此令牌。"
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "您的密码已被修改。"
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr ""
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr ""
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "名"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "名不能为空"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "姓氏"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "姓氏不能为空"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "区域"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "区域不能为空"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "区域必须为有效的区域代码"
 
 # | msgid "IRC Nickname"
+#: noggin/form/edit_user.py:111
 #, fuzzy
 msgid "Chat Nicknames"
 msgstr "IRC 昵称"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "时区"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "时区不能为空"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "时区必须为有效的时区"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub 用户名"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab 用户名"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr ""
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "注销"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr ""
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr ""
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr ""
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "电子邮件地址"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "电子邮件地址不能为空"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "电子邮件地址必须有效"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla Email"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH 密钥"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG 密钥"
 
 # | msgid "Token ID"
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 #, fuzzy
 msgid "Token name"
 msgstr "令牌 ID"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr ""
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "输入您当前的密码"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "您必须提供一个密码"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr ""
 
 # | msgid "Confirm Password"
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 #, fuzzy
 msgid "One-Time Password"
 msgstr "确认密码"
 
 # | msgid "Enter your current password"
+#: noggin/form/edit_user.py:206
 #, fuzzy
 msgid "Enter your One-Time Password"
 msgstr "输入您当前的密码"
 
 # | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:209
 #, fuzzy
 msgid "Generate OTP Token"
 msgstr "同步 OTP 令牌"
 
 # | msgid "Could not log in to the IPA server."
+#: noggin/form/edit_user.py:215
 #, fuzzy
 msgid "Could not find the token secret"
 msgstr "无法登录至 IPA 服务器。"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr ""
 
 # | msgid "You must provide a second code"
+#: noggin/form/edit_user.py:223
 #, fuzzy
 msgid "You must provide a verification code"
 msgstr "必须提供一个第二代码"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr ""
 
 # | msgid "Could not change password, please try again."
+#: noggin/form/edit_user.py:230
 #, fuzzy
 msgid "The code is wrong, please try again."
 msgstr "无法修改密码，请重试。"
 
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 #, fuzzy
 msgid "Token must not be empty"
 msgstr "令牌必须不能为空"
 
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "同步 OTP 令牌"
+
+# | msgid "Sync OTP Token"
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "同步 OTP 令牌"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "输入您当前的密码"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "密码不能为空"
+
 # | msgid "token must not be empty"
+#: noggin/form/edit_user.py:285
 #, fuzzy
 msgid "Agreement must not be empty"
 msgstr "令牌必须不能为空"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "新成员的用户名不能为空"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "用户名"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "用户名必须不能为空"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "电子邮件地址"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "您必须提供一个用户名"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "密码"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "登录"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "新密码"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "密码不能为空"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "密码必须匹配"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "确认新密码"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr ""
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "当前密码"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "当前密码必须不能为空"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "用户名"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "用户名必须不能为空"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "输入您的用户名以重置您的密码"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr ""
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr ""
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr ""
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "注册"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr ""
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "请选择一个强密码"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "确认密码"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr ""
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "第一 OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "您必须提供一个第一代码"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "第二 OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "必须提供一个第二代码"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "令牌 ID"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr ""
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr ""
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr ""
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "此页面无法找到。"
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr ""
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:21
 #, fuzzy
 msgid "Forgot Password?"
 msgstr "忘记密码？"
 
 # | msgid "Forgot password?"
+#: noggin/templates/_login_form.html:23
 #, fuzzy
 msgid "Forgot Password or OTP?"
 msgstr "忘记密码？"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "同步令牌"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr ""
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr ""
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr ""
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "组"
 
 # | msgid "Username"
+#: noggin/templates/base.html:29
 #, fuzzy
 msgid "Users"
 msgstr "用户名"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "密码恢复"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "您是否忘记了您的密码？"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
 msgstr "输入您的用户名，一封带有下一步指引的邮件将会被发送至您的邮箱。"
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "发送"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "重置密码"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "%(username)s 的密码重置"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s 组"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr ""
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr ""
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "要加入此组，请联系组赞助者。"
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "赞助者"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "无赞助者"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "成员"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "添加用户..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "尚无成员。"
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "组列表"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s 个成员"
 
 # | msgid "Groups"
+#: noggin/templates/groups.html:49
 #, fuzzy
 msgid "No groups."
 msgstr "组"
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "登录"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr ""
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr ""
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr ""
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "已经过期的密码重置"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "%(username)s 的过期密码重置"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "修改密码"
 
 # | msgid "Register"
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 #, fuzzy
 msgid "Registering Users"
 msgstr "注册"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr ""
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr ""
 
 # | msgid "Register"
+#: noggin/templates/registering.html:53
 #, fuzzy
 msgid "Registered:"
 msgstr "注册"
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr ""
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr ""
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr ""
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr ""
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr ""
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr ""
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr ""
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr ""
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr ""
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr ""
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:2
 msgid "Sign agreements"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr ""
 
 # | msgid ""
 # | "Congratulations, you now have an account! Go ahead and sign in to
 # proceed."
+#: noggin/templates/registration-confirmation.html:16
 #, fuzzy, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "恭喜，您已经拥有了一个账户！登录以继续。"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr ""
 
 # | msgid "Your password has been changed"
+#: noggin/templates/registration-spamcheck-wait.html:13
 #, fuzzy
 msgid "Your account is being checked"
 msgstr "您的密码已被修改"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr ""
 
 # | msgid "Your password has been changed."
+#: noggin/templates/registration-spamcheck-wait.html:32
 #, fuzzy
 msgid "Your account has been flagged as spam."
 msgstr "您的密码已被修改。"
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr ""
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr ""
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "同步 OTP 令牌"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "同步 OTP 令牌"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "同步"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr ""
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr ""
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "保存"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG 密钥 ID"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH 公钥"
 
-msgid "Scan your new token"
-msgstr "扫描您的新令牌"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "%(username)s 的设置"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
-msgstr "您的新令牌已就绪。点击下方的按钮以显示二维码并扫描。"
-
-msgid "Reveal"
-msgstr "显示"
-
-msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr "若您无法扫描二维码，可以复制粘贴以下的 URL ："
-
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
 msgstr ""
 
-msgid "Add OTP Token"
-msgstr "添加 OTP 令牌"
+# | msgid "Could not change password, please try again."
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "无法修改密码，请重试。"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
 msgstr ""
 
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr ""
+# | msgid "Sync OTP Token"
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "同步 OTP 令牌"
 
-msgid "OTP Tokens"
-msgstr "OTP 令牌"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr ""
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "您没有 OTP 令牌"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+msgid "Warning:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "密码"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "扫描您的新令牌"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr "您的新令牌已就绪。点击下方的按钮以显示二维码并扫描。"
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "显示"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr "若您无法扫描二维码，可以复制粘贴以下的 URL ："
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "添加 OTP 令牌"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "OTP 令牌"
+
 # | msgid "Username"
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 #, fuzzy
 msgid "Rename"
 msgstr "用户名"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "停用"
 
 # | msgid "Disable"
+#: noggin/templates/user-settings-otp.html:157
 #, fuzzy
 msgid "Enable"
 msgstr "停用"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "您没有 OTP 令牌"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr ""
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "保存"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "当前密码"
+
+#: noggin/templates/user-settings-otp.html:223
+msgid "Not set up"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH 密钥"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "您没有 OTP 令牌"
+
+#: noggin/templates/user-settings-passkeys.html:40
+msgid "Add a passkey to enable passwordless authentication."
+msgstr ""
+
 # | msgid "Change Password"
+#: noggin/templates/user-settings-profile.html:12
 #, fuzzy
 msgid "Change Avatar"
 msgstr "修改密码"
 
+#: noggin/templates/user-settings-profile.html:37
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 
+#: noggin/templates/user-settings-profile.html:44
 #, python-format
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "%(username)s 的设置"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "个人资料"
 
 # | msgid "E-mail Address"
+#: noggin/templates/user-settings.html:22
 #, fuzzy
 msgid "Emails"
 msgstr "电子邮件地址"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG 密钥"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr ""
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "%(username)s 的个人资料"
 
 # | msgid "Profile"
+#: noggin/templates/user.html:17
 #, fuzzy
 msgid "Edit Profile"
 msgstr "个人资料"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "第一 OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr ""
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr ""
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "登录"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr ""
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr ""
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr ""
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "赞助者"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "成员"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "用户 %(username)s 不存在"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr ""
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, fuzzy, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr "要重置您的密码，请点击以下的链接："
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, fuzzy, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr "如果您并未请求重置您的密码，您可以忽略此邮件。"
 
 # | msgid "The Noggin team"
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "The AlmaLinux Team"
 msgstr "Noggin 团队"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr ""
 
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 #, fuzzy
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr "如果您并未请求重置您的密码，您可以忽略此邮件。"
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "搜索..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "设置"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr ""
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "注销"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "由 %(noggin_link)s 驱动"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/almalinux/templates/main.html:88
 #, fuzzy
 msgid "AlmaLinux Accounts"
 msgstr "Fedora 账户"
@@ -1035,13 +1759,18 @@ msgstr "Fedora 账户"
 # | msgid ""
 # | "Fedora Accounts allows you to create and manage an account for Fedora "
 # | "Tools and Infrastructure."
+#: noggin/themes/almalinux/templates/main.html:90
 #, fuzzy
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
 msgstr "Fedora 账户使得您可以创建和管理用于 Fedora 工具和基础设施的账户。"
 
 # | msgid "To reset your password, click on the link below:"
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, fuzzy, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "要重置您的密码，请点击以下的链接："
@@ -1049,83 +1778,119 @@ msgstr "要重置您的密码，请点击以下的链接："
 # | msgid ""
 # | "If you did not request your password to be reset, you can ignore this "
 # | "email."
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, fuzzy, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
 msgstr "如果您并未请求重置您的密码，您可以忽略此邮件。"
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin 团队"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "欢迎使用 noggin！"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
-msgstr ""
-"这是一个开源的适用于 FreeIPA 的社区自服务门户。其使得您可以做到创建用户、修改"
-"密码、管理组成员等一系列事情。"
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
+msgstr "这是一个开源的适用于 FreeIPA 的社区自服务门户。其使得您可以做到创建用户、修改密码、管理组成员等一系列事情。"
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr ""
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr ""
 
 # | msgid "The token has expired, please request a new one."
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 #, fuzzy
 msgid "If the link has expired, you can request a new one here: "
 msgstr "此令牌已过期，请请求一个新的。"
 
 # | msgid "Fedora Accounts"
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 #, fuzzy
 msgid "Fedora Accounts System"
 msgstr "Fedora 账户"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora 账户"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr "Fedora 账户使得您可以创建和管理用于 Fedora 工具和基础设施的账户。"
 
 # | msgid "Groups"
+#: noggin/themes/fas/templates/main.html:167
 #, fuzzy
 msgid "Edit Group"
 msgstr "组"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "创建一个 PDR 请求以停用您的账户"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "请求账户删除"
 
 # | msgid "Did you lose your OTP token?"
+#: noggin/themes/fas/templates/main.html:190
 #, fuzzy
 msgid "Did you lose your last OTP token?"
 msgstr "您是否遗失了您的 OTP 令牌？"
@@ -1136,51 +1901,74 @@ msgstr "您是否遗失了您的 OTP 令牌？"
 # "
 # | "your account if possible, so that the administrator can verify your "
 # | "identity."
+#: noggin/themes/fas/templates/main.html:194
 #, fuzzy, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"如果您遗失了您的 OTP 令牌，您需要发送一封邮件至 %(admin_email)s。请在可能的情"
-"况下用与您账户相关联的 GPG 密钥签名此邮件，以便管理员确认您的身份。"
+"如果您遗失了您的 OTP 令牌，您需要发送一封邮件至 %(admin_email)s。请在可能的情况下用与您账户相关联的 GPG "
+"密钥签名此邮件，以便管理员确认您的身份。"
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr ""
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "无法找到组 %(groupname)s。"
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr ""
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr ""
@@ -1207,8 +1995,9 @@ msgstr ""
 #~ msgstr "注册"
 
 #~ msgid ""
-#~ "This will never be shown to you again, don't close this window until your "
-#~ "token is saved."
+#~ "This will never be shown to you"
+#~ " again, don't close this window until"
+#~ " your token is saved."
 #~ msgstr "这些信息将不会再向您显示，在保存您的令牌前不要关闭此窗口。"
 
 #~ msgid "Password or Password + One-Time-Password"
@@ -1224,8 +2013,11 @@ msgstr ""
 #~ msgstr "RHBZ E-Mail"
 
 #~ msgid ""
-#~ "file a Fedora Infra ticket to change the details or sponsors of this group"
+#~ "file a Fedora Infra ticket to "
+#~ "change the details or sponsors of "
+#~ "this group"
 #~ msgstr "提交一个 Fedora Infra 工单以修改此组的详细信息或赞助者"
 
 #~ msgid "Request Change of Details"
 #~ msgstr "请求详细信息变更"
+

--- a/noggin/translations/zh_Hant/LC_MESSAGES/messages.po
+++ b/noggin/translations/zh_Hant/LC_MESSAGES/messages.po
@@ -10,1116 +10,1886 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-12-11 11:55+0100\n"
+"POT-Creation-Date: 2026-07-02 20:33+0300\n"
 "PO-Revision-Date: 2025-04-28 00:53+0000\n"
-"Last-Translator: Weblate Translation Memory <noreply-mt-weblate-translation-"
-"memory@weblate.org>\n"
-"Language-Team: Chinese (Traditional Han script) <https://"
-"translate.fedoraproject.org/projects/fedora-infra/noggin/zh_Hant/>\n"
+"Last-Translator: Weblate Translation Memory <noreply-mt-weblate-"
+"translation-memory@weblate.org>\n"
 "Language: zh_Hant\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Chinese (Traditional Han script) "
+"<https://translate.fedoraproject.org/projects/fedora-"
+"infra/noggin/zh_Hant/>\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.17.0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
 
+#: noggin/defaults.py:79
+msgid ""
+"Not signing the FPCA will prevent you from logging in to many Fedora "
+"services such as Pagure, Fedora Discussion, and other contributor "
+"platforms."
+msgstr ""
+
+#: noggin/controller/authentication.py:51
 msgid "Password expired. Please reset it."
 msgstr "密碼已過期。請重新設定。"
 
+#: noggin/controller/authentication.py:62
+#: noggin/controller/authentication.py:69
 msgid "Could not log in to the IPA server."
 msgstr "無法登入 IPA 伺服器。"
 
+#: noggin/controller/authentication.py:71
+#: noggin/controller/authentication.py:256
 #, python-format
 msgid "Welcome, %(username)s!"
 msgstr "歡迎， %(username)s！"
 
+#: noggin/controller/authentication.py:96
 msgid "Token successfully synchronized"
 msgstr "權杖己成功同步"
 
+#: noggin/controller/authentication.py:106 noggin/controller/password.py:49
+#: noggin/controller/password.py:300 noggin/controller/registration.py:310
 msgid "No IPA server available"
 msgstr ""
 
+#: noggin/controller/authentication.py:130
+msgid "User not found."
+msgstr ""
+
+#: noggin/controller/authentication.py:135
+#: noggin/controller/authentication.py:210
+#, fuzzy
+msgid "Could not look up user."
+msgstr "無法登入 IPA 伺服器。"
+
+#: noggin/controller/authentication.py:141
+msgid "No passkeys registered for this user."
+msgstr ""
+
+#: noggin/controller/authentication.py:181
+msgid "Challenge missing or expired."
+msgstr ""
+
+#: noggin/controller/authentication.py:184
+#, fuzzy
+msgid "Challenge expired. Please try again."
+msgstr "無法變更密碼，請再試一次。"
+
+#: noggin/controller/authentication.py:190
+msgid "Missing request body."
+msgstr ""
+
+#: noggin/controller/authentication.py:200
+msgid "Missing assertion data."
+msgstr ""
+
+#: noggin/controller/authentication.py:223
+msgid "Unknown credential."
+msgstr ""
+
+#: noggin/controller/authentication.py:242
+#, fuzzy
+msgid "Passkey verification failed."
+msgstr "驗證碼"
+
+#: noggin/controller/authentication.py:248
+msgid "Passkey login is not available."
+msgstr ""
+
+#: noggin/controller/authentication.py:253
+msgid "Could not establish session."
+msgstr ""
+
+#: noggin/controller/group.py:65
 #, python-format
 msgid "User %(username)s was not found in the system."
 msgstr "系統中未找到使用者 %(username)s。"
 
+#: noggin/controller/group.py:78
 #, python-format
 msgid "Unable to add user %(username)s: %(errormessage)s"
 msgstr "無法新增使用者 %(username)s: %(errormessage)s"
 
+#: noggin/controller/group.py:87
 #, python-format
 msgid "You got it! %(username)s has been added to %(groupname)s."
 msgstr "您成功了！%(username)s 已加入 %(groupname)s。"
 
+#: noggin/controller/group.py:139
 #, python-format
 msgid "You got it! %(username)s has been removed from %(groupname)s."
 msgstr "您成功了！%(username)s 已從 %(groupname)s 移除。"
 
+#: noggin/controller/group.py:194
 #, python-format
 msgid "You got it! %(username)s is no longer a sponsor of %(groupname)s."
 msgstr "你猜對了！%(username)s 不再是 %(groupname)s 的贊助商。"
 
+#: noggin/controller/password.py:60
 msgid "The old password or username is not correct"
 msgstr "舊密碼或使用者名稱不正確"
 
+#: noggin/controller/password.py:71
 msgid "Could not change password."
 msgstr "無法變更密碼。"
 
+#: noggin/controller/password.py:74
 msgid "Your password has been changed"
 msgstr "您的密碼已更改"
 
+#: noggin/controller/password.py:156
 #, python-format
 msgid ""
-"You have already requested a password reset, you need to wait %(wait_min)s "
-"minute(s) and %(wait_sec)s seconds before you can request another."
-msgstr ""
-"您已經要求過密碼重設，您需要等待 %(wait_min)s 分鐘和 %(wait_sec)s 秒才能再要"
-"求一次。"
+"You have already requested a password reset, you need to wait "
+"%(wait_min)s minute(s) and %(wait_sec)s seconds before you can request "
+"another."
+msgstr "您已經要求過密碼重設，您需要等待 %(wait_min)s 分鐘和 %(wait_sec)s 秒才能再要求一次。"
 
+#: noggin/controller/password.py:167
 #, python-format
 msgid "User %(username)s does not exist"
 msgstr "使用者 %(username)s 不存在"
 
+#: noggin/controller/password.py:184
 msgid "We could not send you an email, please retry later"
 msgstr "我們無法傳送電子郵件給您，請稍後再試"
 
+#: noggin/controller/password.py:188
 msgid "Your email address is rejected by smtp server"
 msgstr "您的電子郵件地址被 smtp 伺服器拒絕"
 
+#: noggin/controller/password.py:198
 msgid ""
 "An email has been sent to your address with instructions on how to reset "
 "your password"
 msgstr "我們已向您的地址發送電子郵件，該封郵件會說明如何重設您的密碼"
 
+#: noggin/controller/password.py:216
 msgid "The token is invalid, please request a new one."
 msgstr "權杖己無效，請重新申請新的權杖。"
 
+#: noggin/controller/password.py:224
 msgid "The token has expired, please request a new one."
 msgstr "權杖已過期，請重新申請新的權杖。"
 
+#: noggin/controller/password.py:234
 msgid ""
 "Your password has been changed since you requested this token, please "
 "request a new one."
 msgstr "您的密碼在您申請此權杖後已經更改，請重新申請一個新密碼。"
 
+#: noggin/controller/password.py:265
 #, python-format
 msgid ""
 "Your password has been changed, but it does not comply with the policy "
-"(%(policy_error)s) and has thus been set as expired. You will be asked to "
-"change it after logging in."
-msgstr ""
-"您的密碼已更改，但不符合政策 (%(policy_error)s) 的規定，因此被設定為過期。登"
-"入後，系統會要求您更改密碼。"
+"(%(policy_error)s) and has thus been set as expired. You will be asked to"
+" change it after logging in."
+msgstr "您的密碼已更改，但不符合政策 (%(policy_error)s) 的規定，因此被設定為過期。登入後，系統會要求您更改密碼。"
 
+#: noggin/controller/password.py:289
 msgid "Incorrect value."
 msgstr "不正確的值。"
 
+#: noggin/controller/password.py:297
 msgid "Could not change password, please try again."
 msgstr "無法變更密碼，請再試一次。"
 
+#: noggin/controller/password.py:303
 msgid "Your password has been changed."
 msgstr "您的密碼已更改。"
 
+#: noggin/controller/registration.py:75 noggin/controller/user.py:221
 msgid "Verify your email address"
 msgstr "驗證您的電子郵件地址"
 
+#: noggin/controller/registration.py:84 noggin/controller/user.py:268
 msgid "We could not send you the address validation email, please retry later"
 msgstr "我們無法傳送地址驗證電子郵件給您，請稍後再試"
 
+#: noggin/controller/registration.py:132
 #, python-format
 msgid ""
 "The username '%(username)s' or the email address '%(email)s' are already "
 "taken."
 msgstr "使用者名稱 '%(username)s' 或電子郵件地址 '%(email)s' 已被使用。"
 
+#: noggin/controller/registration.py:147
 msgid "An error occurred while creating the account, please try again."
 msgstr "建立帳戶時發生錯誤，請再試一次。"
 
+#: noggin/controller/registration.py:168 noggin/controller/registration.py:185
 msgid "The registration seems to have failed, please try again."
 msgstr "提交註冊請求似乎失敗，請再試一次。"
 
+#: noggin/controller/registration.py:196
 msgid ""
-"The address validation email has be sent again. Make sure it did not land in "
-"your spam folder"
+"The address validation email has be sent again. Make sure it did not land"
+" in your spam folder"
 msgstr "地址驗證電子郵件已再次寄出。請確定它沒有進入您的垃圾郵件夾中"
 
+#: noggin/controller/registration.py:212 noggin/controller/user.py:305
 msgid "No token provided, please check your email validation link."
 msgstr "未提供權杖，請檢查您的電子郵件驗證連結。"
 
+#: noggin/controller/registration.py:219
 msgid "The token is invalid, please register again."
 msgstr "權杖無效，請重新註冊。"
 
+#: noggin/controller/registration.py:222
 msgid "This token is no longer valid, please register again."
 msgstr "此權杖已失效，請重新註冊。"
 
+#: noggin/controller/registration.py:228
 msgid "This user cannot be found, please register again."
 msgstr "無法找到此使用者，請重新註冊。"
 
+#: noggin/controller/registration.py:239
 msgid ""
-"The username and the email address don't match the token you used, please "
-"register again."
+"The username and the email address don't match the token you used, please"
+" register again."
 msgstr "使用者名稱和電子郵件地址與您使用的權杖不符，請重新註冊。"
 
-msgid ""
-"Something went wrong while creating your account, please try again later."
+#: noggin/controller/registration.py:262
+msgid "Something went wrong while creating your account, please try again later."
 msgstr "在建立您的帳戶時出了問題，請稍後再試。"
 
+#: noggin/controller/registration.py:282
 #, python-format
 msgid ""
-"Your account has been created, but the password you chose does not comply "
-"with the policy (%(policy_error)s) and has thus been set as expired. You "
-"will be asked to change it after logging in."
-msgstr ""
-"您的帳戶已建立，但您選擇的密碼不符合政策 (%(policy_error)s) 的規定，因此被設"
-"定為過期。登入後，系統會要求您變更密碼。"
+"Your account has been created, but the password you chose does not comply"
+" with the policy (%(policy_error)s) and has thus been set as expired. You"
+" will be asked to change it after logging in."
+msgstr "您的帳戶已建立，但您選擇的密碼不符合政策 (%(policy_error)s) 的規定，因此被設定為過期。登入後，系統會要求您變更密碼。"
 
+#: noggin/controller/registration.py:302
 #, python-format
 msgid ""
 "Your account has been created, but an error occurred while setting your "
 "password (%(message)s). You may need to change it after logging in."
-msgstr ""
-"您的帳戶已建立，但在設定密碼時發生錯誤 (%(message)s)。您可能需要在登入後更改"
-"密碼。"
+msgstr "您的帳戶已建立，但在設定密碼時發生錯誤 (%(message)s)。您可能需要在登入後更改密碼。"
 
+#: noggin/controller/registration.py:320
 #, python-format
 msgid "Congratulations, your account has been created! Welcome, %(name)s."
 msgstr "恭喜，您的帳戶已建立！歡迎，%(name)s。"
 
+#: noggin/controller/registration.py:330
 msgid ""
 "Congratulations, your account has been created! Go ahead and sign in to "
 "proceed."
 msgstr "恭喜您，您的帳戶已經建立！請繼續登入以進行下一步。"
 
+#: noggin/controller/registration.py:408
 msgid "All"
 msgstr "全部"
 
+#: noggin/controller/registration.py:409
 msgid "Unknown"
 msgstr "未知"
 
+#: noggin/controller/registration.py:410
 msgid "Not Spam"
 msgstr "不是垃圾郵件"
 
+#: noggin/controller/registration.py:411
 msgid "Spam"
 msgstr "垃圾郵件"
 
+#: noggin/controller/registration.py:412
 msgid "Awaiting"
 msgstr "等待中"
 
+#: noggin/controller/root.py:49 noggin/templates/_register_form.html:37
 msgid "Registration is closed at the moment."
 msgstr "目前註冊已截止。"
 
+#: noggin/controller/user.py:153
+#, python-format
+msgid "Profile Updated: <a href=\"%(url)s\">view your profile</a>"
+msgstr ""
+
+#: noggin/controller/user.py:274
 #, python-format
 msgid ""
-"The email address %(mail)s needs to be validated. Please check your inbox "
-"and click on the link to proceed. If you can't find the email in a couple "
-"minutes, check your spam folder."
-msgstr ""
-"電子郵件地址 %(mail)s 需要驗證。請檢查您的收件匣，然後按一下連結繼續。如果您"
-"在幾分鐘之內找不到該電子郵件，請檢查您的垃圾信件匣。"
+"The email address %(mail)s needs to be validated. Please check your inbox"
+" and click on the link to proceed. If you can't find the email in a "
+"couple minutes, check your spam folder."
+msgstr "電子郵件地址 %(mail)s 需要驗證。請檢查您的收件匣，然後按一下連結繼續。如果您在幾分鐘之內找不到該電子郵件，請檢查您的垃圾信件匣。"
 
+#: noggin/controller/user.py:287
 msgid "No modifications."
 msgstr "無修改。"
 
+#: noggin/controller/user.py:312
 msgid "The token is invalid, please set the email again."
 msgstr "權杖無效，請重新設定電子郵件。"
 
+#: noggin/controller/user.py:316
 msgid "This token is no longer valid, please set the email again."
 msgstr "此權杖已失效，請重新設定電子郵件。"
 
+#: noggin/controller/user.py:320
 msgid "This token does not belong to you."
 msgstr "此權杖不屬於您。"
 
+#: noggin/controller/user.py:399 noggin/controller/user.py:726
+#: noggin/controller/user.py:781
 msgid "Incorrect password"
 msgstr "密碼不正確"
 
+#: noggin/controller/user.py:419
 msgid "Cannot create the token."
 msgstr "無法建立權杖。"
 
+#: noggin/controller/user.py:421
 msgid "The token has been created."
 msgstr "權杖已建立。"
 
+#: noggin/controller/user.py:444
+#, python-format
+msgid ""
+"<a href=\"%(url)s\">Generate recovery codes</a> now to avoid being locked"
+" out."
+msgstr ""
+
+#: noggin/controller/user.py:545
+msgid ""
+"Could not load your token list, but your new recovery codes are shown "
+"below. Please save them now."
+msgstr ""
+
+#: noggin/controller/user.py:550 noggin/controller/user.py:945
+#, fuzzy
+msgid "Could not load OTP tokens."
+msgstr "無法找到權杖密碼"
+
+#: noggin/controller/user.py:591
+msgid "This description is reserved for recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:606
 msgid "Cannot rename the token."
 msgstr "無法重新命名權杖。"
 
+#: noggin/controller/user.py:633
 msgid "Sorry, You cannot disable your last active token."
 msgstr "抱歉，您無法停用最後一個使用中的權杖。"
 
+#: noggin/controller/user.py:635 noggin/controller/user.py:640
 msgid "Cannot disable the token."
 msgstr "無法停用權杖。"
 
+#: noggin/controller/user.py:666
 #, python-format
 msgid "Cannot enable the token. %(errormessage)s"
 msgstr "無法啟用權杖。%(errormessage)s"
 
+#: noggin/controller/user.py:694
 msgid "Sorry, You cannot delete your last active token."
 msgstr "抱歉，您無法刪除上一個使用中的權杖。"
 
+#: noggin/controller/user.py:696 noggin/controller/user.py:701
 msgid "Cannot delete the token."
 msgstr "無法刪除權杖。"
 
+#: noggin/controller/user.py:741 noggin/controller/user.py:756
+#: noggin/controller/user.py:835
+#, fuzzy
+msgid "Cannot create recovery codes."
+msgstr "無法建立權杖。"
+
+#: noggin/controller/user.py:745
+msgid "You already have recovery codes. Regenerate them instead."
+msgstr ""
+
+#: noggin/controller/user.py:795 noggin/controller/user.py:818
+#: noggin/controller/user.py:826
+#, fuzzy
+msgid "Cannot regenerate recovery codes."
+msgstr "無法重新命名權杖。"
+
+#: noggin/controller/user.py:806
+msgid ""
+"Cannot regenerate recovery codes while they are your only active token. "
+"Add a regular OTP token first."
+msgstr ""
+
+#: noggin/controller/user.py:862
+#, fuzzy
+msgid "Incorrect password."
+msgstr "密碼不正確"
+
+#: noggin/controller/user.py:874
+msgid "Error creating recovery codes."
+msgstr ""
+
+#: noggin/controller/user.py:890
+msgid ""
+"Recovery codes were created but old tokens could not be removed. Please "
+"try again."
+msgstr ""
+
+#: noggin/controller/user.py:913
+#, fuzzy
+msgid "Error deleting OTP tokens."
+msgstr "驗證並啟用 OTP 權杖"
+
+#: noggin/controller/user.py:922
+#, fuzzy, python-format
+msgid "OTP tokens have been reset for %(username)s."
+msgstr "重設 %(username)s 的密碼"
+
+#: noggin/controller/user.py:967
 #, python-format
 msgid "Cannot sign the agreement \"%(name)s\": %(error)s"
 msgstr "無法簽署 \"%(name)s\" 協議： %(error)s"
 
+#: noggin/controller/user.py:975
 #, python-format
 msgid "You signed the \"%(name)s\" agreement."
 msgstr "您簽署了 \"%(name)s\" 協議。"
 
+#: noggin/controller/user.py:1174
+msgid "Invalid passkey value."
+msgstr ""
+
+#: noggin/controller/user.py:1182
+#, fuzzy
+msgid "Cannot delete the passkey."
+msgstr "無法刪除權杖。"
+
+#: noggin/controller/user.py:1187
+#, fuzzy
+msgid "The passkey has been removed."
+msgstr "權杖已建立。"
+
+#: noggin/form/edit_user.py:79
 msgid "This does not look like a valid nickname."
 msgstr "這看起來不像是有效的暱稱。"
 
+#: noggin/form/edit_user.py:81
 msgid "This does not look like a valid server name."
 msgstr "這看起來不像是有效的伺服器名稱。"
 
+#: noggin/form/edit_user.py:86
+msgid "URL should start with \"https://\"."
+msgstr ""
+
+#: noggin/form/edit_user.py:91 noggin/form/register_user.py:27
 msgid "First Name"
 msgstr "名字"
 
+#: noggin/form/edit_user.py:92 noggin/form/register_user.py:28
 msgid "First name must not be empty"
 msgstr "名字不可為空白"
 
+#: noggin/form/edit_user.py:96 noggin/form/register_user.py:33
 msgid "Last Name"
 msgstr "姓氏"
 
+#: noggin/form/edit_user.py:97 noggin/form/register_user.py:34
 msgid "Last name must not be empty"
 msgstr "姓氏不可為空白"
 
+#: noggin/form/edit_user.py:101
 msgid "Locale"
 msgstr "地點"
 
+#: noggin/form/edit_user.py:104
 msgid "Locale must not be empty"
 msgstr "地點不得為空"
 
+#: noggin/form/edit_user.py:105
 msgid "Locale must be a valid locale short-code"
 msgstr "地點必須是有效的 locale 短碼"
 
+#: noggin/form/edit_user.py:111
 msgid "Chat Nicknames"
 msgstr "聊天暱稱"
 
+#: noggin/form/edit_user.py:115 noggin/templates/user.html:46
+#: noggin/templates/user.html:48
 msgid "Timezone"
 msgstr "時區"
 
+#: noggin/form/edit_user.py:118
 msgid "Timezone must not be empty"
 msgstr "時區不可為空白"
 
+#: noggin/form/edit_user.py:119
 msgid "Timezone must be a valid timezone"
 msgstr "時區必須是有效的時區"
 
+#: noggin/form/edit_user.py:124
 msgid "GitHub Username"
 msgstr "GitHub 使用者名稱"
 
+#: noggin/form/edit_user.py:128
 msgid "GitLab Username"
 msgstr "GitLab 使用者名稱"
 
+#: noggin/form/edit_user.py:135 noggin/form/edit_user.py:147
 msgid "Valid URL required"
 msgstr "需要有效的 URL"
 
+#: noggin/form/edit_user.py:140 noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog URL"
 msgstr "登出"
 
+#: noggin/form/edit_user.py:152 noggin/templates/user.html:110
 msgid "RSS URL"
 msgstr ""
 
+#: noggin/form/edit_user.py:156
 msgid "Private"
 msgstr "私有"
 
+#: noggin/form/edit_user.py:158
 msgid "Hide information from other users, see the Privacy Policy for details."
 msgstr "隱藏其他使用者的資訊，詳情請參閱隱私權政策。"
 
+#: noggin/form/edit_user.py:163 noggin/templates/user.html:33
+#: noggin/templates/user.html:35
 msgid "Pronouns"
 msgstr "代詞"
 
+#: noggin/form/edit_user.py:168 noggin/form/register_user.py:68
 msgid "E-mail Address"
 msgstr "電子郵件地址"
 
+#: noggin/form/edit_user.py:170 noggin/form/register_user.py:70
 msgid "Email must not be empty"
 msgstr "電子郵件不得為空白"
 
+#: noggin/form/edit_user.py:171 noggin/form/register_user.py:71
 msgid "Email must be valid"
 msgstr "電子郵件必須有效"
 
+#: noggin/form/edit_user.py:175
 msgid "Red Hat Bugzilla Email"
 msgstr "Red Hat Bugzilla 電子郵件"
 
+#: noggin/form/edit_user.py:181 noggin/templates/user.html:88
 msgid "SSH Keys"
 msgstr "SSH 金鑰"
 
+#: noggin/form/edit_user.py:186 noggin/templates/user.html:78
 msgid "GPG Keys"
 msgstr "GPG 密鑰"
 
+#: noggin/form/edit_user.py:192 noggin/templates/user-settings-otp.html:110
 msgid "Token name"
 msgstr "權杖名稱"
 
+#: noggin/form/edit_user.py:194
 msgid "Add an optional name to help you identify this token"
 msgstr "新增可選的名稱，以協助您識別此權杖"
 
+#: noggin/form/edit_user.py:198 noggin/form/edit_user.py:250
 msgid "Enter your current password"
 msgstr "輸入您目前的密碼"
 
+#: noggin/form/edit_user.py:199 noggin/form/edit_user.py:251
+#: noggin/form/edit_user.py:267 noggin/form/login_user.py:21
+#: noggin/form/sync_token.py:16
 msgid "You must provide a password"
 msgstr "輸入您目前的密碼"
 
+#: noggin/form/edit_user.py:200
 msgid "please reauthenticate so we know it is you"
 msgstr "請重新驗證，以便我們知道是您"
 
+#: noggin/form/edit_user.py:204 noggin/form/edit_user.py:254
+#: noggin/form/edit_user.py:270 noggin/form/login_user.py:24
+#: noggin/templates/user-settings-otp-admin-reset.html:92
+#: noggin/templates/user-settings-otp.html:113
+#: noggin/templates/user-settings-otp.html:216
+#: noggin/templates/user-settings-otp.html:239
 msgid "One-Time Password"
 msgstr "一次性密碼(OTP)"
 
+#: noggin/form/edit_user.py:206
 msgid "Enter your One-Time Password"
 msgstr "輸入您的一次性密碼(OTP)"
 
+#: noggin/form/edit_user.py:209
 msgid "Generate OTP Token"
 msgstr "產生 OTP 權杖"
 
+#: noggin/form/edit_user.py:215
 msgid "Could not find the token secret"
 msgstr "無法找到權杖密碼"
 
+#: noggin/form/edit_user.py:222 noggin/templates/user-settings-otp.html:27
 msgid "Verification Code"
 msgstr "驗證碼"
 
+#: noggin/form/edit_user.py:223
 msgid "You must provide a verification code"
 msgstr "您必須提供驗證碼"
 
+#: noggin/form/edit_user.py:225
 msgid "Verify and Enable OTP Token"
 msgstr "驗證並啟用 OTP 權杖"
 
+#: noggin/form/edit_user.py:230
 msgid "The code is wrong, please try again."
 msgstr "代碼錯誤，請再試一次。"
 
+#: noggin/form/edit_user.py:235 noggin/form/edit_user.py:241
 msgid "Token must not be empty"
 msgstr "權杖不得為空白"
 
+#: noggin/form/edit_user.py:257
+#, fuzzy
+msgid "Generate Recovery Codes"
+msgstr "產生 OTP 權杖"
+
+#: noggin/form/edit_user.py:261
+#, fuzzy
+msgid "Regenerate Recovery Codes"
+msgstr "產生 OTP 權杖"
+
+#: noggin/form/edit_user.py:266
+#, fuzzy
+msgid "Enter your password to confirm"
+msgstr "輸入您目前的密碼"
+
+#: noggin/form/edit_user.py:273
+msgid "Reset OTP and Generate Recovery Codes"
+msgstr ""
+
+#: noggin/form/edit_user.py:279
+#, fuzzy
+msgid "Passkey must not be empty"
+msgstr "密碼不得為空白"
+
+#: noggin/form/edit_user.py:285
 msgid "Agreement must not be empty"
 msgstr "協議不得為空白"
 
+#: noggin/form/fields.py:199
+msgid "CAPTCHA payload missing"
+msgstr ""
+
+#: noggin/form/fields.py:207
+msgid "Invalid CAPTCHA payload"
+msgstr ""
+
+#: noggin/form/fields.py:210
+#, python-format
+msgid "Failed to process CAPTCHA payload: %(error)s"
+msgstr ""
+
+#: noggin/form/group.py:11
 msgid "New member username must not be empty"
 msgstr "新會員使用者名稱不可為空白"
 
+#: noggin/form/group.py:17 noggin/form/register_user.py:39
+#: noggin/form/sync_token.py:10 noggin/templates/sync-token.html:16
 msgid "Username"
 msgstr "使用者名稱"
 
+#: noggin/form/group.py:18
 msgid "Username must not be empty"
 msgstr "使用者名稱不得為空白"
 
+#: noggin/form/login_user.py:12
 #, fuzzy
 msgid "Username (or email address)"
 msgstr "驗證您的電子郵件地址"
 
+#: noggin/form/login_user.py:14 noggin/form/sync_token.py:11
 msgid "You must provide a user name"
 msgstr "您必須提供使用者名稱"
 
+#: noggin/form/login_user.py:20 noggin/form/register_user.py:95
+#: noggin/form/sync_token.py:15 noggin/templates/sync-token.html:19
+#: noggin/templates/user-settings-otp.html:111
+#: noggin/templates/user-settings.html:34
 msgid "Password"
 msgstr "密碼"
 
+#: noggin/form/login_user.py:26
 msgid "Log In"
 msgstr "登入"
 
+#: noggin/form/password_reset.py:11
 msgid "New Password"
 msgstr "新密碼"
 
+#: noggin/form/password_reset.py:13 noggin/form/register_user.py:97
 msgid "Password must not be empty"
 msgstr "密碼不得為空白"
 
+#: noggin/form/password_reset.py:15 noggin/form/register_user.py:99
 msgid "Passwords must match"
 msgstr "密碼必須相符"
 
+#: noggin/form/password_reset.py:19
 msgid "Confirm New Password"
 msgstr "確認新密碼"
 
-msgid ""
-"One-Time Password (if your account has Two-Factor Authentication enabled)"
+#: noggin/form/password_reset.py:22
+msgid "One-Time Password (if your account has Two-Factor Authentication enabled)"
 msgstr "一次性密碼(如果您的帳戶已啟用雙重認證）"
 
+#: noggin/form/password_reset.py:29
 msgid "Current Password"
 msgstr "目前密碼"
 
+#: noggin/form/password_reset.py:30
 msgid "Current password must not be empty"
 msgstr "目前密碼不得為空白"
 
+#: noggin/form/password_reset.py:36
 #, fuzzy
 msgid "Username or Email"
 msgstr "使用者名稱"
 
+#: noggin/form/password_reset.py:37 noggin/form/register_user.py:41
 msgid "User name must not be empty"
 msgstr "使用者名稱不得為空白"
 
+#: noggin/form/password_reset.py:38
 #, fuzzy
 msgid "Enter your username or email to reset your password"
 msgstr "輸入您的使用者名稱以重設密碼"
 
+#: noggin/form/register_user.py:55
 #, python-format
 msgid "Only these characters are allowed: \"%(chars)s\"."
 msgstr "只允許使用這些字元： \"%(chars)s\"。"
 
+#: noggin/form/register_user.py:77
 msgid "I am over 16 years old"
 msgstr "我已年滿 16 歲"
 
+#: noggin/form/register_user.py:80
 msgid "You must be over 16 years old to create an account"
 msgstr "您必須年滿 16 歲才能建立帳號"
 
+#: noggin/form/register_user.py:86 noggin/templates/index.html:21
 msgid "Register"
 msgstr "註冊"
 
+#: noggin/form/register_user.py:90
 msgid "Resend email"
 msgstr "重新傳送電子郵件"
 
+#: noggin/form/register_user.py:102
 msgid "Please choose a strong password"
 msgstr "請選擇強而有力的密碼"
 
+#: noggin/form/register_user.py:105
 msgid "Confirm Password"
 msgstr "確認密碼"
 
+#: noggin/form/register_user.py:107
 msgid "Activate"
 msgstr "啟動"
 
+#: noggin/form/sync_token.py:20 noggin/templates/sync-token.html:22
 msgid "First OTP"
 msgstr "首個 OTP"
 
+#: noggin/form/sync_token.py:21
 msgid "You must provide a first code"
 msgstr "您必須提供首個代碼"
 
+#: noggin/form/sync_token.py:25 noggin/templates/sync-token.html:25
 msgid "Second OTP"
 msgstr "第二個 OTP"
 
+#: noggin/form/sync_token.py:26
 msgid "You must provide a second code"
 msgstr "您必須提供第二個代碼"
 
+#: noggin/form/sync_token.py:29 noggin/templates/sync-token.html:28
 msgid "Token ID"
 msgstr "權杖 ID"
 
+#: noggin/form/validators.py:19
 msgid "Email addresses from that domain are not allowed"
 msgstr "不允許使用來自該網域的電子郵件地址"
 
+#: noggin/form/validators.py:39
 msgid "Mixed case is not allowed, try lower case."
 msgstr "不允許混合大小寫，請嘗試使用小寫。"
 
+#: noggin/form/validators.py:66
 #, python-format
 msgid "Field must not match \"%(pattern)s\"."
 msgstr "欄位不得匹配 \"%(pattern)s\"。"
 
+#: noggin/templates/404.html:3 noggin/templates/404.html:10
 msgid "That page wasn't found."
 msgstr "找不到該頁面。"
 
+#: noggin/templates/_agreements_form.html:20
 msgid "View agreement"
 msgstr "檢視協議"
 
+#: noggin/templates/_agreements_form.html:23
 msgid "Review"
 msgstr ""
 
+#: noggin/templates/_agreements_form.html:47
 msgid "Sign User Agreement"
 msgstr "簽署使用者協議"
 
+#: noggin/templates/_login_form.html:21
 msgid "Forgot Password?"
 msgstr "忘記密碼？"
 
+#: noggin/templates/_login_form.html:23
 msgid "Forgot Password or OTP?"
 msgstr "忘記密碼或 OTP？"
 
+#: noggin/templates/_login_form.html:26
 msgid "Sync Token"
 msgstr "同步權杖"
 
+#: noggin/templates/_login_form.html:37
+msgid "or"
+msgstr ""
+
+#: noggin/templates/_login_form.html:40
+msgid "Sign in with Passkey"
+msgstr ""
+
+#: noggin/templates/_pagination.html:8
 msgid "Previous"
 msgstr "上一頁"
 
+#: noggin/templates/_pagination.html:17
 msgid "current"
 msgstr "目前"
 
+#: noggin/templates/_pagination.html:35
 msgid "Next"
 msgstr "下一版"
 
+#: noggin/templates/base.html:28 noggin/themes/almalinux/templates/main.html:24
+#: noggin/themes/centos/templates/main.html:16
+#: noggin/themes/default/templates/main.html:16
+#: noggin/themes/fas/templates/main.html:27
 msgid "Groups"
 msgstr "群組"
 
+#: noggin/templates/base.html:29
 msgid "Users"
 msgstr "使用者"
 
+#: noggin/templates/forgot-password-ask.html:2
 msgid "Password Recovery"
 msgstr "密碼復原"
 
+#: noggin/templates/forgot-password-ask.html:16
 msgid "Did you forget your password?"
 msgstr "您忘記密碼了嗎？"
 
+#: noggin/templates/forgot-password-ask.html:17
 #, fuzzy
 msgid ""
 "Enter your username or email address and an email will be sent to your "
 "address with further instructions."
-msgstr ""
-"請輸入您的使用者名稱，我們將發送一封電子郵件到您的地址，並提供進一步的說明。"
+msgstr "請輸入您的使用者名稱，我們將發送一封電子郵件到您的地址，並提供進一步的說明。"
 
+#: noggin/templates/forgot-password-ask.html:22
 msgid "Send"
 msgstr "寄送"
 
+#: noggin/templates/forgot-password-change.html:2
+#: noggin/templates/forgot-password-change.html:23
 msgid "Reset Password"
 msgstr "重置密碼"
 
+#: noggin/templates/forgot-password-change.html:16
 #, python-format
 msgid "Password Reset for %(username)s"
 msgstr "重設 %(username)s 的密碼"
 
+#: noggin/templates/group.html:6
 #, python-format
 msgid "%(groupname)s Group"
 msgstr "%(groupname)s 群組"
 
+#: noggin/templates/group.html:36
 msgid "Leave group"
 msgstr "離開群組"
 
+#: noggin/templates/group.html:55
 msgid ""
-"You are a sponsor of this group, but not a member. Add yourself if you want "
-"to be a member."
+"You are a sponsor of this group, but not a member. Add yourself if you "
+"want to be a member."
 msgstr "您是這個群組的贊助者，但不是成員。如果您想成為成員，請加入您自己。"
 
+#: noggin/templates/group.html:57
 msgid "To join this group, contact a group sponsor."
 msgstr "若要加入此小組，請聯絡小組贊助者。"
 
+#: noggin/templates/group.html:65
 msgid "Sponsors"
 msgstr "贊助商"
 
+#: noggin/templates/group.html:69
 msgid "no sponsors"
 msgstr "非贊助商"
 
+#: noggin/templates/group.html:106
 msgid "Members"
 msgstr "成員"
 
+#: noggin/templates/group.html:113
 msgid "add user..."
 msgstr "新增使用者..."
 
+#: noggin/templates/group.html:121
 msgid "No members yet."
 msgstr "尚未有成員。"
 
+#: noggin/templates/groups.html:6 noggin/templates/groups.html:13
 msgid "Group List"
 msgstr "群組清單"
 
+#: noggin/templates/groups.html:44
 #, python-format
 msgid "%(member_count)s members"
 msgstr "%(member_count)s 成員"
 
+#: noggin/templates/groups.html:49
 msgid "No groups."
 msgstr "沒有群組。"
 
+#: noggin/templates/index.html:18
 msgid "Login"
 msgstr "登入"
 
+#: noggin/templates/ipa_error.html:11
 msgid "IPA Error"
 msgstr "IPA 錯誤"
 
+#: noggin/templates/ipa_error.html:13
 msgid "There was a problem with the IPA backend, please try again later."
 msgstr "IPA 後端出現問題，請稍後再試。"
 
+#: noggin/templates/ipa_error.html:15
 #, python-format
 msgid ""
-"You can also <a href=\"%(url)s\">log out</a> and log back in if the problem "
-"persists."
+"You can also <a href=\"%(url)s\">log out</a> and log back in if the "
+"problem persists."
 msgstr "您也可以<a href=\"%(url)s\">登出</a>，如果問題仍然存在，再重新登入。"
 
+#: noggin/templates/password-reset.html:2
 msgid "Expired Password Reset"
 msgstr "過期密碼重設"
 
+#: noggin/templates/password-reset.html:15
 #, python-format
 msgid "Expired Password Reset for %(username)s"
 msgstr "重置 %(username)s 的過期密碼"
 
+#: noggin/templates/password-reset.html:26
+#: noggin/templates/user-settings-password.html:7
+#: noggin/templates/user-settings-password.html:18
 msgid "Change Password"
 msgstr "變更密碼"
 
+#: noggin/templates/registering.html:2 noggin/templates/registering.html:10
+#: noggin/themes/almalinux/templates/main.html:34
+#: noggin/themes/centos/templates/main.html:27
+#: noggin/themes/default/templates/main.html:27
+#: noggin/themes/fas/templates/main.html:38
 msgid "Registering Users"
 msgstr "註冊使用者"
 
+#: noggin/templates/registering.html:43
 msgid "Name:"
 msgstr "名稱："
 
+#: noggin/templates/registering.html:48
 msgid "Email:"
 msgstr "電子郵件："
 
+#: noggin/templates/registering.html:53
 msgid "Registered:"
 msgstr "已註冊於："
 
+#: noggin/templates/registering.html:59
 msgid "Status:"
 msgstr "狀態："
 
+#: noggin/templates/registering.html:63
 msgid "Waiting for spam check"
 msgstr "等待垃圾郵件檢查"
 
+#: noggin/templates/registering.html:65
 msgid "Not flagged as spam"
 msgstr "未被標記為垃圾郵件"
 
+#: noggin/templates/registering.html:67
 msgid "Flagged as spam"
 msgstr "被標記為垃圾郵件"
 
+#: noggin/templates/registering.html:69
 msgid "Spam status unknown"
 msgstr "垃圾郵件狀態不明"
 
+#: noggin/templates/registering.html:82
 msgid "Accept"
 msgstr "同意"
 
+#: noggin/templates/registering.html:86
 msgid "Flag as spam"
 msgstr "標記為垃圾郵件"
 
+#: noggin/templates/registering.html:89
 msgid "Delete"
 msgstr "刪除"
 
+#: noggin/templates/registering.html:108
 msgid ""
 "Clicking on Accept will send the validation email to this user. Other "
 "buttons will not send anything."
 msgstr "按一下「接受」會傳送驗證電子郵件給此使用者。其他按鈕不會發送任何內容。"
 
+#: noggin/templates/registering.html:121
 msgid "No registering users in this state at the moment."
 msgstr "此狀態暫時沒有註冊使用者。"
 
+#: noggin/templates/registering.html:123
 msgid "No registering users at the moment."
 msgstr "目前沒有註冊使用者。"
 
+#: noggin/templates/registration-activation.html:2
 msgid "Activate your account"
 msgstr "啟動您的帳戶"
 
+#: noggin/templates/registration-activation.html:17
 msgid "Account creation, step 3/3"
 msgstr "建立帳戶，步驟 3/3"
 
+#: noggin/templates/registration-activation.html:18
 #, python-format
 msgid "Hello %(name)s. To activate your account, please choose a password."
 msgstr "您好 %(name)s。如想啟用您的帳戶，請選擇把密碼輸入完成。"
 
+#: noggin/templates/registration-agreements.html:2
 #, fuzzy
 msgid "Sign agreements"
 msgstr "簽署使用者協議"
 
+#: noggin/templates/registration-agreements.html:14
 msgid "Optional agreement signing"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:16
 #, python-format
 msgid ""
-"Hello %(name)s. Please review the agreement below and then sign it if you "
-"agree with its content."
+"Hello %(name)s. Please review the agreement below and then sign it if you"
+" agree with its content."
 msgid_plural ""
-"Hello %(name)s. Please review the agreements below and then sign them if you "
-"agree with their content."
+"Hello %(name)s. Please review the agreements below and then sign them if "
+"you agree with their content."
 msgstr[0] ""
 
+#: noggin/templates/registration-agreements.html:31
 msgid "Continue"
 msgstr ""
 
+#: noggin/templates/registration-agreements.html:34
 msgid "Skip"
 msgstr ""
 
+#: noggin/templates/registration-confirmation.html:2
 msgid "Validate your email address"
 msgstr "驗證您的電子郵件地址"
 
+#: noggin/templates/registration-confirmation.html:15
 msgid "Account creation, step 2/3"
 msgstr "建立帳戶，步驟 2/3"
 
+#: noggin/templates/registration-confirmation.html:16
 #, python-format
 msgid "Congratulations %(name)s, your account has been created!"
 msgstr "恭喜 %(name)s,，您的帳戶已建立！"
 
+#: noggin/templates/registration-confirmation.html:17
 #, python-format
 msgid ""
-"Before you can log in, your email address: %(mail)s needs to be validated. "
-"Please check your inbox and click on the link to proceed."
-msgstr ""
-"在您登入之前，您的電子郵件地址： %(mail)s 需要驗證。請檢查您的收件匣，然後按"
-"一下連結繼續。"
+"Before you can log in, your email address: %(mail)s needs to be "
+"validated. Please check your inbox and click on the link to proceed."
+msgstr "在您登入之前，您的電子郵件地址： %(mail)s 需要驗證。請檢查您的收件匣，然後按一下連結繼續。"
 
+#: noggin/templates/registration-confirmation.html:19
 msgid ""
-"If you can't find the email in a couple minutes, check your spam folder. If "
-"it's not there, you can ask for another validation email by clicking on the "
-"button below."
-msgstr ""
-"如果您在幾分鐘之內找不到該電子郵件，請檢查您的垃圾郵件資料夾。如果沒有，您可"
-"以按一下下面的按鈕，要求另一封驗證電子郵件。"
+"If you can't find the email in a couple minutes, check your spam folder. "
+"If it's not there, you can ask for another validation email by clicking "
+"on the button below."
+msgstr "如果您在幾分鐘之內找不到該電子郵件，請檢查您的垃圾郵件資料夾。如果沒有，您可以按一下下面的按鈕，要求另一封驗證電子郵件。"
 
+#: noggin/templates/registration-spamcheck-wait.html:2
 msgid "Spam check in progress"
 msgstr "垃圾郵件檢查中"
 
+#: noggin/templates/registration-spamcheck-wait.html:13
 msgid "Your account is being checked"
 msgstr "正在檢查您的帳戶"
 
+#: noggin/templates/registration-spamcheck-wait.html:15
 msgid ""
-"Before you can log in, your account needs to be check for spam likelihood. "
-"It should only take a few seconds, please wait..."
-msgstr ""
-"在您登入之前，您的帳戶需要檢查是否有垃圾郵件的可能性。這只需要幾秒鐘，請稍"
-"候..."
+"Before you can log in, your account needs to be check for spam "
+"likelihood. It should only take a few seconds, please wait..."
+msgstr "在您登入之前，您的帳戶需要檢查是否有垃圾郵件的可能性。這只需要幾秒鐘，請稍候..."
 
+#: noggin/templates/registration-spamcheck-wait.html:18
 msgid "Your account requires admin approval"
 msgstr "您的帳號需要管理員批准"
 
+#: noggin/templates/registration-spamcheck-wait.html:21
 msgid "Your account needs to be approved by an administrator."
 msgstr "您的帳號需要由管理員批准。"
 
+#: noggin/templates/registration-spamcheck-wait.html:22
 msgid "You will receive an email when the decision has been taken."
 msgstr "您作出決定後，將會收到電子郵件。"
 
+#: noggin/templates/registration-spamcheck-wait.html:23
 msgid "Thank you for your patience."
 msgstr "感謝您的耐心等待。"
 
+#: noggin/templates/registration-spamcheck-wait.html:30
 msgid "Your account is blocked"
 msgstr "您的帳號已被封鎖"
 
+#: noggin/templates/registration-spamcheck-wait.html:32
 msgid "Your account has been flagged as spam."
 msgstr "您的帳號已被標記為垃圾郵件。"
 
+#: noggin/templates/registration-spamcheck-wait.html:38
 msgid "Something went wrong"
 msgstr "出了問題"
 
+#: noggin/templates/registration-spamcheck-wait.html:41
 #, python-format
 msgid "Unsupported spam status: %s, please contact the administrators"
 msgstr "不支援的垃圾郵件狀態：%s，請聯絡管理員"
 
+#: noggin/templates/sync-token.html:2
 msgid "Sync OTP Token"
 msgstr "同步 OTP 權杖"
 
+#: noggin/templates/sync-token.html:10
 msgid "Synchronize OTP Token"
 msgstr "同步 OTP 權杖"
 
+#: noggin/templates/sync-token.html:33
 msgid "Sync"
 msgstr "同步"
 
+#: noggin/templates/user-settings-email-validation.html:2
+#: noggin/templates/user-settings-email-validation.html:17
 msgid "Validate your email"
 msgstr "驗證您的電子郵件"
 
+#: noggin/templates/user-settings-email-validation.html:18
 #, python-format
 msgid "Hello %(user_name)s. Do you want to set your %(attr_name)s to %(mail)s?"
 msgstr "您好 %(user_name)s。您想要將您的 %(attr_name)s 設定為 %(mail)s 嗎？"
 
+#: noggin/templates/user-settings-email-validation.html:23
+#: noggin/templates/user-settings-otp-admin-reset.html:98
+#: noggin/templates/user-settings-otp.html:32
+#: noggin/templates/user-settings-otp.html:33
 msgid "Cancel"
 msgstr "取消"
 
+#: noggin/templates/user-settings-email-validation.html:24
 msgid "Do it"
 msgstr "執行"
 
+#: noggin/templates/user-settings-email.html:14
+#: noggin/templates/user-settings-keys.html:13
+#: noggin/templates/user-settings-profile.html:58
 msgid "Save"
 msgstr "儲存"
 
+#: noggin/templates/user-settings-keys.html:8
 msgid "GPG Key ID"
 msgstr "GPG 金鑰 ID"
 
+#: noggin/templates/user-settings-keys.html:9
 msgid "SSH Public Key"
 msgstr "SSH 公用金鑰"
 
-msgid "Scan your new token"
-msgstr "掃描您的新權杖"
+#: noggin/templates/user-settings-otp-admin-reset.html:5
+#: noggin/templates/user-settings-otp-admin-reset.html:16
+#, fuzzy, python-format
+msgid "Reset OTP for %(username)s"
+msgstr "設定 %(username)s"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:21
 msgid ""
-"Your new token is ready. Click on the button below to reveal the QR code and "
-"scan it."
-msgstr "您的新權杖已準備就緒。點擊下面的按鈕，顯示 QR code並進行掃描。"
+"OTP tokens have been reset. Share the recovery codes below with the user "
+"through a verified secure channel."
+msgstr ""
 
-msgid "Reveal"
-msgstr "揭示"
+#: noggin/templates/user-settings-otp-admin-reset.html:25
+#, fuzzy
+msgid "These codes will not be shown again."
+msgstr "代碼錯誤，請再試一次。"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:26
+msgid "Make sure the user saves them before you leave this page."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:41
+#: noggin/templates/user-settings-otp-admin-reset.html:124
+#: noggin/templates/user-settings-otp.html:70
+#: noggin/templates/user-settings-otp.html:278
+msgid "Copy all"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:44
+#: noggin/templates/user-settings-otp.html:73
+msgid "Download as text file"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:48
+#: noggin/templates/user-settings-otp.html:86
+msgid "Done"
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:51
+#, python-format
 msgid ""
-"or copy and paste the following token URL if you can't scan the QR code:"
-msgstr "如果您無法掃描 QR Code，請複製並貼上以下權杖 URL："
+"This will delete all OTP tokens for %(username)s and generate a set of "
+"recovery codes that you can share with the user."
+msgstr ""
 
-msgid ""
-"After enrolling the token in your application, verify it by generating your "
-"first code and entering it below:"
-msgstr "在您的應用程式中註冊權杖後，請在下方產生第一個代碼並輸入，以驗證它："
+#: noggin/templates/user-settings-otp-admin-reset.html:56
+#, fuzzy
+msgid "Current OTP tokens:"
+msgstr "產生 OTP 權杖"
 
-msgid "Add OTP Token"
-msgstr "加入 OTP 權杖"
-
-msgid ""
-"Creating your first OTP token enables two-factor authentication using OTP."
-msgstr "建立您的第一個 OTP 權杖可使用 OTP 進行雙重認證。"
-
-msgid "Once enabled, two-factor authentication cannot be disabled."
-msgstr "一旦啟用，就無法停用雙因素驗證。"
-
-msgid "OTP Tokens"
-msgstr "OTP 權杖"
-
+#: noggin/templates/user-settings-otp-admin-reset.html:60
+#: noggin/templates/user-settings-otp.html:136
 msgid "(no name)"
 msgstr "(無名稱)"
 
+#: noggin/templates/user-settings-otp-admin-reset.html:66
+#, fuzzy
+msgid "This user has no OTP tokens."
+msgstr "您沒有 OTP 權杖"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:72
+msgid "This user also has recovery codes which will be replaced."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:77
+#, fuzzy
+msgid "Warning:"
+msgstr "等待中"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:78
+msgid ""
+"This action cannot be undone. All existing OTP tokens will be permanently"
+" deleted."
+msgstr ""
+
+#: noggin/templates/user-settings-otp-admin-reset.html:88
+#, fuzzy
+msgid "Your password"
+msgstr "密碼"
+
+#: noggin/templates/user-settings-otp-admin-reset.html:122
+#: noggin/templates/user-settings-otp.html:276
+msgid "Copied!"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:11
+msgid "Scan your new token"
+msgstr "掃描您的新權杖"
+
+#: noggin/templates/user-settings-otp.html:12
+#: noggin/templates/user-settings-otp.html:99
+msgid "Close"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:16
+msgid ""
+"Your new token is ready. Click on the button below to reveal the QR code "
+"and scan it."
+msgstr "您的新權杖已準備就緒。點擊下面的按鈕，顯示 QR code並進行掃描。"
+
+#: noggin/templates/user-settings-otp.html:17
+msgid "Reveal"
+msgstr "揭示"
+
+#: noggin/templates/user-settings-otp.html:19
+msgid "or copy and paste the following token URL if you can't scan the QR code:"
+msgstr "如果您無法掃描 QR Code，請複製並貼上以下權杖 URL："
+
+#: noggin/templates/user-settings-otp.html:26
+msgid ""
+"After enrolling the token in your application, verify it by generating "
+"your first code and entering it below:"
+msgstr "在您的應用程式中註冊權杖後，請在下方產生第一個代碼並輸入，以驗證它："
+
+#: noggin/templates/user-settings-otp.html:49
+#: noggin/templates/user-settings-otp.html:178
+msgid "Recovery Codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:53
+msgid "Save these codes in a safe place."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:54
+msgid ""
+"You will not be able to see them again. If you lose your authenticator "
+"device, you can use one of these codes to sign in."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:79
+msgid "I have saved my recovery codes"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:98
+#: noggin/templates/user-settings-otp.html:126
+msgid "Add OTP Token"
+msgstr "加入 OTP 權杖"
+
+#: noggin/templates/user-settings-otp.html:104
+msgid "Creating your first OTP token enables two-factor authentication using OTP."
+msgstr "建立您的第一個 OTP 權杖可使用 OTP 進行雙重認證。"
+
+#: noggin/templates/user-settings-otp.html:105
+msgid "Once enabled, two-factor authentication cannot be disabled."
+msgstr "一旦啟用，就無法停用雙因素驗證。"
+
+#: noggin/templates/user-settings-otp.html:125
+msgid "OTP Tokens"
+msgstr "OTP 權杖"
+
+#: noggin/templates/user-settings-otp.html:137
+#: noggin/templates/user-settings-otp.html:143
 msgid "Rename"
 msgstr "重新命名"
 
+#: noggin/templates/user-settings-otp.html:152
 msgid "Disable"
 msgstr "停用"
 
+#: noggin/templates/user-settings-otp.html:157
 msgid "Enable"
 msgstr "啟用"
 
+#: noggin/templates/user-settings-otp.html:169
 msgid "You have no OTP tokens"
 msgstr "您沒有 OTP 權杖"
 
+#: noggin/templates/user-settings-otp.html:170
 msgid "Add an OTP token to enable two-factor authentication on your account."
 msgstr "新增 OTP 權杖以啟用帳戶的雙重認證。"
 
+#: noggin/templates/user-settings-otp.html:180
+msgid ""
+"Recovery codes can be used to sign in if you lose access to your "
+"authenticator app. Each code can only be used once."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:186
+msgid "Exhausted"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:187
+msgid "All recovery codes have been used. Regenerate now to stay protected."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:189
+msgid "Low"
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:190
+#: noggin/templates/user-settings-otp.html:196
+#, python-format
+msgid "%(num)d recovery code remaining."
+msgid_plural "%(num)d recovery codes remaining."
+msgstr[0] ""
+
+#: noggin/templates/user-settings-otp.html:193
+msgid "Consider regenerating your recovery codes."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:195
+#: noggin/templates/user-settings-otp.html:200
+#, fuzzy
+msgid "Active"
+msgstr "啟動"
+
+#: noggin/templates/user-settings-otp.html:201
+msgid "You have recovery codes set up."
+msgstr ""
+
+#: noggin/templates/user-settings-otp.html:211
+#: noggin/templates/user-settings-otp.html:234
+#, fuzzy
+msgid "Current password"
+msgstr "目前密碼"
+
+#: noggin/templates/user-settings-otp.html:223
+#, fuzzy
+msgid "Not set up"
+msgstr "不是垃圾郵件"
+
+#: noggin/templates/user-settings-otp.html:224
+msgid ""
+"You have no recovery codes. Generate them now to avoid being locked out "
+"if you lose your authenticator device."
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:8
+#: noggin/templates/user-settings.html:31
+#, fuzzy
+msgid "Passkeys"
+msgstr "SSH 金鑰"
+
+#: noggin/templates/user-settings-passkeys.html:10
+msgid "Add Passkey"
+msgstr ""
+
+#: noggin/templates/user-settings-passkeys.html:39
+#, fuzzy
+msgid "You have no passkeys"
+msgstr "您沒有 OTP 權杖"
+
+#: noggin/templates/user-settings-passkeys.html:40
+#, fuzzy
+msgid "Add a passkey to enable passwordless authentication."
+msgstr "新增 OTP 權杖以啟用帳戶的雙重認證。"
+
+#: noggin/templates/user-settings-profile.html:12
 msgid "Change Avatar"
 msgstr "變更頭像"
 
+# | msgid ""
+# | "\n"
+# | "            The format is either <code>username</code> or "
+# | "<code>username:server.name</code> if you're not using the default "
+# | "servers:\n"
+# | "          "
+#: noggin/templates/user-settings-profile.html:37
 #, fuzzy
-#| msgid ""
-#| "\n"
-#| "            The format is either <code>username</code> or "
-#| "<code>username:server.name</code> if you're not using the default "
-#| "servers:\n"
-#| "          "
 msgid ""
-"The format is either <code>username</code> or <code>username:server.name</"
-"code> if you're not using the default servers:"
+"The format is either <code>username</code> or "
+"<code>username:server.name</code> if you're not using the default "
+"servers:"
 msgstr ""
 "\n"
-"            格式為 <code>username</code> 或 <code>username:server.name</"
-"code> (如果您沒有使用預設的伺服器)：\n"
+"            格式為 <code>username</code> 或 <code>username:server.name</code>"
+" (如果您沒有使用預設的伺服器)：\n"
 "          "
 
+# | msgid ""
+# | "\n"
+# | "              For %(title)s: <code>%(server)s</code>\n"
+# | "            "
+#: noggin/templates/user-settings-profile.html:44
 #, fuzzy, python-format
-#| msgid ""
-#| "\n"
-#| "              For %(title)s: <code>%(server)s</code>\n"
-#| "            "
 msgid "For %(title)s: <code>%(server)s</code>"
 msgstr ""
 "\n"
 "              對於  %(title)s： <code>%(server)s</code>\n"
 "            "
 
+#: noggin/templates/user-settings.html:3 noggin/templates/user-settings.html:14
 #, python-format
 msgid "Settings for %(username)s"
 msgstr "設定 %(username)s"
 
+#: noggin/templates/user-settings.html:19
+#: noggin/themes/almalinux/templates/main.html:31
+#: noggin/themes/centos/templates/main.html:24
+#: noggin/themes/default/templates/main.html:24
+#: noggin/themes/fas/templates/main.html:35
 msgid "Profile"
 msgstr "簡介"
 
+#: noggin/templates/user-settings.html:22
 msgid "Emails"
 msgstr "電子郵件"
 
+#: noggin/templates/user-settings.html:25
 msgid "SSH &amp; GPG Keys"
 msgstr "SSH &amp; GPG 金鑰"
 
+#: noggin/templates/user-settings.html:28
 msgid "OTP"
 msgstr "OTP"
 
+#: noggin/templates/user-settings.html:37
 msgid "Agreements"
 msgstr "協議"
 
+#: noggin/templates/user.html:3
 #, python-format
 msgid "Profile for %(username)s"
 msgstr "%(username)s 的簡介"
 
+#: noggin/templates/user.html:17
 msgid "Edit Profile"
 msgstr "編輯簡介"
 
+#: noggin/templates/user.html:21
+#, fuzzy
+msgid "Reset OTP"
+msgstr "首個 OTP"
+
+#: noggin/templates/user.html:27
 msgid "Created on"
 msgstr ""
 
+#: noggin/templates/user.html:55 noggin/templates/user.html:57
 msgid "Current Time"
 msgstr "目前時間"
 
+#: noggin/templates/user.html:66 noggin/templates/user.html:67
 msgid "Chat"
 msgstr "聊聊"
 
+#: noggin/templates/user.html:98
 #, fuzzy
 msgid "Blog"
 msgstr "登入"
 
+#: noggin/templates/user.html:110
 msgid "RSS"
 msgstr ""
 
+#: noggin/templates/user.html:122
 msgid "RHBZ"
 msgstr "RHBZ"
 
+#: noggin/templates/user.html:144
 #, python-format
 msgid "%(groupcount)s Group(s), %(agreementcount)s Agreement(s)"
 msgstr "%(groupcount)s 團體，%(agreementcount)s 協議"
 
+#: noggin/templates/user.html:161
 msgid "signed"
 msgstr "已簽署"
 
+#: noggin/templates/user.html:179
 msgid "sponsor"
 msgstr "贊助"
 
+#: noggin/templates/user.html:180
 msgid "member"
 msgstr "成員"
 
+#: noggin/templates/user.html:184
+#, fuzzy, python-format
+msgid "%(username)s has no group memberships"
+msgstr "使用者 %(username)s 不存在"
+
+#: noggin/themes/almalinux/templates/email-validation.html:2
+#: noggin/themes/almalinux/templates/settings-email-validation.html:2
+#: noggin/themes/centos/templates/email-validation.html:2
+#: noggin/themes/centos/templates/settings-email-validation.html:2
+#: noggin/themes/default/templates/email-validation.html:2
+#: noggin/themes/default/templates/settings-email-validation.html:2
+#: noggin/themes/fas/templates/email-validation.html:2
+#: noggin/themes/fas/templates/settings-email-validation.html:2
 #, python-format
 msgid "Hello %(name)s,"
 msgstr "您好 %(name)s,"
 
+#: noggin/themes/almalinux/templates/email-validation.html:3
+#: noggin/themes/centos/templates/email-validation.html:3
+#: noggin/themes/default/templates/email-validation.html:3
+#: noggin/themes/fas/templates/email-validation.html:3
 #, python-format
 msgid ""
-"To activate your account with username %(username)s, click on the link below:"
+"To activate your account with username %(username)s, click on the link "
+"below:"
 msgstr "若要使用使用者名稱 %(username)s 啟用您的帳號，請點選以下連結："
 
+#: noggin/themes/almalinux/templates/email-validation.html:9
+#: noggin/themes/centos/templates/email-validation.html:9
+#: noggin/themes/default/templates/email-validation.html:16
+#: noggin/themes/fas/templates/email-validation.html:16
 #, python-format
 msgid ""
-"If you did not create an account for username %(username)s, you can ignore "
-"this email."
+"If you did not create an account for username %(username)s, you can "
+"ignore this email."
 msgstr "如果您沒有為使用者名稱 %(username)s 建立帳號，您可以忽略此電子郵件。"
 
+#: noggin/themes/almalinux/templates/email-validation.html:11
+#: noggin/themes/almalinux/templates/forgot-password-email.html:9
+#: noggin/themes/almalinux/templates/settings-email-validation.html:11
 msgid "The AlmaLinux Team"
 msgstr "AlmaLinux 團隊"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:1
+#: noggin/themes/centos/templates/forgot-password-email.html:1
+#: noggin/themes/default/templates/forgot-password-email.html:1
+#: noggin/themes/fas/templates/forgot-password-email.html:1
 msgid "Hi,"
 msgstr "你好，"
 
+#: noggin/themes/almalinux/templates/forgot-password-email.html:2
+#: noggin/themes/centos/templates/forgot-password-email.html:2
+#: noggin/themes/default/templates/forgot-password-email.html:2
+#: noggin/themes/fas/templates/forgot-password-email.html:2
 msgid ""
 "Click the link below to reset your password. If you did not request a "
 "password reset, please ignore this email."
 msgstr "點擊下面的鏈接重置您的密碼。如果您沒有要求重設密碼，請忽略此電子郵件。"
 
+#: noggin/themes/almalinux/templates/main.html:2
 msgid "AlmaLinux Account Services"
 msgstr "AlmaLinux 帳號服務"
 
+#: noggin/themes/almalinux/templates/main.html:21
+#: noggin/themes/centos/templates/main.html:13
+#: noggin/themes/default/templates/main.html:13
+#: noggin/themes/fas/templates/main.html:24
 msgid "search..."
 msgstr "搜尋..."
 
+#: noggin/themes/almalinux/templates/main.html:32
+#: noggin/themes/centos/templates/main.html:25
+#: noggin/themes/default/templates/main.html:25
+#: noggin/themes/fas/templates/main.html:36
 msgid "Settings"
 msgstr "設定"
 
+#: noggin/themes/almalinux/templates/main.html:37
+#: noggin/themes/centos/templates/main.html:30
+#: noggin/themes/fas/templates/main.html:41
 msgid "Help"
 msgstr "協助"
 
+#: noggin/themes/almalinux/templates/main.html:38
+#: noggin/themes/centos/templates/main.html:31
+#: noggin/themes/default/templates/main.html:29
+#: noggin/themes/fas/templates/main.html:42
 msgid "Log Out"
 msgstr "登出"
 
+#: noggin/themes/almalinux/templates/main.html:72
+#: noggin/themes/centos/templates/main.html:63
+#: noggin/themes/default/templates/main.html:61
+#: noggin/themes/fas/templates/main.html:116
 #, python-format
 msgid "Powered by %(noggin_link)s"
 msgstr "由 %(noggin_link)s 提供支援"
 
+#: noggin/themes/almalinux/templates/main.html:88
 msgid "AlmaLinux Accounts"
 msgstr "AlmaLinux 帳號"
 
+#: noggin/themes/almalinux/templates/main.html:90
 msgid ""
-"AlmaLinux Accounts provides the ability to create and manage your account "
-"across AlmaLinux's entire infrastructure."
-msgstr ""
-"AlmaLinux 帳號提供了在 AlmaLinux 的整個基礎架構中建置和管理您的帳戶的功能。"
+"AlmaLinux Accounts provides the ability to create and manage your account"
+" across AlmaLinux's entire infrastructure."
+msgstr "AlmaLinux 帳號提供了在 AlmaLinux 的整個基礎架構中建置和管理您的帳戶的功能。"
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:3
+#: noggin/themes/centos/templates/settings-email-validation.html:3
+#: noggin/themes/default/templates/settings-email-validation.html:3
+#: noggin/themes/fas/templates/settings-email-validation.html:3
 #, python-format
 msgid "To validate the email address %(address)s, click on the link below:"
 msgstr "若要驗證電子郵件地址 %(address)s，請點選以下連結："
 
+#: noggin/themes/almalinux/templates/settings-email-validation.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:9
 #, python-format
 msgid ""
 "If you did not set the email address %(address)s in your account "
 "%(username)s, you can ignore this email."
-msgstr ""
-"如果您沒有在帳號 %(username)s 中設定電子郵件地址 %(address)s，您可以忽略此電"
-"子郵件。"
+msgstr "如果您沒有在帳號 %(username)s 中設定電子郵件地址 %(address)s，您可以忽略此電子郵件。"
 
+#: noggin/themes/centos/templates/email-validation.html:11
+#: noggin/themes/centos/templates/forgot-password-email.html:9
+#: noggin/themes/centos/templates/settings-email-validation.html:11
+#: noggin/themes/default/templates/email-validation.html:18
+#: noggin/themes/default/templates/forgot-password-email.html:9
+#: noggin/themes/default/templates/settings-email-validation.html:11
 msgid "The Noggin team"
 msgstr "Noggin 團隊"
 
+#: noggin/themes/centos/templates/main.html:78
+#: noggin/themes/default/templates/main.html:76
 msgid "Welcome to noggin!"
 msgstr "歡迎來到 noggin！"
 
+#: noggin/themes/centos/templates/main.html:80
+#: noggin/themes/default/templates/main.html:78
 msgid ""
 "This is the open source, community self-service portal for FreeIPA. It "
-"allows you to do things like create an account, change your password, manage "
-"group membership, and more."
-msgstr ""
-"這是 FreeIPA 的開放原始碼社群自助服務入口網站。您可以使用它來建立帳號、變更密"
-"碼、管理群組成員等。"
+"allows you to do things like create an account, change your password, "
+"manage group membership, and more."
+msgstr "這是 FreeIPA 的開放原始碼社群自助服務入口網站。您可以使用它來建立帳號、變更密碼、管理群組成員等。"
 
+#: noggin/themes/centos/templates/main.html:110
+#: noggin/themes/fas/templates/main.html:208
 msgid ""
-"Additional configuration is required when using Kerberos tickets when OTP is "
-"enabled"
+"Additional configuration is required when using Kerberos tickets when OTP"
+" is enabled"
 msgstr "啟用 OTP 時，使用 Kerberos 票券需要額外的設定"
 
+#: noggin/themes/centos/templates/main.html:111
+#: noggin/themes/fas/templates/main.html:209
 msgid ""
-"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>documentation</a> for details on configuring your system"
+"Read the <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>documentation</a> for details on configuring your "
+"system"
 msgstr ""
-"請閱讀 <a href='https://docs.fedoraproject.org/en-US/fedora-accounts/user/"
-"#pkinit'>說明文件</a>，以瞭解設定系統的詳細資訊"
+"請閱讀 <a href='https://docs.fedoraproject.org/en-US/fedora-"
+"accounts/user/#pkinit'>說明文件</a>，以瞭解設定系統的詳細資訊"
 
+#: noggin/themes/centos/templates/main.html:121
 msgid "You can also use your Fedora account to login here."
 msgstr "您也可以使用 Fedora 帳號登入此處。"
 
+#: noggin/themes/default/templates/email-validation.html:10
+#: noggin/themes/fas/templates/email-validation.html:10
 #, python-format
-msgid ""
-"This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
+msgid "This link will be valid for %(ttl)s minutes (until %(valid_until)s UTC)."
 msgstr "此連結將在 %(ttl)s 分鐘內有效 (直到 %(valid_until)s UTC)。"
 
+#: noggin/themes/default/templates/email-validation.html:11
+#: noggin/themes/fas/templates/email-validation.html:11
 msgid "If the link has expired, you can request a new one here: "
 msgstr "如果連結已過期，您可以在此申請新的連結： "
 
+#: noggin/themes/fas/templates/email-validation.html:1
+#: noggin/themes/fas/templates/email-validation.html:18
+#: noggin/themes/fas/templates/forgot-password-email.html:9
+#: noggin/themes/fas/templates/settings-email-validation.html:1
+#: noggin/themes/fas/templates/settings-email-validation.html:11
 msgid "Fedora Accounts System"
 msgstr "Fedora 帳號系統"
 
+#: noggin/themes/fas/templates/main.html:2
+#: noggin/themes/fas/templates/main.html:153
 msgid "Fedora Accounts"
 msgstr "Fedora 帳號"
 
+#: noggin/themes/fas/templates/main.html:142
 msgid "Wiki"
 msgstr "Wiki"
 
+#: noggin/themes/fas/templates/main.html:146
 msgid "Fedora People"
 msgstr "Fedora People"
 
+#: noggin/themes/fas/templates/main.html:155
 msgid ""
-"Fedora Accounts allows you to create and manage an account for Fedora Tools "
-"and Infrastructure."
+"Fedora Accounts allows you to create and manage an account for Fedora "
+"Tools and Infrastructure."
 msgstr "Fedora 帳號允許您建立和管理 Fedora 工具和基礎建設的帳戶。"
 
+#: noggin/themes/fas/templates/main.html:167
 msgid "Edit Group"
 msgstr "編輯群組"
 
+#: noggin/themes/fas/templates/main.html:168
 msgid "To change group details or add sponsors, file a ticket with"
 msgstr "若要變更團體詳細資訊或新增贊助商，請向下列單位提出申請"
 
+#: noggin/themes/fas/templates/main.html:178
 msgid "Create a PDR request to disable your account"
 msgstr "建立 PDR 請求以停用您的帳戶"
 
+#: noggin/themes/fas/templates/main.html:179
 msgid "Request account deletion"
 msgstr "要求刪除帳號"
 
+#: noggin/themes/fas/templates/main.html:190
 msgid "Did you lose your last OTP token?"
 msgstr "您是否遺失了最後一個 OTP 權杖？"
 
+#: noggin/themes/fas/templates/main.html:194
 #, python-format
 msgid ""
 "If you have lost your last OTP token you need to send an email to "
-"%(admin_email)s. Please sign this email using the GPG key associated with "
-"your account if possible, so that the administrator can verify your identity."
+"%(admin_email)s. Please sign this email using the GPG key associated with"
+" your account if possible, so that the administrator can verify your "
+"identity."
 msgstr ""
-"如果您遺失了上一個 OTP 權杖，您需要發送電子郵件到 %(admin_email)s。如果可能的"
-"話，請使用與您帳戶關聯的 GPG 金鑰簽署這封電子郵件，以便管理員驗證您的身份。"
+"如果您遺失了上一個 OTP 權杖，您需要發送電子郵件到 %(admin_email)s。如果可能的話，請使用與您帳戶關聯的 GPG "
+"金鑰簽署這封電子郵件，以便管理員驗證您的身份。"
 
+#: noggin/themes/fas/templates/main.html:195
 msgid ""
-"If you had multiple tokens and lost one, you can use another to login and "
-"delete the lost token from your account."
-msgstr ""
-"如果您有多個權杖，但遺失了其中一個，您可以使用另一個權杖登入，並從帳戶中刪除"
-"遺失的權杖。"
+"If you had multiple tokens and lost one, you can use another to login and"
+" delete the lost token from your account."
+msgstr "如果您有多個權杖，但遺失了其中一個，您可以使用另一個權杖登入，並從帳戶中刪除遺失的權杖。"
 
+#: noggin/themes/fas/templates/main.html:196
 msgid ""
 "If you haven't enrolled a OTP token, you don't have one and this doesn't "
 "apply to you."
 msgstr "如果您還沒有註冊 OTP 權杖，您就沒有 OTP 權杖，這對您不適用。"
 
+#: noggin/themes/fas/templates/main.html:220
 #, python-format
 msgid ""
 "To let admins know that you're not a spammer, please send an email to "
 "%(email_link)s and explain the situation."
-msgstr ""
-"為了讓管理員知道您不是垃圾郵件發送者，請發送電子郵件到 %(email_link)s 並解釋"
-"情況。"
+msgstr "為了讓管理員知道您不是垃圾郵件發送者，請發送電子郵件到 %(email_link)s 並解釋情況。"
 
+#: noggin/themes/fas/templates/main.html:228
 msgid ""
-"By using a Fedora account, you agree to follow the <a href='https://"
-"docs.fedoraproject.org/en-US/project/code-of-"
+"By using a Fedora account, you agree to follow the <a "
+"href='https://docs.fedoraproject.org/en-US/project/code-of-"
 "conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>."
 msgstr ""
-"使用 Fedora 帳號即表示您同意遵守<a href='https://docs.fedoraproject.org/en-"
-"US/project/code-of-conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>。"
+"使用 Fedora 帳號即表示您同意遵守<a href='https://docs.fedoraproject.org/en-US/project"
+"/code-of-conduct/'>Fedora&nbsp;Code&nbsp;of&nbsp;Conduct</a>。"
 
+#: noggin/themes/fas/templates/main.html:231
 msgid "You can also use your CentOS account to login here."
 msgstr "您也可以使用 CentOS 帳號登入此處。"
 
+#: noggin/utility/controllers.py:37
+msgid "Please log in to continue."
+msgstr ""
+
+#: noggin/utility/controllers.py:59
+msgid "You do not have permission to edit this account."
+msgstr ""
+
+#: noggin/utility/controllers.py:85 noggin/utility/controllers.py:96
+msgid "You do not have permission to reset OTP for this user."
+msgstr ""
+
+#: noggin/utility/controllers.py:108
 #, python-format
 msgid "Group %(groupname)s could not be found."
 msgstr "無法找到群組 %(groupname)s 。"
 
+#: noggin/utility/controllers.py:130
 #, python-format
 msgid "No Users with email %(username_or_email)s found"
 msgstr ""
 
+#: noggin/utility/templates.py:26
 msgid "Undo"
 msgstr "撤銷"
 
+#: noggin/utility/templates.py:89
 #, python-format
 msgid "%(protocol)s on %(server)s"
 msgstr "%(server)s 上的 %(protocol)s"
@@ -1135,3 +1905,4 @@ msgstr "%(server)s 上的 %(protocol)s"
 
 #~ msgid "Website"
 #~ msgstr "網站"
+

--- a/noggin/utility/controllers.py
+++ b/noggin/utility/controllers.py
@@ -5,8 +5,21 @@ import python_freeipa
 from flask import abort, current_app, flash, g, redirect, request, session, url_for
 from flask_babel import lazy_gettext as _
 
+from noggin.app import ipa_admin
 from noggin.representation.user import User
 from noggin.security.ipa import maybe_ipa_session
+
+
+def is_role_member(role_result, username, user_groups=None):
+    """Check if a user is a member of an IPA role (directly or via group)."""
+    result = role_result.get('result', {})
+    if username in result.get('member_user', []):
+        return True
+    if user_groups:
+        role_groups = set(result.get('member_group', []))
+        if role_groups.intersection(user_groups):
+            return True
+    return False
 
 
 # A wrapper that will give us 'ipa' if it exists, or bump the user back to /
@@ -21,7 +34,7 @@ def with_ipa():
                 g.current_user = User(g.ipa.user_find(whoami=True)['result'][0])
                 return f(*args, **kwargs, ipa=ipa)
             coming_from = quote(request.full_path)
-            flash('Please log in to continue.', 'warning')
+            flash(_('Please log in to continue.'), 'warning')
             return redirect(f"{url_for('.root')}?next={coming_from}")
 
         return fn
@@ -43,11 +56,53 @@ def require_self(f):
                 "as a component.",
             )
         if session.get('noggin_username') != username:
-            flash('You do not have permission to edit this account.', 'danger')
+            flash(_('You do not have permission to edit this account.'), 'danger')
             return redirect(url_for('.user', username=username))
         return f(*args, **kwargs)
 
     return fn
+
+
+def require_otp_admin(f):
+    """Require the logged-in user to be an OTP recovery admin for the target user."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        role = current_app.config.get('OTP_ADMIN_RECOVERY_ROLE')
+        if not role:
+            abort(404)
+        current_username = session.get('noggin_username')
+        target_username = kwargs.get('username')
+        if current_username == target_username:
+            return redirect(
+                url_for('.user_settings_otp', username=target_username)
+            )
+        try:
+            role_info = ipa_admin.role_show(a_cn=role)
+            user_groups = getattr(g.current_user, 'groups', None)
+            if not is_role_member(role_info, current_username, user_groups):
+                flash(
+                    _('You do not have permission to reset OTP for this user.'),
+                    'danger',
+                )
+                return redirect(url_for('.user', username=target_username))
+        except python_freeipa.exceptions.FreeIPAError:
+            current_app.logger.warning(
+                'Failed to check OTP admin role %s for user %s',
+                role,
+                current_username,
+            )
+            flash(
+                _(
+                    'Could not verify your permissions. '
+                    'Please try again later.'
+                ),
+                'danger',
+            )
+            return redirect(url_for('.user', username=target_username))
+        return f(*args, **kwargs)
+
+    return wrapper
 
 
 def group_or_404(ipa, groupname):

--- a/noggin/utility/recovery_codes.py
+++ b/noggin/utility/recovery_codes.py
@@ -1,0 +1,10 @@
+import hashlib
+
+from pyotp import HOTP
+
+
+def generate_recovery_codes(secret_b32: str, count: int) -> list[str]:
+    if count <= 0:
+        return []
+    hotp = HOTP(secret_b32, digits=8, digest=hashlib.sha256)
+    return [hotp.at(i) for i in range(count)]

--- a/tests/unit/controller/cassettes/test_user_otp/test_recovery_generate_invalid_form.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_recovery_generate_invalid_form.yaml
@@ -1,0 +1,845 @@
+interactions:
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:27 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=rKBnGlA8M2AmEVZZSK7xwKmvDxK85NwWPoBK6irtWoxmsgWQTT31tCf%2fpjUuxNyNUVPizeYNYmTllFXXjj75aFS2cqMvsFeMtme%2bkNfR82jC%2f2C49jT4IR1zkiM7scNDdxKbx0aPcUjbCtbF7Yo2jZMuvfYra1LoUW8oTR9K4H01vvWji%2fE9AwO2WzTZL9QMU1imd8HRbR0p4kYadV0rMg%3d%3d;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rKBnGlA8M2AmEVZZSK7xwKmvDxK85NwWPoBK6irtWoxmsgWQTT31tCf%2fpjUuxNyNUVPizeYNYmTllFXXjj75aFS2cqMvsFeMtme%2bkNfR82jC%2f2C49jT4IR1zkiM7scNDdxKbx0aPcUjbCtbF7Yo2jZMuvfYra1LoUW8oTR9K4H01vvWji%2fE9AwO2WzTZL9QMU1imd8HRbR0p4kYadV0rMg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:27 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@unit.tests",
+      "userpassword": "dummy_password", "random": false, "noprivate": false, "all":
+      true, "raw": false, "no_members": false, "fascreationtime": "2024-04-15T14:27:27Z",
+      "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rKBnGlA8M2AmEVZZSK7xwKmvDxK85NwWPoBK6irtWoxmsgWQTT31tCf%2fpjUuxNyNUVPizeYNYmTllFXXjj75aFS2cqMvsFeMtme%2bkNfR82jC%2f2C49jT4IR1zkiM7scNDdxKbx0aPcUjbCtbF7Yo2jZMuvfYra1LoUW8oTR9K4H01vvWji%2fE9AwO2WzTZL9QMU1imd8HRbR0p4kYadV0rMg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "objectclass": ["top",
+        "person", "organizationalperson", "inetorgperson", "inetuser", "posixaccount",
+        "krbprincipalaux", "krbticketpolicyaux", "ipaobject", "ipasshuser", "fasuser",
+        "ipaSshGroupOfPubKeys", "mepOriginEntry", "ipantuserattrs"], "ipauniqueid":
+        ["494187a0-fb34-11ee-86a1-525400e27449"], "krbpasswordexpiration": [{"__datetime__":
+        "20240415142727Z"}], "krblastpwdchange": [{"__datetime__": "20240415142727Z"}],
+        "krbextradata": [{"__base64__": "AAJPOR1mcm9vdC9hZG1pbkBUSU5ZU1RBR0UuVEVTVAA="}],
+        "mepmanagedentry": ["cn=dummy,cn=groups,cn=accounts,dc=tinystage,dc=test"],
+        "mail": ["dummy@unit.tests"], "sn": ["User"], "gidnumber": ["801809236"],
+        "homedirectory": ["/home/dummy"], "loginshell": ["/bin/bash"], "krbcanonicalname":
+        ["dummy@TINYSTAGE.TEST"], "uid": ["dummy"], "givenname": ["Dummy"], "krbprincipalname":
+        ["dummy@TINYSTAGE.TEST"], "uidnumber": ["801809236"], "fascreationtime": [{"__datetime__":
+        "20240415142727Z"}], "preserved": false, "has_password": true, "has_keytab":
+        true, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"},
+        "value": "dummy", "summary": "Added user \"dummy\""}, "error": null, "id":
+        null, "principal": "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:27 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=rKBnGlA8M2AmEVZZSK7xwKmvDxK85NwWPoBK6irtWoxmsgWQTT31tCf%2fpjUuxNyNUVPizeYNYmTllFXXjj75aFS2cqMvsFeMtme%2bkNfR82jC%2f2C49jT4IR1zkiM7scNDdxKbx0aPcUjbCtbF7Yo2jZMuvfYra1LoUW8oTR9K4H01vvWji%2fE9AwO2WzTZL9QMU1imd8HRbR0p4kYadV0rMg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/change_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/change_password
+  response:
+    body:
+      string: '<html>
+
+        <head>
+
+        <title>200 Success</title>
+
+        </head>
+
+        <body>
+
+        <h1>Password change successful</h1>
+
+        <p>
+
+        <strong>Password was changed.</strong>
+
+        </p>
+
+        </body>
+
+        </html>'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[null], {"whoami": true, "all": true,
+      "raw": false, "no_members": true, "pkey_only": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "fascreationtime": [{"__datetime__":
+        "20240415142727Z"}], "objectclass": ["top", "person", "organizationalperson",
+        "inetorgperson", "inetuser", "posixaccount", "krbprincipalaux", "krbticketpolicyaux",
+        "ipaobject", "ipasshuser", "fasuser", "ipaSshGroupOfPubKeys", "mepOriginEntry",
+        "ipantuserattrs"], "ipauniqueid": ["494187a0-fb34-11ee-86a1-525400e27449"],
+        "krbpasswordexpiration": [{"__datetime__": "20240714142728Z"}], "krblastpwdchange":
+        [{"__datetime__": "20240415142728Z"}], "ipantsecurityidentifier": ["S-1-5-21-642839132-256774972-2695044819-10236"],
+        "loginshell": ["/bin/bash"], "gidnumber": ["801809236"], "krbprincipalname":
+        ["dummy@TINYSTAGE.TEST"], "mail": ["dummy@unit.tests"], "sn": ["User"], "uidnumber":
+        ["801809236"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"], "homedirectory":
+        ["/home/dummy"], "givenname": ["Dummy"], "uid": ["dummy"], "nsaccountlock":
+        false, "preserved": false, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"}],
+        "count": 1, "truncated": false, "summary": "1 user matched"}, "error": null,
+        "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_show", "params": [["dummy"], {"rights": false, "all":
+      true, "raw": false, "no_members": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "objectclass": ["top",
+        "person", "organizationalperson", "inetorgperson", "inetuser", "posixaccount",
+        "krbprincipalaux", "krbticketpolicyaux", "ipaobject", "ipasshuser", "fasuser",
+        "ipaSshGroupOfPubKeys", "mepOriginEntry", "ipantuserattrs"], "ipauniqueid":
+        ["494187a0-fb34-11ee-86a1-525400e27449"], "krbpasswordexpiration": [{"__datetime__":
+        "20240714142728Z"}], "krblastpwdchange": [{"__datetime__": "20240415142728Z"}],
+        "ipantsecurityidentifier": ["S-1-5-21-642839132-256774972-2695044819-10236"],
+        "fascreationtime": [{"__datetime__": "20240415142727Z"}], "loginshell": ["/bin/bash"],
+        "uid": ["dummy"], "uidnumber": ["801809236"], "gidnumber": ["801809236"],
+        "sn": ["User"], "mail": ["dummy@unit.tests"], "givenname": ["Dummy"], "homedirectory":
+        ["/home/dummy"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"], "krbprincipalname":
+        ["dummy@TINYSTAGE.TEST"], "nsaccountlock": false, "has_password": true, "has_keytab":
+        true, "preserved": false, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"},
+        "value": "dummy", "summary": null}, "error": null, "id": null, "principal":
+        "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:28 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "otptoken_find", "params": [[null], {"ipatokenowner": "dummy",
+      "all": true, "raw": false, "no_members": true, "pkey_only": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '162'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [], "count": 0, "truncated": false, "summary":
+        "0 OTP tokens matched"}, "error": null, "id": null, "principal": "dummy@TINYSTAGE.TEST",
+        "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=cffLIkAvG59IYy1yXE11TqJGNJ833%2fR2n1Gu4mkNOhvL430wxamc5oxdv8zpSIhYTVkKzYGaE2yV6hJoyDBUpDx5cb9F0OlySbNVXU9dKMYbhHxoEX9OukQF%2fS6EjNIlMmUjNtJw8RQZqdT%2bxNKkkrHTtPPjx4NsJYesz2vGAtgyLI09Qu%2f409r1I8sz2pxAJxxkczS6rTGAGmt30qsLXA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=kzKdIN8o5PKf1PRTIttrgaLQn8tYTVnRDYSfe5oRgGAiuI1SrZTOdcksm340%2ffMfksBzI64BkiddXYClRLzpJInCGB6Ed5VBWGVWqzycvqvUvd8DnD3PIpvs7A1IiEJgyPSHRMIwbisWYA8F%2bq7kiFPm9oBuwp7pMj4jwBQpftWZFl9hE14ZiJjmiRiutzmVCV9z6qKdf19bDecckjvXng%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=kzKdIN8o5PKf1PRTIttrgaLQn8tYTVnRDYSfe5oRgGAiuI1SrZTOdcksm340%2ffMfksBzI64BkiddXYClRLzpJInCGB6Ed5VBWGVWqzycvqvUvd8DnD3PIpvs7A1IiEJgyPSHRMIwbisWYA8F%2bq7kiFPm9oBuwp7pMj4jwBQpftWZFl9hE14ZiJjmiRiutzmVCV9z6qKdf19bDecckjvXng%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=kzKdIN8o5PKf1PRTIttrgaLQn8tYTVnRDYSfe5oRgGAiuI1SrZTOdcksm340%2ffMfksBzI64BkiddXYClRLzpJInCGB6Ed5VBWGVWqzycvqvUvd8DnD3PIpvs7A1IiEJgyPSHRMIwbisWYA8F%2bq7kiFPm9oBuwp7pMj4jwBQpftWZFl9hE14ZiJjmiRiutzmVCV9z6qKdf19bDecckjvXng%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"failed": []}, "value": ["dummy"], "summary":
+        "Deleted user \"dummy\""}, "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST",
+        "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:29 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=kzKdIN8o5PKf1PRTIttrgaLQn8tYTVnRDYSfe5oRgGAiuI1SrZTOdcksm340%2ffMfksBzI64BkiddXYClRLzpJInCGB6Ed5VBWGVWqzycvqvUvd8DnD3PIpvs7A1IiEJgyPSHRMIwbisWYA8F%2bq7kiFPm9oBuwp7pMj4jwBQpftWZFl9hE14ZiJjmiRiutzmVCV9z6qKdf19bDecckjvXng%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:30 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/tests/unit/controller/cassettes/test_user_otp/test_recovery_generate_no_permission.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_recovery_generate_no_permission.yaml
@@ -1,0 +1,725 @@
+interactions:
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:04 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@unit.tests",
+      "userpassword": "dummy_password", "random": false, "noprivate": false, "all":
+      true, "raw": false, "no_members": false, "fascreationtime": "2024-04-15T14:27:04Z",
+      "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "objectclass": ["top",
+        "person", "organizationalperson", "inetorgperson", "inetuser", "posixaccount",
+        "krbprincipalaux", "krbticketpolicyaux", "ipaobject", "ipasshuser", "fasuser",
+        "ipaSshGroupOfPubKeys", "mepOriginEntry", "ipantuserattrs"], "ipauniqueid":
+        ["3bc5d072-fb34-11ee-a89a-525400e27449"], "krbpasswordexpiration": [{"__datetime__":
+        "20240415142704Z"}], "krblastpwdchange": [{"__datetime__": "20240415142704Z"}],
+        "krbextradata": [{"__base64__": "AAI4OR1mcm9vdC9hZG1pbkBUSU5ZU1RBR0UuVEVTVAA="}],
+        "mepmanagedentry": ["cn=dummy,cn=groups,cn=accounts,dc=tinystage,dc=test"],
+        "mail": ["dummy@unit.tests"], "krbprincipalname": ["dummy@TINYSTAGE.TEST"],
+        "uidnumber": ["801809228"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"],
+        "sn": ["User"], "uid": ["dummy"], "fascreationtime": [{"__datetime__": "20240415142704Z"}],
+        "loginshell": ["/bin/bash"], "gidnumber": ["801809228"], "givenname": ["Dummy"],
+        "homedirectory": ["/home/dummy"], "preserved": false, "has_password": true,
+        "has_keytab": true, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"},
+        "value": "dummy", "summary": "Added user \"dummy\""}, "error": null, "id":
+        null, "principal": "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/change_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/change_password
+  response:
+    body:
+      string: '<html>
+
+        <head>
+
+        <title>200 Success</title>
+
+        </head>
+
+        <body>
+
+        <h1>Password change successful</h1>
+
+        <p>
+
+        <strong>Password was changed.</strong>
+
+        </p>
+
+        </body>
+
+        </html>'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[null], {"whoami": true, "all": true,
+      "raw": false, "no_members": true, "pkey_only": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "fascreationtime": [{"__datetime__":
+        "20240415142704Z"}], "objectclass": ["top", "person", "organizationalperson",
+        "inetorgperson", "inetuser", "posixaccount", "krbprincipalaux", "krbticketpolicyaux",
+        "ipaobject", "ipasshuser", "fasuser", "ipaSshGroupOfPubKeys", "mepOriginEntry",
+        "ipantuserattrs"], "ipauniqueid": ["3bc5d072-fb34-11ee-a89a-525400e27449"],
+        "krbpasswordexpiration": [{"__datetime__": "20240714142705Z"}], "krblastpwdchange":
+        [{"__datetime__": "20240415142705Z"}], "ipantsecurityidentifier": ["S-1-5-21-642839132-256774972-2695044819-10228"],
+        "homedirectory": ["/home/dummy"], "gidnumber": ["801809228"], "uidnumber":
+        ["801809228"], "loginshell": ["/bin/bash"], "krbprincipalname": ["dummy@TINYSTAGE.TEST"],
+        "mail": ["dummy@unit.tests"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"],
+        "givenname": ["Dummy"], "sn": ["User"], "uid": ["dummy"], "nsaccountlock":
+        false, "preserved": false, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"}],
+        "count": 1, "truncated": false, "summary": "1 user matched"}, "error": null,
+        "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"failed": []}, "value": ["dummy"], "summary":
+        "Deleted user \"dummy\""}, "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST",
+        "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/tests/unit/controller/cassettes/test_user_otp/test_recovery_regenerate_no_permission.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_recovery_regenerate_no_permission.yaml
@@ -1,0 +1,725 @@
+interactions:
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:04 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_add", "params": [["dummy"], {"givenname": "Dummy", "sn":
+      "User", "cn": "Dummy User", "loginshell": "/bin/bash", "mail": "dummy@unit.tests",
+      "userpassword": "dummy_password", "random": false, "noprivate": false, "all":
+      true, "raw": false, "no_members": false, "fascreationtime": "2024-04-15T14:27:04Z",
+      "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "objectclass": ["top",
+        "person", "organizationalperson", "inetorgperson", "inetuser", "posixaccount",
+        "krbprincipalaux", "krbticketpolicyaux", "ipaobject", "ipasshuser", "fasuser",
+        "ipaSshGroupOfPubKeys", "mepOriginEntry", "ipantuserattrs"], "ipauniqueid":
+        ["3bc5d072-fb34-11ee-a89a-525400e27449"], "krbpasswordexpiration": [{"__datetime__":
+        "20240415142704Z"}], "krblastpwdchange": [{"__datetime__": "20240415142704Z"}],
+        "krbextradata": [{"__base64__": "AAI4OR1mcm9vdC9hZG1pbkBUSU5ZU1RBR0UuVEVTVAA="}],
+        "mepmanagedentry": ["cn=dummy,cn=groups,cn=accounts,dc=tinystage,dc=test"],
+        "mail": ["dummy@unit.tests"], "krbprincipalname": ["dummy@TINYSTAGE.TEST"],
+        "uidnumber": ["801809228"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"],
+        "sn": ["User"], "uid": ["dummy"], "fascreationtime": [{"__datetime__": "20240415142704Z"}],
+        "loginshell": ["/bin/bash"], "gidnumber": ["801809228"], "givenname": ["Dummy"],
+        "homedirectory": ["/home/dummy"], "preserved": false, "has_password": true,
+        "has_keytab": true, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"},
+        "value": "dummy", "summary": "Added user \"dummy\""}, "error": null, "id":
+        null, "principal": "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=vx1w%2bm8udjukWGk%2fL3yCMujgfMTVTfpINNgTq3%2bNM9Z%2fEe4dGju9btAakE74dOVybxWiHSJBmEEdyOOFWnUDIucITXgsyUbhndUR7r9oJvcKKncTd5F8vWGq3TKH1CLlSvIG6jx2bvE%2fkIJg478Gc%2fAU5EMIYy1SnN5MF1iThHMt1d37UIIJRPltiOUvGGZTsuJnAptC5YBLB%2fBPd3r%2b7Q%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&new_password=dummy_password&old_password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/change_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/change_password
+  response:
+    body:
+      string: '<html>
+
+        <head>
+
+        <title>200 Success</title>
+
+        </head>
+
+        <body>
+
+        <h1>Password change successful</h1>
+
+        <p>
+
+        <strong>Password was changed.</strong>
+
+        </p>
+
+        </body>
+
+        </html>'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+      X-IPA-Pwchange-Result:
+      - ok
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=dummy&password=dummy_password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '34'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:05 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_find", "params": [[null], {"whoami": true, "all": true,
+      "raw": false, "no_members": true, "pkey_only": false, "version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"cn": ["Dummy User"], "displayname": ["Dummy
+        User"], "initials": ["DU"], "gecos": ["Dummy User"], "fascreationtime": [{"__datetime__":
+        "20240415142704Z"}], "objectclass": ["top", "person", "organizationalperson",
+        "inetorgperson", "inetuser", "posixaccount", "krbprincipalaux", "krbticketpolicyaux",
+        "ipaobject", "ipasshuser", "fasuser", "ipaSshGroupOfPubKeys", "mepOriginEntry",
+        "ipantuserattrs"], "ipauniqueid": ["3bc5d072-fb34-11ee-a89a-525400e27449"],
+        "krbpasswordexpiration": [{"__datetime__": "20240714142705Z"}], "krblastpwdchange":
+        [{"__datetime__": "20240415142705Z"}], "ipantsecurityidentifier": ["S-1-5-21-642839132-256774972-2695044819-10228"],
+        "homedirectory": ["/home/dummy"], "gidnumber": ["801809228"], "uidnumber":
+        ["801809228"], "loginshell": ["/bin/bash"], "krbprincipalname": ["dummy@TINYSTAGE.TEST"],
+        "mail": ["dummy@unit.tests"], "krbcanonicalname": ["dummy@TINYSTAGE.TEST"],
+        "givenname": ["Dummy"], "sn": ["User"], "uid": ["dummy"], "nsaccountlock":
+        false, "preserved": false, "memberof_group": ["ipausers"], "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test"}],
+        "count": 1, "truncated": false, "summary": "1 user matched"}, "error": null,
+        "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=tiyzo8kdLexrDn7aBPXjNxySz6jvJcr1vbWwjLCAURCNLwiPp9%2b4e8fgS3FJ5APyjwigudqCdl7KAUPK75T2dGP9si%2fHX5tn3uUfQYFkLWaQBOzBRhWGKrwm5ZeXfz50rQtELG8UKbFN%2flYISACXKrooTEYa82HHGKxs2Anqw7PKRr4E5cJRsPN6nYduUstIbUmw6acBFET3bYwUgGy8eg%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: user=admin&password=password
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Referer:
+      - https://ipa.tinystage.test/ipa/session/login_password
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/login_password
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '20'
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d;path=/ipa;httponly;secure;
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"summary": "IPA server version 4.10.3. API version 2.252"},
+        "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST", "version":
+        "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:06 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "user_del", "params": [["dummy"], {"continue": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": {"failed": []}, "value": ["dummy"], "summary":
+        "Deleted user \"dummy\""}, "error": null, "id": null, "principal": "admin@TINYSTAGE.TEST",
+        "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
+    body: '{"method": "session_logout", "params": [[], {"version": "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=26oB58NzeWk%2bNLzVIm44cpFQl9YDjdjhWAsQtKSkCi4oJ3p1yfpey3Vmf9FVZvC0qiyO243Mep97AwHJoAMcyJoesnPHivOoBmcefu2vw7yyjX0RMihGptnWrxFn3RajzitA8iL2ziFPeu3IAFoHVJzCn8oFrJJxKvR1r1G3yjs26BClET8tniPzSM0tS6Mz1ujWUheEWR39TbZqoYbC0g%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": null}, "error": null, "id": null, "principal":
+        "admin@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:07 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Set-Cookie:
+      - ipa_session=;Max-Age=0;path=/ipa;httponly;secure;
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+version: 1

--- a/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_add_second_confirm.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_add_second_confirm.yaml
@@ -648,6 +648,68 @@ interactions:
       code: 200
       message: Success
 - request:
+    body: '{"method": "otptoken_find", "params": [[null], {"ipatokenowner": "dummy",
+      "all": true, "raw": false, "no_members": true, "pkey_only": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '162'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=G%2bA%2b0AymcyNbJdEyw2QHnJlziAX0dxrN4G2MfbXzAiTNU7Ps%2f2BNaruTLtzpBv3vqXG144TjpyuExybsEsw3QsV%2fNcXtEMkYsmTT3xqRkeGHVd4qA4RG13v3EU5QJE54HzYFFGjwCNiXFiDjqDHMSoVgr05Ljs3PzDkoPuNo40FKKGhQMPSZRMvHNdPHcdgZ4Ta%2bTBOzLFjHpoZkneNk%2bA%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"ipatokenotpalgorithm": ["sha1"], "ipatokenotpdigits":
+        ["6"], "ipatokentotptimestep": ["30"], "ipatokenuniqueid": ["0a43d55d-84e2-4f52-8fb3-8ac88837d921"],
+        "description": ["pants token"], "objectclass": ["ipatoken", "ipatokentotp",
+        "top"], "ipatokenowner": ["dummy"], "type": "TOTP", "managedby_user": ["dummy"],
+        "dn": "ipatokenuniqueid=0a43d55d-84e2-4f52-8fb3-8ac88837d921,cn=otp,dc=tinystage,dc=test"},
+        {"ipatokenotpalgorithm": ["sha1"], "ipatokenotpdigits": ["6"], "ipatokentotptimestep":
+        ["30"], "ipatokenuniqueid": ["ba25ca27-5e5c-471d-a852-cb382ec90af2"], "description":
+        ["dummy''s token"], "objectclass": ["ipatoken", "ipatokentotp", "top"], "ipatokenowner":
+        ["dummy"], "type": "TOTP", "managedby_user": ["dummy"], "dn": "ipatokenuniqueid=ba25ca27-5e5c-471d-a852-cb382ec90af2,cn=otp,dc=tinystage,dc=test"}],
+        "count": 2, "truncated": false, "summary": "2 OTP tokens matched"}, "error":
+        null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:18 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
     body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
     headers:
       Accept:

--- a/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_check_no_description.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_check_no_description.yaml
@@ -589,6 +589,63 @@ interactions:
       code: 200
       message: Success
 - request:
+    body: '{"method": "otptoken_find", "params": [[null], {"ipatokenowner": "dummy",
+      "all": true, "raw": false, "no_members": true, "pkey_only": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '162'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=XOyeKgYYVsMA95XHmwIKjEquKAoPpElURFL9bNdqiIGLFBDqO82lghzHFsQzeCCceKO%2bKnL9Vnk7%2fmVlISGnb0ifLPvewbJK5R%2bz2vmCCLMnRW%2bWXbQKCcGWA06z0vD6AGA6ObdRuHrQoSxWYvMTeHGMneCrU0MWCXwuGPvMSVaRDKdeoX6KialFJzPZdgJTHzdI5mFggilNjB4NPMe%2fUw%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"ipatokenotpalgorithm": ["sha1"], "ipatokenotpdigits":
+        ["6"], "ipatokentotptimestep": ["30"], "ipatokenowner": ["dummy"], "ipatokenuniqueid":
+        ["4cb9504a-198e-4596-9a41-e99ed3b4c2c6"], "objectclass": ["ipatoken", "ipatokentotp",
+        "top"], "type": "TOTP", "managedby_user": ["dummy"], "dn": "ipatokenuniqueid=4cb9504a-198e-4596-9a41-e99ed3b4c2c6,cn=otp,dc=tinystage,dc=test"}],
+        "count": 1, "truncated": false, "summary": "1 OTP token matched"}, "error":
+        null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:21 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
     body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
     headers:
       Accept:

--- a/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_confirm.yaml
+++ b/tests/unit/controller/cassettes/test_user_otp/test_user_settings_otp_confirm.yaml
@@ -589,6 +589,64 @@ interactions:
       code: 200
       message: Success
 - request:
+    body: '{"method": "otptoken_find", "params": [[null], {"ipatokenowner": "dummy",
+      "all": true, "raw": false, "no_members": true, "pkey_only": false, "version":
+      "2.235"}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '162'
+      Content-Type:
+      - application/json
+      Cookie:
+      - ipa_session=MagBearerToken=MDEAKCMRsJKd%2bm3OXa8pi5WTmdiU5KymKKnsKiVwVsFE4LT4rNNnmMZW8by85Ga9b4tSHV%2b%2b7cP%2brmdr4vuzYrOoR1LeYGzke5Uc3FT5%2bny4O9XC7LzTK0hd7RMwW5KPIYVVWqRwQPTp6K%2bE2kVmdzOTBl2k%2bh4Jd%2bM42pe3Wlg8G08e6Z%2f6JRv4JK6QGjN3ztk8mghz6aM4kPX2Rpd1zQ%3d%3d
+      Referer:
+      - https://ipa.tinystage.test/ipa
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://ipa.tinystage.test/ipa/session/json
+  response:
+    body:
+      string: '{"result": {"result": [{"ipatokenotpalgorithm": ["sha1"], "ipatokenotpdigits":
+        ["6"], "ipatokentotptimestep": ["30"], "ipatokenuniqueid": ["64389ded-032d-4062-a402-2469b70b7111"],
+        "description": ["pants token"], "objectclass": ["ipatoken", "ipatokentotp",
+        "top"], "ipatokenowner": ["dummy"], "type": "TOTP", "managedby_user": ["dummy"],
+        "dn": "ipatokenuniqueid=64389ded-032d-4062-a402-2469b70b7111,cn=otp,dc=tinystage,dc=test"}],
+        "count": 1, "truncated": false, "summary": "1 OTP token matched"}, "error":
+        null, "id": null, "principal": "dummy@TINYSTAGE.TEST", "version": "4.10.3"}'
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 15 Apr 2024 14:27:11 GMT
+      Keep-Alive:
+      - timeout=30, max=100
+      Server:
+      - Apache/2.4.58 (Fedora Linux) OpenSSL/3.0.8 mod_wsgi/4.9.4 Python/3.11 mod_auth_gssapi/1.6.5
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: Success
+- request:
     body: '{"method": "ping", "params": [[], {"version": "2.235"}]}'
     headers:
       Accept:

--- a/tests/unit/controller/test_user_otp.py
+++ b/tests/unit/controller/test_user_otp.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 import python_freeipa
 from bs4 import BeautifulSoup
+from flask import get_flashed_messages
 from pyotp import TOTP
 
 from noggin.app import ipa_admin
@@ -126,12 +127,13 @@ def test_user_settings_otp_confirm(
             "confirm-submit": "1",
         },
     )
-    assert_redirects_with_flash(
-        result,
-        expected_url="/user/dummy/settings/otp/",
-        expected_message="The token has been created.",
-        expected_category="success",
-    )
+    assert result.status_code == 302
+    assert result.location == "/user/dummy/settings/otp/"
+    messages = get_flashed_messages(with_categories=True)
+    assert len(messages) == 2
+    assert messages[0] == ("success", "The token has been created.")
+    assert messages[1][0] == "warning"
+    assert "recovery codes" in messages[1][1].lower()
     result = client.get("/user/dummy/settings/otp/")
     page = BeautifulSoup(result.data, "html.parser")
     tokenlist = page.select_one("div.list-group")
@@ -260,7 +262,6 @@ def test_user_settings_otp_check_description_escaping(
 
     page = BeautifulSoup(result.data, "html.parser")
     otp_uri = page.select_one("input#otp-uri")
-    print(page.prettify())
     assert otp_uri is not None
     parsed_otp_uri = urlparse(otp_uri["value"])
 
@@ -774,3 +775,600 @@ def test_user_settings_otp_rename_invalid_form(client, logged_in_dummy_user_with
         expected_message="Token must not be empty",
         expected_category="danger",
     )
+# --- Recovery code tests ---
+
+# These tests mock the IPA client directly instead of using VCR cassettes,
+# since the recovery code routes were added after the original cassettes
+# were recorded.
+
+DUMMY_USER_RESULT = {
+    "cn": ["Dummy User"],
+    "displayname": ["Dummy User"],
+    "uid": ["dummy"],
+    "krbprincipalname": ["dummy@TINYSTAGE.TEST"],
+    "mail": ["dummy@unit.tests"],
+    "sn": ["User"],
+    "givenname": ["Dummy"],
+    "nsaccountlock": False,
+    "dn": "uid=dummy,cn=users,cn=accounts,dc=tinystage,dc=test",
+}
+
+DUMMY_TOTP_TOKEN = {
+    "ipatokenotpalgorithm": ["sha1"],
+    "ipatokenotpdigits": ["6"],
+    "ipatokentotptimestep": ["30"],
+    "ipatokenuniqueid": ["totp-token-id-001"],
+    "description": ["dummy's token"],
+    "objectclass": ["ipatoken", "ipatokentotp", "top"],
+    "ipatokenowner": ["dummy"],
+    "type": "TOTP",
+    "managedby_user": ["dummy"],
+    "dn": "ipatokenuniqueid=totp-token-id-001,cn=otp,dc=tinystage,dc=test",
+}
+
+DUMMY_RECOVERY_TOKEN = {
+    "ipatokenotpalgorithm": ["sha256"],
+    "ipatokenotpdigits": ["8"],
+    "ipatokenuniqueid": ["recovery-token-id-001"],
+    "ipatokenhotpcounter": ["0"],
+    "description": ["Recovery codes"],
+    "objectclass": ["ipatoken", "ipatokenhotp", "top"],
+    "ipatokenowner": ["dummy"],
+    "type": "HOTP",
+    "managedby_user": ["dummy"],
+    "dn": "ipatokenuniqueid=recovery-token-id-001,cn=otp,dc=tinystage,dc=test",
+}
+
+
+@pytest.fixture
+def mock_ipa_client(client, app):
+    """Provide a logged-in session with a mock IPA client."""
+    mock_client = mock.MagicMock()
+    mock_client.ping.return_value = {"summary": "IPA server version 4.10.3"}
+    mock_client.ipa_version = "IPA server version 4.10.3"
+    mock_client.user_find.return_value = {"result": [DUMMY_USER_RESULT]}
+    mock_client.user_show.return_value = {"result": DUMMY_USER_RESULT}
+
+    with mock.patch("noggin.utility.controllers.maybe_ipa_session", return_value=mock_client):
+        with client.session_transaction() as sess:
+            sess["noggin_session"] = b"fake-session"
+            sess["noggin_username"] = "dummy"
+            sess["noggin_ipa_server_hostname"] = "ipa.tinystage.test"
+        yield mock_client
+
+
+def test_recovery_generate(client, mock_ipa_client):
+    """Test generating recovery codes"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [DUMMY_TOTP_TOKEN], "count": 0}
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "uri": "otpauth://hotp/dummy@TEST:recovery"}
+    }
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    def otptoken_find_side_effect(**kwargs):
+        if kwargs.get("o_type") == "hotp":
+            return {"result": [], "count": 0}
+        return {"result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN], "count": 2}
+
+    ipa.otptoken_find.side_effect = otptoken_find_side_effect
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/generate",
+            data={
+                "gen-password": "dummy_password",
+                "gen-submit": "1",
+            },
+        )
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, "html.parser")
+    codes = page.select('[data-role="recovery-code"]')
+    assert len(codes) == 10
+    for code_el in codes:
+        text = code_el.get_text(strip=True)
+        code_part = text.split(". ", 1)[1]
+        assert len(code_part) == 8
+        assert code_part.isdigit()
+
+
+def test_recovery_generate_requires_auth(client, mock_ipa_client):
+    """Test that wrong password is rejected"""
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.side_effect = python_freeipa.exceptions.InvalidSessionPassword(
+            message="invalid credentials", code="4242"
+        )
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/generate",
+            data={
+                "gen-password": "wrong_password",
+                "gen-submit": "1",
+            },
+        )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="Incorrect password",
+        expected_category="danger",
+    )
+
+
+def test_recovery_generate_duplicate(client, mock_ipa_client):
+    """Test that generating codes when recovery token already exists returns error"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [DUMMY_RECOVERY_TOKEN], "count": 1}
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/generate",
+            data={
+                "gen-password": "dummy_password",
+                "gen-submit": "1",
+            },
+        )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="You already have recovery codes. Regenerate them instead.",
+        expected_category="warning",
+    )
+
+
+def test_recovery_regenerate(client, mock_ipa_client):
+    """Test regenerating recovery codes"""
+    ipa = mock_ipa_client
+
+    find_calls = [0]
+
+    def otptoken_find_side_effect(**kwargs):
+        find_calls[0] += 1
+        if kwargs.get("o_type") == "hotp":
+            return {"result": [DUMMY_RECOVERY_TOKEN], "count": 1}
+        return {"result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN], "count": 2}
+
+    ipa.otptoken_find.side_effect = otptoken_find_side_effect
+    ipa.otptoken_del.return_value = {"result": True}
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "uri": "otpauth://hotp/dummy@TEST:recovery"}
+    }
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/regenerate",
+            data={
+                "regen-password": "dummy_password",
+                "regen-submit": "1",
+            },
+        )
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, "html.parser")
+    codes = page.select('[data-role="recovery-code"]')
+    assert len(codes) == 10
+
+
+def test_recovery_regenerate_last_token(client, mock_ipa_client):
+    """Test regeneration when recovery token is the last active token"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [DUMMY_RECOVERY_TOKEN], "count": 1}
+    ipa.otptoken_del.side_effect = python_freeipa.exceptions.BadRequest(
+        message="Server is unwilling to perform: Can't delete last active token",
+        code="4242",
+    )
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/regenerate",
+            data={
+                "regen-password": "dummy_password",
+                "regen-submit": "1",
+            },
+        )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message=(
+            "Cannot regenerate recovery codes while they are your only "
+            "active token. Add a regular OTP token first."
+        ),
+        expected_category="warning",
+    )
+
+
+def test_recovery_generate_ipa_error(client, mock_ipa_client):
+    """Test IPA error during recovery token creation"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [], "count": 0}
+    ipa.otptoken_add.side_effect = python_freeipa.exceptions.FreeIPAError(
+        message="Cannot create the token.", code="4242"
+    )
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/generate",
+            data={
+                "gen-password": "dummy_password",
+                "gen-submit": "1",
+            },
+        )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="Cannot create recovery codes.",
+        expected_category="danger",
+    )
+
+
+def test_recovery_token_hidden_from_list(client, mock_ipa_client):
+    """Test that the recovery token does not appear in the regular token list"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    result = client.get("/user/dummy/settings/otp/")
+    page = BeautifulSoup(result.data, "html.parser")
+    tokenlist = page.select("div.list-group .list-group-item")
+    assert len(tokenlist) == 1
+    desc = tokenlist[0].select_one("div[data-role='token-description']")
+    assert desc is not None
+    assert "Recovery codes" not in desc.get_text(strip=True)
+
+    recovery_section = page.select_one("#recovery-codes")
+    assert recovery_section is not None
+
+
+@pytest.mark.vcr()
+def test_recovery_generate_no_permission(client, logged_in_dummy_user):
+    """Verify that a user can't generate recovery codes for another user"""
+    result = client.post(
+        "/user/dudemcpants/settings/otp/recovery/generate",
+        data={"gen-password": "dummy_password", "gen-submit": "1"},
+    )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dudemcpants/",
+        expected_message="You do not have permission to edit this account.",
+        expected_category="danger",
+    )
+
+
+@pytest.mark.vcr()
+def test_recovery_regenerate_no_permission(client, logged_in_dummy_user):
+    """Verify that a user can't regenerate recovery codes for another user"""
+    result = client.post(
+        "/user/dudemcpants/settings/otp/recovery/regenerate",
+        data={"regen-password": "dummy_password", "regen-submit": "1"},
+    )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dudemcpants/",
+        expected_message="You do not have permission to edit this account.",
+        expected_category="danger",
+    )
+
+
+@pytest.mark.vcr()
+def test_recovery_generate_invalid_form(client, logged_in_dummy_user):
+    """Test that submitting the generate form without a password returns error"""
+    result = client.post(
+        "/user/dummy/settings/otp/recovery/generate",
+        data={"gen-submit": "1"},
+    )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="You must provide a password",
+        expected_category="danger",
+    )
+
+
+def test_recovery_token_no_rename(client, mock_ipa_client):
+    """Verify the recovery token has no rename button in the UI"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    result = client.get("/user/dummy/settings/otp/")
+    page = BeautifulSoup(result.data, "html.parser")
+    token_items = page.select("div.list-group .list-group-item")
+    assert len(token_items) == 1
+    rename_buttons = token_items[0].select("button[title='Rename']")
+    assert len(rename_buttons) == 1
+    rename_forms = page.select(
+        "form[action='/user/dummy/settings/otp/rename/'] "
+        "button[value='recovery-token-id-001']"
+    )
+    assert len(rename_forms) == 0
+
+
+def test_rename_to_recovery_description_blocked(client, mock_ipa_client):
+    """Server rejects renaming a token TO the recovery description."""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+
+    result = client.post(
+        "/user/dummy/settings/otp/rename/",
+        data={"token": "some-token-id", "description": "Recovery codes"},
+    )
+    assert result.status_code == 302
+    assert "/user/dummy/settings/otp/" in result.headers["Location"]
+    ipa.otptoken_mod.assert_not_called()
+
+
+def test_recovery_codes_remaining_display(client, mock_ipa_client):
+    """Verify the remaining code count appears on the OTP page"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    ipa.otptoken_show.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "ipatokenhotpcounter": ["3"]},
+    }
+
+    result = client.get("/user/dummy/settings/otp/")
+    page = BeautifulSoup(result.data, "html.parser")
+    recovery_section = page.select_one("#recovery-codes")
+    assert recovery_section is not None
+    text = recovery_section.get_text()
+    assert "7 recovery codes remaining" in text
+    badge = recovery_section.select_one("span.badge.bg-success")
+    assert badge is not None
+    assert badge.get_text(strip=True) == "Active"
+
+
+def test_recovery_codes_remaining_low_warning(client, mock_ipa_client):
+    """Verify warning badge when codes are running low"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    ipa.otptoken_show.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "ipatokenhotpcounter": ["8"]},
+    }
+
+    result = client.get("/user/dummy/settings/otp/")
+    page = BeautifulSoup(result.data, "html.parser")
+    recovery_section = page.select_one("#recovery-codes")
+    text = recovery_section.get_text()
+    assert "2 recovery codes remaining" in text
+    assert "Consider regenerating" in text
+    badge = recovery_section.select_one("span.badge.bg-warning")
+    assert badge is not None
+    assert badge.get_text(strip=True) == "Low"
+
+
+def test_recovery_codes_remaining_zero(client, mock_ipa_client):
+    """Verify display when all codes are exhausted"""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    ipa.otptoken_show.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "ipatokenhotpcounter": ["10"]},
+    }
+
+    result = client.get("/user/dummy/settings/otp/")
+    page = BeautifulSoup(result.data, "html.parser")
+    recovery_section = page.select_one("#recovery-codes")
+    text = recovery_section.get_text()
+    assert "Exhausted" in text
+    assert "Regenerate now" in text
+    badge = recovery_section.select_one("span.badge.bg-danger")
+    assert badge is not None
+
+
+# --- Enhancement 2: Mandatory recovery codes ---
+
+
+def _confirm_otp_data(totp_secret="JBSWY3DPEHPK3PXP"):
+    """Build POST data for the confirm OTP form with a valid TOTP code."""
+    totp = TOTP(totp_secret)
+    return {
+        "confirm-description": "my token",
+        "confirm-secret": totp_secret,
+        "confirm-code": totp.now(),
+        "confirm-submit": "1",
+    }
+
+
+def test_mandatory_recovery_codes_on_first_token(
+    client, mock_ipa_client, app, monkeypatch
+):
+    """With OTP_REQUIRE_RECOVERY_CODES enabled, confirming the first OTP token
+    auto-generates recovery codes and shows the modal."""
+    ipa = mock_ipa_client
+    monkeypatch.setitem(app.config, 'OTP_REQUIRE_RECOVERY_CODES', True)
+
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_TOTP_TOKEN, "uri": "otpauth://totp/dummy@TEST:token"}
+    }
+
+    find_calls = [0]
+
+    def otptoken_find_side_effect(**kwargs):
+        find_calls[0] += 1
+        if find_calls[0] == 1:
+            return {"result": [DUMMY_TOTP_TOKEN], "count": 1}
+        return {"result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN], "count": 2}
+
+    ipa.otptoken_find.side_effect = otptoken_find_side_effect
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    result = client.post(
+        "/user/dummy/settings/otp/",
+        data=_confirm_otp_data(),
+    )
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, "html.parser")
+    modal = page.select_one("#recovery-codes-modal")
+    assert modal is not None
+    codes = page.select('[data-role="recovery-code"]')
+    assert len(codes) == 10
+
+
+def test_mandatory_recovery_codes_disabled(
+    client, mock_ipa_client, app, monkeypatch
+):
+    """With OTP_REQUIRE_RECOVERY_CODES disabled (default), confirming the first
+    token redirects with a warning flash instead of auto-generating codes."""
+    ipa = mock_ipa_client
+    monkeypatch.setitem(app.config, 'OTP_REQUIRE_RECOVERY_CODES', False)
+
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_TOTP_TOKEN, "uri": "otpauth://totp/dummy@TEST:token"}
+    }
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+
+    result = client.post(
+        "/user/dummy/settings/otp/",
+        data=_confirm_otp_data(),
+    )
+    assert result.status_code == 302
+    messages = get_flashed_messages(with_categories=True)
+    assert len(messages) == 2
+    assert messages[0] == ("success", "The token has been created.")
+    assert messages[1][0] == "warning"
+    assert "recovery codes" in messages[1][1].lower()
+
+
+def test_mandatory_recovery_codes_already_has_recovery(
+    client, mock_ipa_client, app, monkeypatch
+):
+    """With OTP_REQUIRE_RECOVERY_CODES enabled, if user already has a recovery
+    token, normal redirect with no auto-generation."""
+    ipa = mock_ipa_client
+    monkeypatch.setitem(app.config, 'OTP_REQUIRE_RECOVERY_CODES', True)
+
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_TOTP_TOKEN, "uri": "otpauth://totp/dummy@TEST:token"}
+    }
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+
+    result = client.post(
+        "/user/dummy/settings/otp/",
+        data=_confirm_otp_data(),
+    )
+    assert result.status_code == 302
+    messages = get_flashed_messages(with_categories=True)
+    assert len(messages) == 1
+    assert messages[0] == ("success", "The token has been created.")
+
+
+
+def test_recovery_regenerate_delete_error(client, mock_ipa_client):
+    """IPA error deleting old recovery token during regeneration."""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [DUMMY_RECOVERY_TOKEN], "count": 1}
+    ipa.otptoken_del.side_effect = python_freeipa.exceptions.FreeIPAError(
+        message="Cannot delete token", code="4242"
+    )
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/regenerate",
+            data={
+                "regen-password": "dummy_password",
+                "regen-submit": "1",
+            },
+        )
+    assert_redirects_with_flash(
+        result,
+        expected_url="/user/dummy/settings/otp/",
+        expected_message="Cannot regenerate recovery codes.",
+        expected_category="danger",
+    )
+
+
+def test_mandatory_recovery_codes_auto_generate_failure(
+    client, mock_ipa_client, app, monkeypatch
+):
+    """With OTP_REQUIRE_RECOVERY_CODES enabled, if auto-creating recovery codes
+    fails, the user gets a warning flash and redirect instead of codes modal."""
+    ipa = mock_ipa_client
+    monkeypatch.setitem(app.config, 'OTP_REQUIRE_RECOVERY_CODES', True)
+
+    add_calls = [0]
+
+    def otptoken_add_side_effect(**kwargs):
+        add_calls[0] += 1
+        if add_calls[0] == 1:
+            return {
+                "result": {
+                    **DUMMY_TOTP_TOKEN,
+                    "uri": "otpauth://totp/dummy@TEST:token",
+                }
+            }
+        raise python_freeipa.exceptions.FreeIPAError(
+            message="Cannot create token", code="4242"
+        )
+
+    ipa.otptoken_add.side_effect = otptoken_add_side_effect
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+
+    result = client.post(
+        "/user/dummy/settings/otp/",
+        data=_confirm_otp_data(),
+    )
+    assert result.status_code == 302
+    messages = get_flashed_messages(with_categories=True)
+    assert len(messages) == 2
+    assert messages[0] == ("success", "The token has been created.")
+    assert messages[1][0] == "warning"
+    assert "recovery codes" in messages[1][1].lower()
+
+
+def test_recovery_generate_cache_control(client, mock_ipa_client):
+    """Recovery code responses include Cache-Control: no-store."""
+    ipa = mock_ipa_client
+    ipa.otptoken_find.return_value = {"result": [DUMMY_TOTP_TOKEN], "count": 0}
+    ipa.otptoken_add.return_value = {
+        "result": {**DUMMY_RECOVERY_TOKEN, "uri": "otpauth://hotp/dummy@TEST:recovery"}
+    }
+    ipa.otptoken_show.return_value = {"result": {**DUMMY_RECOVERY_TOKEN}}
+
+    def otptoken_find_side_effect(**kwargs):
+        if kwargs.get("o_type") == "hotp":
+            return {"result": [], "count": 0}
+        return {"result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN], "count": 2}
+
+    ipa.otptoken_find.side_effect = otptoken_find_side_effect
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/recovery/generate",
+            data={
+                "gen-password": "dummy_password",
+                "gen-submit": "1",
+            },
+        )
+    assert result.status_code == 200
+    assert result.headers.get("Cache-Control") == "no-store"
+

--- a/tests/unit/controller/test_user_otp.py
+++ b/tests/unit/controller/test_user_otp.py
@@ -1372,3 +1372,292 @@ def test_recovery_generate_cache_control(client, mock_ipa_client):
     assert result.status_code == 200
     assert result.headers.get("Cache-Control") == "no-store"
 
+
+# --- Enhancement 3: Admin-assisted OTP recovery ---
+
+ADMIN_USER_RESULT = {
+    "cn": ["Admin User"],
+    "displayname": ["Admin User"],
+    "uid": ["admin_user"],
+    "krbprincipalname": ["admin_user@TINYSTAGE.TEST"],
+    "mail": ["admin@unit.tests"],
+    "sn": ["User"],
+    "givenname": ["Admin"],
+    "nsaccountlock": False,
+    "dn": "uid=admin_user,cn=users,cn=accounts,dc=tinystage,dc=test",
+}
+
+
+@pytest.fixture
+def mock_admin_client(client, app):
+    """Provide a logged-in session as admin_user with mocked IPA admin."""
+    app.config['OTP_ADMIN_RECOVERY_ROLE'] = 'OTP Recovery Admins'
+
+    mock_client = mock.MagicMock()
+    mock_client.ping.return_value = {"summary": "IPA server version 4.10.3"}
+    mock_client.ipa_version = "IPA server version 4.10.3"
+    mock_client.user_find.return_value = {"result": [ADMIN_USER_RESULT]}
+    mock_client.user_show.return_value = {"result": DUMMY_USER_RESULT}
+
+    mock_admin = mock.MagicMock()
+    mock_admin.role_show.return_value = {
+        "result": {
+            "cn": ["OTP Recovery Admins"],
+            "member_user": ["admin_user"],
+        }
+    }
+
+    with mock.patch(
+        "noggin.utility.controllers.maybe_ipa_session", return_value=mock_client
+    ), mock.patch(
+        "noggin.utility.controllers.ipa_admin", mock_admin
+    ), mock.patch(
+        "noggin.controller.user_otp.ipa_admin", mock_admin
+    ):
+        with client.session_transaction() as sess:
+            sess["noggin_session"] = b"fake-session"
+            sess["noggin_username"] = "admin_user"
+            sess["noggin_ipa_server_hostname"] = "ipa.tinystage.test"
+        yield mock_client, mock_admin
+
+
+def test_admin_otp_reset_get(client, mock_admin_client):
+    """Admin can view the OTP reset confirmation page for another user."""
+    ipa, admin = mock_admin_client
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+
+    result = client.get("/user/dummy/settings/otp/admin-reset")
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, "html.parser")
+    heading = page.select_one("#pageheading")
+    assert heading is not None
+    assert "dummy" in heading.get_text()
+    assert "Reset OTP" in heading.get_text()
+    token_list = page.select("ul.list-group li.list-group-item")
+    assert len(token_list) == 1
+    assert "dummy's token" in token_list[0].get_text()
+    form = page.select_one(
+        "form[action='/user/dummy/settings/otp/admin-reset']"
+    )
+    assert form is not None
+
+
+def test_admin_otp_reset_post(client, mock_admin_client):
+    """Admin successfully resets OTP and recovery codes are generated."""
+    ipa, admin = mock_admin_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, DUMMY_RECOVERY_TOKEN],
+        "count": 2,
+    }
+    old_recovery = {
+        **DUMMY_RECOVERY_TOKEN,
+        "ipatokenuniqueid": ["old-recovery-id"],
+        "ipatokenhotpcounter": ["5"],
+    }
+    new_recovery = {
+        **DUMMY_RECOVERY_TOKEN,
+        "ipatokenuniqueid": ["new-recovery-id"],
+        "ipatokenhotpcounter": ["0"],
+    }
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN, old_recovery, new_recovery],
+        "count": 3,
+    }
+    admin.otptoken_del.return_value = {"result": True}
+    admin.otptoken_add.return_value = {
+        "result": {
+            **DUMMY_RECOVERY_TOKEN,
+            "ipatokenuniqueid": ["new-recovery-id"],
+            "uri": "otpauth://hotp/dummy@TEST:recovery",
+        }
+    }
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/admin-reset",
+            data={
+                "admin-reset-password": "admin_password",
+                "admin-reset-submit": "1",
+            },
+        )
+    assert result.status_code == 200
+    page = BeautifulSoup(result.data, "html.parser")
+    codes = page.select('[data-role="recovery-code"]')
+    assert len(codes) == 10
+    for code_el in codes:
+        text = code_el.get_text(strip=True)
+        code_part = text.split(". ", 1)[1]
+        assert len(code_part) == 8
+        assert code_part.isdigit()
+    assert admin.otptoken_del.call_count == 2
+    admin.otptoken_add.assert_called_once()
+
+
+def test_admin_otp_reset_no_permission(client, mock_admin_client):
+    """Non-admin user is rejected when trying to reset OTP."""
+    ipa, admin = mock_admin_client
+    admin.role_show.return_value = {
+        "result": {
+            "cn": ["OTP Recovery Admins"],
+            "member_user": ["someone_else"],
+        }
+    }
+
+    result = client.get("/user/dummy/settings/otp/admin-reset")
+    assert result.status_code == 302
+    assert "/user/dummy/" in result.headers["Location"]
+
+
+def test_admin_otp_reset_self(client, mock_admin_client):
+    """Admin trying to reset their own OTP redirects to normal OTP flow."""
+    ipa, admin = mock_admin_client
+    ipa.user_show.return_value = {"result": ADMIN_USER_RESULT}
+
+    result = client.get("/user/admin_user/settings/otp/admin-reset")
+    assert result.status_code == 302
+    assert "/user/admin_user/settings/otp" in result.headers["Location"]
+
+
+def test_admin_otp_reset_disabled(client, mock_ipa_client, app):
+    """When OTP_ADMIN_RECOVERY_ROLE is None, route returns 404."""
+    app.config['OTP_ADMIN_RECOVERY_ROLE'] = None
+    result = client.get("/user/dummy/settings/otp/admin-reset")
+    assert result.status_code == 404
+
+
+def test_admin_otp_reset_requires_auth(client, mock_admin_client):
+    """Wrong admin password is rejected."""
+    ipa, admin = mock_admin_client
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.side_effect = python_freeipa.exceptions.InvalidSessionPassword(
+            message="invalid credentials", code="4242"
+        )
+        result = client.post(
+            "/user/dummy/settings/otp/admin-reset",
+            data={
+                "admin-reset-password": "wrong_password",
+                "admin-reset-submit": "1",
+            },
+        )
+    assert result.status_code == 302
+    assert "/user/dummy/settings/otp/admin-reset" in result.headers["Location"]
+
+
+def test_admin_otp_reset_delete_error(client, mock_admin_client):
+    """IPA error during token deletion shows error message."""
+    ipa, admin = mock_admin_client
+    admin.otptoken_add.return_value = {
+        "result": {
+            **DUMMY_RECOVERY_TOKEN,
+            "ipatokenuniqueid": ["new-recovery-id"],
+            "uri": "otpauth://hotp/dummy@TEST:recovery",
+        }
+    }
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+    admin.otptoken_del.side_effect = python_freeipa.exceptions.FreeIPAError(
+        message="Cannot delete token", code="4242"
+    )
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/admin-reset",
+            data={
+                "admin-reset-password": "admin_password",
+                "admin-reset-submit": "1",
+            },
+        )
+    assert result.status_code == 302
+    assert "/user/dummy/settings/otp/admin-reset" in result.headers["Location"]
+
+
+def test_admin_otp_reset_create_error(client, mock_admin_client):
+    """IPA error during recovery token creation shows error message."""
+    ipa, admin = mock_admin_client
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+    admin.otptoken_del.return_value = {"result": True}
+    admin.otptoken_add.side_effect = python_freeipa.exceptions.FreeIPAError(
+        message="Cannot create token", code="4242"
+    )
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/admin-reset",
+            data={
+                "admin-reset-password": "admin_password",
+                "admin-reset-submit": "1",
+            },
+        )
+    assert result.status_code == 302
+    assert "/user/dummy/settings/otp/admin-reset" in result.headers["Location"]
+
+
+
+def test_admin_otp_reset_cache_control(client, mock_admin_client):
+    """Admin recovery code responses include Cache-Control: no-store."""
+    ipa, admin = mock_admin_client
+    ipa.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+    admin.otptoken_del.return_value = {"result": True}
+    admin.otptoken_add.return_value = {
+        "result": {
+            **DUMMY_RECOVERY_TOKEN,
+            "ipatokenuniqueid": ["new-recovery-id"],
+            "uri": "otpauth://hotp/dummy@TEST:recovery",
+        }
+    }
+
+    with mock.patch("noggin.controller.user_otp.maybe_ipa_login") as login_mock:
+        login_mock.return_value = ipa
+        result = client.post(
+            "/user/dummy/settings/otp/admin-reset",
+            data={
+                "admin-reset-password": "admin_password",
+                "admin-reset-submit": "1",
+            },
+        )
+    assert result.status_code == 200
+    assert result.headers.get("Cache-Control") == "no-store"
+
+
+def test_admin_otp_reset_group_membership(client, mock_admin_client):
+    """Admin with role membership via group can access OTP reset."""
+    ipa, admin = mock_admin_client
+    ipa.user_find.return_value = {
+        "result": [{
+            **ADMIN_USER_RESULT,
+            "memberof_group": ["otp-admins-group", "other-group"],
+        }]
+    }
+    admin.role_show.return_value = {
+        "result": {
+            "cn": ["OTP Recovery Admins"],
+            "member_user": [],
+            "member_group": ["otp-admins-group"],
+        }
+    }
+    admin.otptoken_find.return_value = {
+        "result": [DUMMY_TOTP_TOKEN],
+        "count": 1,
+    }
+
+    result = client.get("/user/dummy/settings/otp/admin-reset")
+    assert result.status_code == 200

--- a/tests/unit/utility/test_recovery_codes.py
+++ b/tests/unit/utility/test_recovery_codes.py
@@ -1,0 +1,57 @@
+import hashlib
+
+from pyotp import HOTP
+
+from noggin.utility.recovery_codes import generate_recovery_codes
+
+
+def test_generate_recovery_codes_count():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 10)
+    assert len(codes) == 10
+
+
+def test_generate_recovery_codes_eight_digits():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 10)
+    for code in codes:
+        assert len(code) == 8
+        assert code.isdigit()
+
+
+def test_generate_recovery_codes_match_hotp():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 10)
+    hotp = HOTP(secret, digits=8, digest=hashlib.sha256)
+    for i, code in enumerate(codes):
+        assert code == hotp.at(i)
+
+
+def test_generate_recovery_codes_uses_sha256():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 3)
+    hotp_sha1 = HOTP(secret, digits=8)
+    sha1_codes = [hotp_sha1.at(i) for i in range(3)]
+    assert codes != sha1_codes
+
+
+def test_generate_recovery_codes_zero_count():
+    secret = "JBSWY3DPEHPK3PXP"
+    assert generate_recovery_codes(secret, 0) == []
+
+
+def test_generate_recovery_codes_negative_count():
+    secret = "JBSWY3DPEHPK3PXP"
+    assert generate_recovery_codes(secret, -1) == []
+
+
+def test_generate_recovery_codes_unique():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 10)
+    assert len(set(codes)) == len(codes)
+
+
+def test_generate_recovery_codes_custom_count():
+    secret = "JBSWY3DPEHPK3PXP"
+    codes = generate_recovery_codes(secret, 5)
+    assert len(codes) == 5


### PR DESCRIPTION
## Add OTP recovery codes and admin-assisted OTP reset

### Summary

Add HOTP-based recovery codes for OTP-enrolled users, so they can
regain access if they lose their authenticator device. Also add an
admin-assisted OTP reset flow that lets designated IPA role members
wipe a user's tokens and issue fresh recovery codes on their behalf.

#### What's included

- **Recovery code generation**: counter-based (HOTP) token with 10
  eight-digit codes, created via the user's OTP settings page
- **Recovery code regeneration**: delete-and-recreate with password
  re-authentication
- **Mandatory recovery codes** (opt-in via config): auto-generate
  codes when the user enrolls their first OTP token
- **Admin OTP reset**: role-gated route that deletes all tokens for
  a target user and creates new recovery codes, with Fedora Messaging
  notification
- **Recovery code display**: remaining count, low-count warning,
  download/copy/print support via shared Jinja2 macros
- **OTP controller extraction**: existing OTP routes moved from
  `user.py` to `user_otp.py` for maintainability

#### Configuration

Five new settings in `noggin/defaults.py`:
- `OTP_RECOVERY_CODE_COUNT` (default: 10)
- `OTP_RECOVERY_DESCRIPTION` (default: "Recovery codes")
- `OTP_RECOVERY_LOW_THRESHOLD` (default: 3)
- `OTP_REQUIRE_RECOVERY_CODES` (default: False)
- `OTP_ADMIN_RECOVERY_ROLE` (default: None — disables admin reset)

### Test plan

- [ ] Generate recovery codes after enrolling an OTP token
- [ ] Regenerate codes and verify old codes stop working
- [ ] Verify admin reset button only appears for role members
- [ ] Verify admin reset deletes all tokens and issues new codes
- [ ] Verify recovery code count decrements after each use
- [ ] Verify low-count warning at threshold

Generated by Claude Code